### PR TITLE
Fix custom level fallback

### DIFF
--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -2,6 +2,7 @@ import { t, detectLang } from "../i18n.js";
 import { ALLERGEN_TRANSLATION } from "../constants.js";
 import { normalizeDWD } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
+import { buildLevelNames } from "../utils/level-names.js";
 
 const DOMAIN = "dwd_pollenflug";
 const ATTR_VAL_TOMORROW = "state_tomorrow";
@@ -71,10 +72,7 @@ export async function fetchForecast(hass, config) {
   const fullPhrases = phrases.full || {};
   const shortPhrases = phrases.short || {};
   const userLevels = phrases.levels;
-  const levelNames =
-    Array.isArray(userLevels) && userLevels.length === 7
-      ? userLevels
-      : Array.from({ length: 7 }, (_, i) => t(`card.levels.${i}`, lang));
+  const levelNames = buildLevelNames(userLevels, lang);
   const noInfoLabel = phrases.no_information || t("card.no_information", lang);
   const userDays = phrases.days || {};
   const days_to_show = config.days_to_show ?? stubConfigDWD.days_to_show;

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -2,6 +2,7 @@
 import { t, detectLang } from "../i18n.js";
 import { ALLERGEN_TRANSLATION } from "../constants.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
+import { buildLevelNames } from "../utils/level-names.js";
 
 // Skapa stubConfigPEU – allergener enligt din sensor.py, i engelsk slugform!
 export const stubConfigPEU = {
@@ -85,11 +86,12 @@ export async function fetchForecast(hass, config) {
   let levelNames = levelNamesDefault.slice();
   if (Array.isArray(userLevels)) {
     if (userLevels.length === 7) {
-      levelNames = userLevels.slice();
+      levelNames = buildLevelNames(userLevels, lang);
     } else if (userLevels.length === defaultNumLevels) {
       const map = [0, 1, 3, 5, 6];
       map.forEach((lvl, idx) => {
-        if (userLevels[idx]) levelNames[lvl] = userLevels[idx];
+        const val = userLevels[idx];
+        if (val != null && val !== "") levelNames[lvl] = val;
       });
     }
   }

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -2,6 +2,7 @@ import { t, detectLang } from "../i18n.js";
 import { ALLERGEN_TRANSLATION } from "../constants.js";
 import { normalize } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
+import { buildLevelNames } from "../utils/level-names.js";
 
 export const stubConfigPP = {
   integration: "pp",
@@ -82,10 +83,7 @@ export async function fetchForecast(hass, config) {
   const fullPhrases = phrases.full;
   const shortPhrases = phrases.short;
   const userLevels = phrases.levels;
-  const levelNames =
-    Array.isArray(userLevels) && userLevels.length === 7
-      ? userLevels
-      : Array.from({ length: 7 }, (_, i) => t(`card.levels.${i}`, lang));
+  const levelNames = buildLevelNames(userLevels, lang);
   const noInfoLabel = phrases.no_information || t("card.no_information", lang);
   const userDays = phrases.days;
 

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -3,6 +3,7 @@ import { t, detectLang } from "../i18n.js";
 import { normalize } from "../utils/normalize.js";
 import { findSilamWeatherEntity } from "../utils/silam.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
+import { buildLevelNames } from "../utils/level-names.js";
 
 // Läs in mapping och namn för allergener
 import silamAllergenMap from "./silam_allergen_map.json" assert { type: "json" };
@@ -92,9 +93,7 @@ export function getPhrases(config, lang) {
 }
 
 export function getLevelNames(phrases, lang) {
-  return Array.isArray(phrases.levels) && phrases.levels.length === 7
-    ? phrases.levels
-    : Array.from({ length: 7 }, (_, i) => t(`card.levels.${i}`, lang));
+  return buildLevelNames(phrases.levels, lang);
 }
 
 export function getAllergenNames(allergen, phrases, lang) {

--- a/src/utils/level-names.js
+++ b/src/utils/level-names.js
@@ -1,0 +1,14 @@
+// src/utils/level-names.js
+// Helper to merge user provided level names with defaults.
+// Returns an array of seven names, falling back to translation
+// strings when user values are missing.
+import { t } from "../i18n.js";
+
+export function buildLevelNames(userLevels, lang) {
+  const defaults = Array.from({ length: 7 }, (_, i) => t(`card.levels.${i}`, lang));
+  if (!Array.isArray(userLevels)) return defaults;
+  return defaults.map((def, idx) => {
+    const val = userLevels[idx];
+    return val == null || val === "" ? def : val;
+  });
+}


### PR DESCRIPTION
## Summary
- ensure user custom levels fall back to defaults
- share fallback logic in new utility function

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885dde205988328b4de07409c9d71c7