### PR TITLE
Fix default allergens

### DIFF
--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -9,7 +9,6 @@ export const stubConfigPEU = {
   integration: "peu",
   location: "",
   allergens: [
-    "allergy_risk",
     "alder",
     "ash",
     "beech",
@@ -54,6 +53,12 @@ export const stubConfigPEU = {
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },
 };
+
+// All possible allergens for the PEU integration
+export const PEU_ALLERGENS = [
+  "allergy_risk",
+  ...stubConfigPEU.allergens,
+];
 
 export async function fetchForecast(hass, config) {
   const debug = Boolean(config.debug);

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -13,7 +13,6 @@ export const stubConfigSILAM = {
   integration: "silam",
   location: "",
   allergens: [
-    "allergy_risk",
     "alder",
     "birch",
     "grass",
@@ -48,6 +47,12 @@ export const stubConfigSILAM = {
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },
 };
+
+// All possible allergens for the SILAM integration
+export const SILAM_ALLERGENS = [
+  ...stubConfigSILAM.allergens,
+  "allergy_risk",
+];
 
 export const SILAM_THRESHOLDS = {
   // birch: [5, 25, 50, 100, 500, 1000, 5000],


### PR DESCRIPTION
## Summary
- update SILAM stub to disable allergy risk by default
- update PEU stub to disable allergy risk by default
- expose full allergen lists for SILAM and PEU
- let editor use the new lists and recognise user-selected allergens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ca53ab6308328a538c26f91d27768