### PR TITLE
Fix DWD and PEU level pie segments

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,14 @@ export const ADAPTERS = {
   silam: SILAM,
 };
 
+// Maximum numeric level for each integration
+export const MAX_LEVEL_VALUE = {
+  pp: 6,
+  dwd: 3,
+  peu: 4,
+  silam: 6,
+};
+
 export const DWD_REGIONS = {
   11: "Schleswig-Holstein und Hamburg",
   12: "Schleswig-Holstein und Hamburg",


### PR DESCRIPTION
## Summary
- add `MAX_LEVEL_VALUE` mapping integrations to their max level
- slice configured level colors using the integration's max level  
  (**dwd** and **peu** are affected; pp and silam are not)
- clamp levels when drawing pie charts so they fit the segment count

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885e1b4b95483289048fb8754583066