### PR TITLE
Use HA locale in editor and standardize translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pollenprognos-card",
       "version": "2.0.0",
       "dependencies": {
+        "intl-messageformat": "^10.7.16",
         "lit": "^2.8.0"
       },
       "devDependencies": {
@@ -1938,6 +1939,57 @@
         "node": ">=18"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
@@ -2544,6 +2596,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.159",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
@@ -2683,6 +2741,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-core-module": {
@@ -3082,6 +3152,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
-    "lit": "^2.8.0"
+    "lit": "^2.8.0",
+    "intl-messageformat": "^10.7.16"
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,74 +1,93 @@
 // src/i18n.js
 
-// Dynamiskt importera alla språkfiler från locales-katalogen via Vite
-// Använder import.meta.glob med eager-flag för att paketera JSON-filerna
+// Import message formatter used by Home Assistant
+import IntlMessageFormat from "intl-messageformat";
+
+// Eagerly import all locale JSON files via Vite
 const localeModules = import.meta.glob("./locales/*.json", { eager: true });
 
+// Build a mapping from language code to translation resources
 const LOCALES = {};
 for (const filePath in localeModules) {
   const match = filePath.match(/\.\/locales\/([\w-]+)\.json$/);
   if (match) {
-    // Varje modul har sin data som default-export
     LOCALES[match[1]] = localeModules[filePath].default;
   }
 }
 
-// Standard-språk om nyckel eller språk saknas
+// Collect supported languages for external use
+export const SUPPORTED_LOCALES = Object.keys(LOCALES);
+
+// Default language used when no match is found
 const DEFAULT = "en";
 
 /**
- * Hjälpfunktion för att plocka ut nested-nycklar från ett objekt
+ * Compute a localize function for a given language following HA's pattern.
  */
-function resolveKey(obj, path) {
-  return path
-    .split(".")
-    .reduce((o, k) => (o && typeof o === "object" ? o[k] : undefined), obj);
+function computeLocalize(language, resources, formats) {
+  const cache = {};
+  return (key, ...args) => {
+    if (!key || !resources || !language || !resources[language]) {
+      return "";
+    }
+    const translatedValue = resources[language][key];
+    if (!translatedValue) {
+      return "";
+    }
+    let translatedMessage = cache[translatedValue];
+    if (!translatedMessage) {
+      try {
+        translatedMessage = new IntlMessageFormat(
+          translatedValue,
+          language,
+          formats
+        );
+      } catch (err) {
+        return `Translation error: ${err.message}`;
+      }
+      cache[translatedValue] = translatedMessage;
+    }
+    let argObject = {};
+    if (args.length === 1 && typeof args[0] === "object") {
+      argObject = args[0];
+    } else {
+      for (let i = 0; i < args.length; i += 2) {
+        argObject[args[i]] = args[i + 1];
+      }
+    }
+    try {
+      return translatedMessage.format(argObject);
+    } catch (err) {
+      return `Translation ${err}`;
+    }
+  };
+}
+
+// Create a localize function for each language using HA's standard approach
+const LOCALIZE_FNS = {};
+for (const lang of SUPPORTED_LOCALES) {
+  LOCALIZE_FNS[lang] = computeLocalize(lang, LOCALES);
 }
 
 /**
- * Detektera tvåbokstavskod för språk baserat på HA eller användarkonfig
+ * Detect the best fitting language based on HA settings or user override.
  */
 export function detectLang(hass, userLocale) {
-  // 1) Hitta den fulla taggen
   let tag = userLocale || hass?.locale?.language || hass?.language || DEFAULT;
-  // 2) Om vi har en exakt match i LOCALES, använd den
-  if (LOCALES[tag]) {
+  if (SUPPORTED_LOCALES.includes(tag)) {
     return tag;
   }
-  // 3) Annars titta på första två bokstäver
   const short = tag.slice(0, 2).toLowerCase();
-  if (LOCALES[short]) {
+  if (SUPPORTED_LOCALES.includes(short)) {
     return short;
   }
-  // 4) Annars fallback
   return DEFAULT;
 }
 
-export const SUPPORTED_LOCALES = Object.keys(LOCALES);
-
 /**
- * Hämta översättning för key i valt språk, med fallback
+ * Retrieve translation for key in the chosen language with fallback.
  */
 export function t(key, lang) {
-  const localeData = LOCALES[lang] || {};
-  // Direkt nyckel
-  if (localeData[key] !== undefined) {
-    return localeData[key];
-  }
-  // Nested-nyckel
-  const nested = resolveKey(localeData, key);
-  if (nested !== undefined) {
-    return nested;
-  }
-  // Fallback till default-språk
-  const defaultData = LOCALES[DEFAULT] || {};
-  if (defaultData[key] !== undefined) {
-    return defaultData[key];
-  }
-  const defaultNested = resolveKey(defaultData, key);
-  if (defaultNested !== undefined) {
-    return defaultNested;
-  }
-  // Om inget hittas, returnera key
-  return key;
+  const localize = LOCALIZE_FNS[lang] || LOCALIZE_FNS[DEFAULT];
+  return localize(key) || LOCALIZE_FNS[DEFAULT](key) || key;
 }

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -196,8 +196,9 @@ class PollenPrognosCardEditor extends LitElement {
     };
   }
 
+  // Use Home Assistant's language for editor strings
   get _lang() {
-    return detectLang(this._hass, this._config.date_locale);
+    return detectLang(this._hass);
   }
 
   _t(key) {
@@ -206,19 +207,19 @@ class PollenPrognosCardEditor extends LitElement {
 
   constructor() {
     super();
-    // Sätt ALLT till neutrala värden, oavsett state på this._hass eller this._config
+    // Set everything to neutral values regardless of hass or config state
     this._userConfig = {};
     this._integrationExplicit = false;
     this._thresholdExplicit = false;
     // this._config = stubConfigPP;
-    this._config = {}; // Tomt – blir ändå satt av setConfig eller set hass
+    this._config = {}; // Empty – will be set by setConfig or hass
     this.installedCities = [];
     this.installedPeuLocations = [];
     this.installedSilamLocations = [];
     this._prevIntegration = undefined;
     this.installedRegionIds = [];
     this._initDone = false;
-    // Säkra att _selectedPhraseLang alltid får fallback om ingen hass eller locale finns
+    // Ensure _selectedPhraseLang always has a fallback if no hass or locale exists
     this._selectedPhraseLang = "sv";
     this._allergensExplicit = false;
     this._origAllergensSet = false;


### PR DESCRIPTION
## Summary
- Ensure the configuration editor always follows Home Assistant's selected language
- Replace custom i18n helper with Home Assistant style localizer backed by IntlMessageFormat
- Add intl-messageformat dependency for standardized translation handling

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ee3b2efb08328806666dd8406e1fb