### PR TITLE
Fix typo in Polish locale

### DIFF
--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -248,7 +248,7 @@
   "editor.summary_advanced": "Zaawansowane",
   "editor.summary_allergens": "Alergeny",
   "editor.summary_appearance_and_layout": "Widok i układ",
-  "editor.summary_card_interactivity": "Interactywność karty",
+  "editor.summary_card_interactivity": "Interaktywność karty",
   "editor.summary_card_layout_and_colors": "Układ i kolory karty",
   "editor.summary_data_view_settings": "Ustawienia widoku daty",
   "editor.summary_day_view_settings": "Ustawienia widoku dnia",


### PR DESCRIPTION
Cherry-picked from PR #166 by @Krzysztonek.

**Change:** Fix typo in `src/locales/pl.json` for card interactivity.

Original commit: 706cf93a4b0d1ab4e5d752509259ed5d44965a5c