### PR TITLE
Update thresholds to match FMI colour-scale when using silam_pollen integration

### DIFF
--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -51,13 +51,13 @@ export async function fetchForecast(hass, config) {
   const daysUppercase = Boolean(config.days_uppercase);
 
   const SILAM_THRESHOLDS = {
-    birch: [0, 1, 10, 50, 100, 200, 400],
-    grass: [0, 1, 10, 30, 50, 100, 200],
-    hazel: [0, 1, 5, 20, 50, 100, 200],
-    alder: [0, 1, 5, 20, 50, 100, 200],
-    ragweed: [0, 1, 3, 10, 30, 50, 100],
-    mugwort: [0, 1, 5, 15, 30, 50, 100],
-    olive: [0, 1, 3, 10, 20, 50, 100],
+    birch: [5, 25, 50, 100, 500, 1000, 5000],
+    grass: [5, 25, 50, 100, 500, 1000, 5000],
+    hazel: [5, 25, 50, 100, 500, 1000, 5000],
+    alder: [1, 10, 25, 50, 100, 500, 1000],
+    ragweed: [1, 10, 25, 50, 100, 500, 1000],
+    mugwort: [1, 10, 25, 50, 100, 500, 1000],
+    olive: [1, 10, 25, 50, 100, 500, 1000],
   };
 
   function grainsToLevel(allergen, grains) {


### PR DESCRIPTION
This PR aligns SILAM concentration thresholds in `adapters/silam.js`
with the official colour legend on the FMI pollen map  
<https://silam.fmi.fi/pollen.html>.

Because the SILAM API returns only numeric concentrations (#/m³),
we map them to qualitative levels (none → extreme) using the same breakpoints.
To keep the **pollenprognos-card**’s level count unchanged,
adjacent FMI ranges were merged:

* **1 – 5** and **5 – 10** → **1 – 10**  
* **5 – 10** and **10 – 25** → **5 – 25**

### Changes
```js
const SILAM_THRESHOLDS = {
  // Birch / Grass / Hazel
  birch:  [5, 25, 50, 100, 500, 1000, 5000],
  grass:  [5, 25, 50, 100, 500, 1000, 5000],
  hazel:  [5, 25, 50, 100, 500, 1000, 5000],

  // Alder / Olive / Mugwort / Ragweed
  alder:   [1, 10, 25, 50, 100, 500, 1000],
  olive:   [1, 10, 25, 50, 100, 500, 1000],
  mugwort: [1, 10, 25, 50, 100, 500, 1000],
  ragweed: [1, 10, 25, 50, 100, 500, 1000],
};
```



* Values **below** the first entry are treated as `none`.  
* The last entry (`5000` / `1000`) represents `extreme`.

### Screenshots
Two legend screenshots
<details>
<summary>Birch / Grass / Hazel</summary>

![image](https://github.com/user-attachments/assets/09cac53f-2564-438e-8861-063520031797)

</details>
<details>
<summary>Alder / Olive / Mugwort / Ragweed</summary>

![image](https://github.com/user-attachments/assets/944f6485-06e3-4a6b-b396-23fc2b8364bd)

</details>

### Reference
Discussion in #8:  
<https://github.com/danishru/silam_pollen/issues/8#issuecomment-3019429914>