### PR TITLE
feat: improve editor language handling

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -55,6 +55,8 @@
   "editor.debug": "Debug",
   "editor.entity_prefix": "Entity prefix",
   "editor.entity_suffix": "Entity suffix",
+  "editor.entity_prefix_placeholder": "Type 'null' for no prefix",
+  "editor.entity_suffix_placeholder": "Type 'null' for no suffix",
   "editor.icon_size": "Icon size (px)",
   "editor.index_top": "Index top of list",
   "editor.integration": "Integration",


### PR DESCRIPTION
## Summary
- add placeholders to prefix/suffix fields showing how to clear
- default phrase language follows card locale or HA language

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f5aab07dc832898da06f0f663411c