### PR TITLE
Add levels_icon_ratio option and improve icon scaling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Additional documentation:
 | `levels_gap` | `integer` | `1` | Gap width between segments. |
 | `levels_text_color` | `string` | `var(--primary-text-color)` | Color for the value inside the level circle. |
 | `levels_text_size` | `number` | `0.3` | Size of the numeric value inside the circle relative to icon size. |
+| `levels_icon_ratio` | `number` | `1` | Multiplier applied to `icon_size` for the level circles. |
 | `levels_text_weight` | `string` | `normal` | Font weight for the value inside the circle. |
 | `icon_size` | `integer` | `48` | Icon size in pixels. |
 | `text_size_ratio` | `number` | `1` | Global text scaling factor. |

--- a/src/constants.js
+++ b/src/constants.js
@@ -124,6 +124,7 @@ export const COSMETIC_FIELDS = [
   "levels_gap",
   "levels_text_color",
   "levels_text_size",
+  "levels_icon_ratio",
   "levels_text_weight",
   "minimal",
   "show_text_allergen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -66,6 +66,7 @@
   "editor.levels_reset": "Reset to default",
   "editor.levels_text_color": "Text color (inner circle)",
   "editor.levels_text_size": "Text size (inner circle, % of normal)",
+  "editor.levels_icon_ratio": "Levels icon ratio",
   "editor.levels_text_weight": "Text weight (inner circle)",
   "editor.levels_thickness": "Thickness (%)",
   "editor.locale": "Locale",

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1092,10 +1092,9 @@ class PollenPrognosCard extends LitElement {
       this.config.levels_gap_color ?? "var(--card-background-color)";
     const thickness = this.config.levels_thickness ?? 60;
     const gap = this.config.levels_gap ?? 5;
-    const size = Math.min(
-      100,
-      Math.max(40, Number(this.config.icon_size) || 80),
-    ); // Use icon_size but with constraints
+    const iconSize = Number(this.config.icon_size) || 48;
+    const iconRatio = Number(this.config.levels_icon_ratio) || 1;
+    const size = Math.min(100, Math.max(1, iconSize * iconRatio));
 
     if (this.debug) {
       console.debug("Display columns:", cols);
@@ -1395,7 +1394,7 @@ class PollenPrognosCard extends LitElement {
         display: block;
         width: var(--pollen-icon-size, 48px);
         max-width: var(--pollen-icon-size, 48px);
-        min-width: 16px;
+        min-width: 0;
         height: auto;
         margin: 0 auto 6px auto;
       }
@@ -1403,7 +1402,7 @@ class PollenPrognosCard extends LitElement {
       .level-circle {
         width: var(--pollen-icon-size, 48px);
         max-width: var(--pollen-icon-size, 48px);
-        min-width: 16px;
+        min-width: 0;
         height: auto;
         margin: 0 auto 6px auto;
       }
@@ -1497,8 +1496,8 @@ class PollenPrognosCard extends LitElement {
         height: var(--pollen-icon-size, 48px);
         max-width: var(--pollen-icon-size, 48px);
         max-height: var(--pollen-icon-size, 48px);
-        min-width: 16px;
-        min-height: 16px;
+        min-width: 0;
+        min-height: 0;
         object-fit: contain;
         margin: 0 auto 6px auto;
         display: block;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1538,6 +1538,31 @@ class PollenPrognosCardEditor extends LitElement {
                 ></ha-textfield>
               </ha-formfield>
 
+              <ha-formfield label="${this._t("levels_icon_ratio")}">
+                <ha-slider
+                  min="0.1"
+                  max="2"
+                  step="0.05"
+                  .value=${c.levels_icon_ratio || 1}
+                  @input=${(e) =>
+                    this._updateConfig(
+                      "levels_icon_ratio",
+                      Number(e.target.value),
+                    )}
+                  style="width: 120px;"
+                ></ha-slider>
+                <ha-textfield
+                  type="number"
+                  .value=${c.levels_icon_ratio || 1}
+                  @input=${(e) =>
+                    this._updateConfig(
+                      "levels_icon_ratio",
+                      Number(e.target.value),
+                    )}
+                  style="width: 80px;"
+                ></ha-textfield>
+              </ha-formfield>
+
               <ha-formfield label="${this._t("levels_text_color")}">
                 <div style="display: flex; align-items: center; gap: 8px;">
                   <input

--- a/src/utils/levels-defaults.js
+++ b/src/utils/levels-defaults.js
@@ -14,5 +14,6 @@ export const LEVELS_DEFAULTS = {
   levels_gap: 1,
   levels_text_weight: "normal",
   levels_text_size: 0.2,
+  levels_icon_ratio: 1,
   levels_text_color: "var(--primary-text-color)",
 };


### PR DESCRIPTION
## Summary
- allow smaller icons by removing minimum width on images
- compute level circle size using new `levels_icon_ratio`
- add `levels_icon_ratio` default and config handling
- document the new option
- expose the setting in the editor

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885c92da36c83289d42c8bb761d7561