### PR TITLE
Fix for card not loading (import cdn content locally)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "pollenprognos-card",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pollenprognos-card",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "intl-messageformat": "^10.7.16",
         "lit": "^2.8.0"
       },
@@ -2055,6 +2056,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
@@ -2536,6 +2543,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pollenprognos-card",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "description": "Custom card for Home Assistant showing pollen forecasts",
   "main": "dist/pollenprognos-card.js",
   "type": "module",
@@ -16,6 +16,7 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "intl-messageformat": "^10.7.16",
     "lit": "^2.8.0"
   }

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -30,7 +30,7 @@ import {
   DoughnutController,
   Tooltip,
   Legend,
-} from "https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.esm.js";
+} from "chart.js/auto";
 
 // Chart.js registreren
 Chart.register(ArcElement, DoughnutController, Tooltip, Legend);


### PR DESCRIPTION
To include external packages in the vite bundle, don't import packages by full url (like `https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.esm.js`).

Fix for #113 