### PR TITLE
feat: update package version from git tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pollenprognos-card",
-  "version": "2.0.0",
+  "version": "2.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pollenprognos-card",
-      "version": "2.0.0",
+      "version": "2.4.8",
       "dependencies": {
         "intl-messageformat": "^10.7.16",
         "lit": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "pollenprognos-card",
-  "version": "2.0.0",
+  "version": "2.4.8",
   "description": "Custom card for Home Assistant showing pollen forecasts",
   "main": "dist/pollenprognos-card.js",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "update-version": "node scripts/update-version.js",
+    "prebuild": "npm run update-version"
   },
   "devDependencies": {
     "@vitejs/plugin-legacy": "^6.1.1",

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Update package.json and package-lock.json with the current git tag version
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+
+// Get the latest git tag and sanitize it for npm
+function getVersion() {
+  try {
+    const tag = execSync("git describe --tags --abbrev=0", {
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    // Remove leading 'v' and any suffix like '-beta1'
+    return tag.replace(/^v/, "").replace(/-.*/, "");
+  } catch (e) {
+    // No tag found; keep existing version
+    return null;
+  }
+}
+
+// Write the version to a given JSON file
+function writeVersion(file, version) {
+  const data = JSON.parse(readFileSync(file, "utf8"));
+  data.version = version;
+  if (data.packages && data.packages[""]) {
+    data.packages[""].version = version;
+  }
+  writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
+}
+
+const version = getVersion();
+if (version) {
+  writeVersion("package.json", version);
+  writeVersion("package-lock.json", version);
+}


### PR DESCRIPTION
## Summary
- update package.json and package-lock.json version from latest git tag
- add script to sanitize git tag and write to package files
- run version update before build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f2ba52c848328a20646cc25a7d63b