### PR TITLE
(silam) Adjust thresholds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,16 @@ ragweed
 index
 ```
 
+#### SILAM threshold values
+
+For the SILAM integration, each allergen uses the following threshold values to determine pollen levels:
+
+- **birch, grass, hazel:** 1, 25, 50, 100, 500, 1000, 5000
+- **alder, ragweed, mugwort, olive:** 1, 10, 25, 50, 100, 500, 1000
+
+> **Note on SILAM thresholds:**  
+> For the SILAM integration, each threshold value marks the start of a new pollen level. A level applies as soon as the pollen value is greater than or equal to its threshold (≥). For example, a value of 25 will be assigned to the level that starts at 25. This ensures that all threshold values are inclusive and consistently interpreted across all levels.
+
 ## Example snippets
 
 Below are a few short configuration examples. Only the relevant lines are shown.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ Additional documentation:
 | `location` *(PEU, SILAM only)* | `string` | **Required** (PEU/SILAM) | Location slug matching your integration sensors, or `manual` for custom entity prefix/suffix. |
 | `entity_prefix` | `string` | *(empty)* | Prefix for sensor entity IDs in manual mode. Leave empty for sensors like `sensor.grass`. |
 | `entity_suffix` | `string` | *(empty)* | Optional suffix after the allergen slug in manual mode. |
-| `mode` *(PEU, SILAM only)* | `string` | `daily` | Forecast mode. SILAM supports `daily`, `hourly` and `twice_daily`. PEU supports `daily`, `twice_daily` and hourly variants: `hourly`, `hourly_second`, `hourly_third`, `hourly_fourth`, `hourly_sixth`, `hourly_eighth`. For PEU, modes other than `daily` only work with the `allergy_risk` sensor and require `polleninformation` **v0.4.4** or later together with card **v2.4.8** or newer. |
+| `mode` *(PEU, SILAM only)* | `string` | `daily` | Forecast mode. SILAM supports `daily`, `hourly` and `twice_daily`. PEU supports `daily`, `twice_daily` and hourly variants: `hourly`, `hourly_second`, `hourly_third`, `hourly_fourth`, `hourly_sixth`, `hourly_eighth`. For PEU, modes other than `daily` only work with the `allergy_risk` sensor and require `polleninformation` **v0.4.4** or later together with card **v2.5.0** or newer. |
 | `levels_colors` | `array<string>` | `["#ffeb3b", "#ffc107", "#ff9800", "#ff5722", "#e64a19", "#d32f2f"]` | Colors for the segments in the level circle. |
 | `levels_empty_color` | `string` | `rgba(200, 200, 200, 0.15)` | Color for empty segments. |
 | `levels_gap_color` | `string` | `var(--card-background-color)` | Color for gaps in the level circle. |
@@ -68,6 +68,7 @@ Additional documentation:
 The following keys are recognised for each adapter. Values must match your integration sensors exactly.
 
 ### Pollenprognos (PP)
+
 ```
 Al
 Alm
@@ -82,6 +83,7 @@ Sälg och viden
 ```
 
 ### DWD Pollenflug
+
 ```
 ambrosia
 beifuss
@@ -94,6 +96,7 @@ roggen
 ```
 
 ### Polleninformation EU (PEU)
+
 ```
 allergy_risk
 alder
@@ -116,9 +119,10 @@ rye
 willow
 ```
 
-Only the `allergy_risk` allergen supports forecast modes other than `daily`. These modes require `polleninformation` **v0.4.4** or later and card **v2.4.8** or newer.
+Only the `allergy_risk` allergen supports forecast modes other than `daily`. These modes require `polleninformation` **v0.4.4** or later and card **v2.5.0** or newer.
 
 ### SILAM Pollen Allergy Sensor
+
 ```
 alder
 birch
@@ -135,6 +139,7 @@ index
 Below are a few short configuration examples. Only the relevant lines are shown.
 
 **Pollenprognos (PP)**
+
 ```yaml
 type: custom:pollenprognos-card
 city: Stockholm
@@ -142,6 +147,7 @@ show_text_allergen: true
 ```
 
 **DWD Pollenflug**
+
 ```yaml
 type: custom:pollenprognos-card
 integration: dwd
@@ -149,6 +155,7 @@ region_id: "91"
 ```
 
 **Minimal layout**
+
 ```yaml
 type: custom:pollenprognos-card
 minimal: true
@@ -156,10 +163,10 @@ show_value_numeric: true
 ```
 
 **Custom phrases**
+
 ```yaml
 phrases:
   short:
     Malörtsambrosia: Ambrs
     Sälg och viden: Sälg
 ```
-

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -12,7 +12,6 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 | Integration | Notes |
 |-------------|------|
 | **Pollenprognos** | For `homeassistant-pollenprognos` **v1.1.0** and higher you need **v1.0.6** or newer of this card. For older integration versions use **v1.0.5** or earlier. |
-| **Polleninformation EU** | For `polleninformation` **v0.4.0** or later you need **v2.4.2** or newer of this card. Versions **v0.3.1** and earlier require card version **v2.2.0–v2.4.1**. Forecast modes were added in card **v2.4.8** and require `polleninformation` **v0.4.4** or later. Only the `allergy_risk` sensor supports modes other than `daily`. |
+| **Polleninformation EU** | For `polleninformation` **v0.4.0** or later you need **v2.4.2** or newer of this card. Versions **v0.3.1** and earlier require card version **v2.2.0–v2.4.1**. Forecast modes were added in card **v2.5.0** and require `polleninformation` **v0.4.4** or later. Only the `allergy_risk` sensor supports modes other than `daily`. |
 | **SILAM Pollen Allergy Sensor** | Do not rename the sensors created by the integration. For `silam_pollen` **v0.2.7** and newer you need **v2.4.1** or newer of this card. Older integration versions require **v2.3.0–v2.4.0**. |
 | **DWD Pollenflug** | Keep the default sensor names. You need card version **v2.0.0** or newer. |
-

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -61,7 +61,7 @@ export const SILAM_THRESHOLDS = {
   // birch: [5, 25, 50, 100, 500, 1000, 5000],
   // grass: [5, 25, 50, 100, 500, 1000, 5000],
   // hazel: [5, 25, 50, 100, 500, 1000, 5000],
-  // The above is the correct level thresholds
+  // The above are the correct level thresholds
   // The below has lower thresholds specifically for the first, lowest level.
   // Just seemed odd to have documented pollen levels, but tell the user that
   // there is *none.*
@@ -78,12 +78,12 @@ export function grainsToLevel(allergen, grains) {
   const arr = SILAM_THRESHOLDS[allergen];
   if (!arr) return -1;
   if (isNaN(grains)) return -1;
-  if (grains <= arr[0]) return 0;
-  if (grains <= arr[1]) return 1;
-  if (grains <= arr[2]) return 2;
-  if (grains <= arr[3]) return 3;
-  if (grains <= arr[4]) return 4;
-  if (grains <= arr[5]) return 5;
+  if (grains < arr[0]) return 0;
+  if (grains < arr[1]) return 1;
+  if (grains < arr[2]) return 2;
+  if (grains < arr[3]) return 3;
+  if (grains < arr[4]) return 4;
+  if (grains < arr[5]) return 5;
   return 6;
 }
 
@@ -240,10 +240,13 @@ export async function fetchForecast(hass, config, forecastEvent = null) {
       if (config.location === "manual") {
         let slug = null;
         for (const mapping of Object.values(silamAllergenMap.mapping)) {
-          const inverse = Object.entries(mapping).reduce((acc, [ha, master]) => {
-            acc[master] = ha;
-            return acc;
-          }, {});
+          const inverse = Object.entries(mapping).reduce(
+            (acc, [ha, master]) => {
+              acc[master] = ha;
+              return acc;
+            },
+            {},
+          );
           if (inverse[allergen]) {
             slug = inverse[allergen];
             break;
@@ -256,10 +259,13 @@ export async function fetchForecast(hass, config, forecastEvent = null) {
         if (hass.states[candidate]) sensorId = candidate;
       } else {
         for (const mapping of Object.values(silamAllergenMap.mapping)) {
-          const inverse = Object.entries(mapping).reduce((acc, [ha, master]) => {
-            acc[master] = ha;
-            return acc;
-          }, {});
+          const inverse = Object.entries(mapping).reduce(
+            (acc, [ha, master]) => {
+              acc[master] = ha;
+              return acc;
+            },
+            {},
+          );
           if (inverse[allergen]) {
             const candidate = `sensor.silam_pollen_${locationSlug}_${inverse[allergen]}`;
             if (hass.states[candidate]) {


### PR DESCRIPTION
Before, with an allergen level equal to `1`, the card reported no allergens, requiring **>** 1. This has now been adjusted so if the allergen gram level is >**=** 1, it will report low levels.

Added to docs.