### PR TITLE
Add version info logging with toggle

### DIFF
--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -35,6 +35,7 @@ export const stubConfigDWD = {
   show_value_numeric_in_circle: false,
   show_empty_days: false,
   debug: false,
+  show_version: true,
   days_to_show: 2,
   days_relative: true,
   days_abbreviated: false,

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -39,6 +39,7 @@ export const stubConfigPEU = {
   show_value_numeric_in_circle: false,
   show_empty_days: false,
   debug: false,
+  show_version: true,
   days_to_show: 4,
   days_relative: true,
   days_abbreviated: false,

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -30,6 +30,7 @@ export const stubConfigPP = {
   show_value_numeric_in_circle: false,
   show_empty_days: false,
   debug: false,
+  show_version: true,
   days_to_show: 4,
   days_relative: true,
   days_abbreviated: false,

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -33,6 +33,7 @@ export const stubConfigSILAM = {
   show_value_numeric_in_circle: false,
   show_empty_days: false,
   debug: false,
+  show_version: true,
   days_to_show: 5,
   days_relative: true,
   days_abbreviated: false,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,7 @@
   "editor.days_relative": "Relative days (today/tomorrow)",
   "editor.days_uppercase": "Uppercase weekdays",
   "editor.debug": "Debug",
+  "editor.show_version": "Log version to console",
   "editor.icon_size": "Icon size (px)",
   "editor.integration": "Integration",
   "editor.integration.dwd": "DWD Pollenflug",

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -41,6 +41,7 @@ class PollenPrognosCard extends LitElement {
   _forecastEvent = null; // Forecast-event (ex. hourly forecast från subscribe)
 
   _chartCache = new Map();
+  _versionLogged = false;
 
   _renderLevelCircle(
     level,
@@ -522,6 +523,7 @@ class PollenPrognosCard extends LitElement {
       "region_id",
       "tap_action",
       "debug",
+      "show_version",
       "title",
       "days_to_show",
       "date_locale",
@@ -554,6 +556,10 @@ class PollenPrognosCard extends LitElement {
     // If data-driven change: update userConfig, config, and fetch new data
     this._userConfig = { ...config };
     this.config = nextConfig;
+    if (!this._versionLogged && this.config.show_version !== false) {
+      console.info(`Pollenprognos Card version ${__VERSION__}`);
+      this._versionLogged = true;
+    }
     this._initDone = false;
     if (this._hass) {
       this.hass = this._hass;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1972,6 +1972,13 @@ class PollenPrognosCardEditor extends LitElement {
               @change=${(e) => this._updateConfig("debug", e.target.checked)}
             ></ha-switch>
           </ha-formfield>
+          <ha-formfield label="${this._t("show_version")}">
+            <ha-switch
+              .checked=${c.show_version !== false}
+              @change=${(e) =>
+                this._updateConfig("show_version", e.target.checked)}
+            ></ha-switch>
+          </ha-formfield>
         </details>
       </div>
     `;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,9 +2,19 @@
 import { defineConfig } from "vite";
 import legacy from "@vitejs/plugin-legacy";
 import { resolve } from "path";
+import { execSync } from "child_process";
 
 export default defineConfig(({ command }) => {
   const isServe = command === "serve";
+
+  let version = "";
+  try {
+    version = execSync("git describe --exact-match --tags")
+      .toString()
+      .trim();
+  } catch (e) {
+    version = execSync("git rev-parse --short HEAD").toString().trim();
+  }
 
   return {
     plugins: [
@@ -14,6 +24,10 @@ export default defineConfig(({ command }) => {
           targets: ["defaults", "not IE 11"],
         }),
     ].filter(Boolean),
+
+    define: {
+      __VERSION__: JSON.stringify(version),
+    },
 
     build: {
       lib: {


### PR DESCRIPTION
## Summary
- log card version using commit or release tag
- allow toggling version logs in advanced editor settings (default on)
- expose version constant during Vite build

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a2d4fc4848328a2ec87d80e29800f