### PR TITLE
Restore grasses canonical mapping for Pollen.lu aliases

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -132,7 +132,6 @@ export const ALLERGEN_TRANSLATION = {
   chenopode: "goosefoot",
   poacea: "poaceae",
   graminees: "poaceae",
-  grasses: "poaceae",
   corylus: "hazel",
   haselnussstrauch: "hazel",
   noisetier: "hazel",


### PR DESCRIPTION
## Summary
- remove the Pollen.lu alias that remapped the `grasses` key to `poaceae`
- preserve the existing `grasses -> grass` canonical mapping for other integrations while keeping new Poaceae aliases

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe4d719a8c832880d1317077b8f970