### PR TITLE
docs: document top placement options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ integration: pp       # auto-detected if omitted
 city: Stockholm       # adapter specific option
 ```
 
+### Special sensors
+
+Some integrations expose a combined allergy risk or index sensor. Use
+`allergy_risk_top` with Polleninformation EU or `index_top` with SILAM to
+pin this sensor at the top of the list.
+
 ## Configuration reference
 
 More details, including all options and example snippets, are available in the documentation:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,8 @@ Additional documentation:
 | `show_empty_days` | `boolean` | `true` | Always render `days_to_show` columns even when there is no data. |
 | `pollen_threshold` | `integer` | `1` | Minimum value required to show an allergen. Use `0` to always show all. |
 | `sort` | `string` | `name_ascending` (PP) / `value_descending` (DWD) | Row sorting mode. |
+| `allergy_risk_top` *(PEU only)* | `boolean` | `true` | Show the `allergy_risk` or `index` sensor first in the list. |
+| `index_top` *(SILAM only)* | `boolean` | `true` | Show the `index` sensor first in the list. |
 | `title` | `string/boolean` | *(auto)* | Card title. `true` for default, `false` to hide, or provide a custom string. |
 | `date_locale` | `string` | `sv-SE` (PP) / `de-DE` (DWD) | Locale used for weekday formatting. |
 | `tap_action` | `object` | *(empty)* | Lovelace tap action configuration. |


### PR DESCRIPTION
## Summary
- document `allergy_risk_top` for PEU integration
- document `index_top` for SILAM integration

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e3b7b4070832899c8b5cde22332e3