### PR TITLE
Fix DWD pie segments and PEU image scaling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -12,13 +12,6 @@ export const ADAPTERS = {
   silam: SILAM,
 };
 
-// Maximum numeric level for each integration
-export const MAX_LEVEL_VALUE = {
-  pp: 6,
-  dwd: 3,
-  peu: 4,
-  silam: 6,
-};
 
 export const DWD_REGIONS = {
   11: "Schleswig-Holstein und Hamburg",


### PR DESCRIPTION
## Summary
- correct PEU level image mapping
- restore six segments for DWD level pie
- scale level values per integration
- drop unused `MAX_LEVEL_VALUE` constant

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885e763e2508328801dd6585675a7ce