### PR TITLE
Fix Atmo France discovery for multi-instance setups

### DIFF
--- a/src/adapters/atmo.js
+++ b/src/adapters/atmo.js
@@ -24,26 +24,6 @@ export const ATMO_ALLERGEN_MAP = {
   qualite_globale: "qualite_globale",
 };
 
-// Reverse map for sensor detection: French slug → canonical
-const ATMO_REVERSE_MAP = Object.fromEntries(
-  Object.entries(ATMO_ALLERGEN_MAP).map(([k, v]) => [v, k]),
-);
-
-// Known French allergen slugs (excluding allergy_risk special entity)
-const ATMO_KNOWN_FR_SLUGS = new Set([
-  "ambroisie",
-  "armoise",
-  "aulne",
-  "bouleau",
-  "gramine",
-  "olivier",
-  "pm25",
-  "pm10",
-  "ozone",
-  "dioxyde_d_azote",
-  "dioxyde_de_soufre",
-]);
-
 // Pollution allergens use a different entity pattern (no "niveau_" prefix)
 export const ATMO_POLLUTION_ALLERGENS = new Set(["pm25", "pm10", "ozone", "no2", "so2"]);
 
@@ -162,9 +142,10 @@ export function discoverAtmoSensors(hass, debug = false) {
 
   // Fallback: regex scan (matches both prefixed and non-prefixed patterns)
   if (!entityIds.length && hass.states) {
+    const atmoFallbackRe = /^sensor\.(?:\w+_)?(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/;
     entityIds = Object.keys(hass.states).filter((id) =>
       typeof id === "string" &&
-      /(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:^sensor\.(?:\w+_)?(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre))|qualite_globale(?:_pollen)?)_/.test(id) &&
+      atmoFallbackRe.test(id) &&
       !/_j_\d+$/.test(id) &&
       !id.includes("concentration_"),
     );

--- a/src/adapters/atmo.js
+++ b/src/adapters/atmo.js
@@ -109,90 +109,214 @@ function classifyAtmoEntity(entityId) {
 }
 
 /**
- * Discover all Atmo France sensors using hass.entities (primary) or regex (fallback).
+ * Relaxed classifier for entities already known to belong to an Atmo France device.
+ * Unlike classifyAtmoEntity(), pollen entities don't need the "niveau_" prefix;
+ * the allergen slug alone suffices (e.g. "ambroisie"), as long as it's not
+ * a concentration entity.
+ */
+export function classifyAtmoEntityRelaxed(entityId) {
+  const id = entityId.replace(/^sensor\./, "");
+
+  // Summary entities (most specific first)
+  if (id.includes("qualite_globale_pollen")) return "allergy_risk";
+  if (id.includes("qualite_globale") && !id.includes("qualite_globale_pollen")) return "qualite_globale";
+
+  // Pollen: allergen slug present, not a concentration entity
+  for (const [canonical, frSlug] of Object.entries(ATMO_ALLERGEN_MAP)) {
+    if (canonical === "allergy_risk" || canonical === "qualite_globale") continue;
+    if (ATMO_POLLUTION_ALLERGENS.has(canonical)) continue;
+    if (id.includes(frSlug) && !id.includes(`concentration_${frSlug}`)) return canonical;
+  }
+
+  // Pollution: same logic as strict classifier
+  for (const canonical of ATMO_POLLUTION_ALLERGENS) {
+    const frSlug = ATMO_ALLERGEN_MAP[canonical];
+    if (id.includes(frSlug) && !id.includes(`niveau_${frSlug}`) && !id.includes(`concentration_${frSlug}`)) {
+      return canonical;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a human-readable label for an Atmo France location.
+ * Priority: device name_by_user > city from identifier > zone attribute > device name > "Auto"
+ *
+ * "Nom de la zone" is deprioritized because it often contains administrative
+ * zone names (e.g. "CC Leff Armor Communauté" instead of "Plouha") or is in
+ * ALL CAPS ("CHAMBRAY-LÈS-TOURS").
+ */
+function resolveAtmoLabel(state, device) {
+  if (device?.name_by_user) return device.name_by_user;
+
+  // Extract city from device identifier: ["atmofrance", "Lig'Air-Chambray-les-Tours"]
+  if (device?.identifiers) {
+    for (const tuple of device.identifiers) {
+      if (Array.isArray(tuple) && tuple[0] === "atmofrance" && tuple[1]) {
+        const dashIdx = tuple[1].indexOf("-");
+        if (dashIdx >= 0) return tuple[1].slice(dashIdx + 1);
+      }
+    }
+  }
+
+  const zoneName = state?.attributes?.["Nom de la zone"];
+  if (zoneName) return zoneName;
+
+  if (device?.name && device.name !== "Atmo France") return device.name;
+
+  return "Auto";
+}
+
+/**
+ * Discover all Atmo France sensors.
  *
  * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
  *
- * Primary: hass.entities -> filter platform === "atmofrance", no entity_category
- * Fallback: hass.states -> regex scan for known Atmo entity patterns
+ * Three-tier discovery:
+ *   1. Device-based: hass.devices (identifiers containing "atmofrance") -> entities by device_id
+ *   2. Entity-registry: hass.entities filtered by platform === "atmofrance"
+ *   3. Regex fallback: hass.states scanned for known Atmo entity patterns
  */
 export function discoverAtmoSensors(hass, debug = false) {
   const result = { locations: new Map() };
   if (!hass) return result;
 
-  let entityIds = [];
-  let usedRegistry = false;
+  // Helper: classify and group a set of entity IDs into result.locations
+  const classifyAndGroup = (entityIds, classifier, getConfigEntryId, getDevice) => {
+    for (const eid of entityIds) {
+      const state = hass.states?.[eid];
+      if (!state) continue;
 
-  // Primary: hass.entities (entity registry)
+      const allergenKey = classifier(eid);
+      if (!allergenKey) {
+        if (debug) console.debug("[ATMO] Could not classify entity:", eid);
+        continue;
+      }
+
+      const configEntryId = getConfigEntryId(eid);
+      if (!result.locations.has(configEntryId)) {
+        const device = getDevice(eid);
+        const label = resolveAtmoLabel(state, device);
+        result.locations.set(configEntryId, { label, entities: new Map() });
+      }
+      result.locations.get(configEntryId).entities.set(allergenKey, eid);
+    }
+  };
+
+  const isRelevant = (eid) => !/_j_\d+$/.test(eid) && !eid.includes("concentration_");
+
+  // --- Tier 1: Device-based discovery ---
+  if (hass.devices && hass.entities) {
+    const atmoDeviceIds = Object.entries(hass.devices)
+      .filter(([, dev]) =>
+        dev.identifiers?.some((tuple) => Array.isArray(tuple) && tuple[0] === "atmofrance")
+      )
+      .map(([devId]) => devId);
+
+    if (atmoDeviceIds.length) {
+      if (debug) console.debug("[ATMO] Discovery tier 1 (device-based): found", atmoDeviceIds.length, "devices");
+
+      // Build device-id set for fast lookup
+      const deviceIdSet = new Set(atmoDeviceIds);
+
+      const candidates = Object.entries(hass.entities)
+        .filter(([eid, entry]) =>
+          deviceIdSet.has(entry.device_id) &&
+          !entry.entity_category &&
+          isRelevant(eid)
+        )
+        .map(([eid]) => eid);
+
+      classifyAndGroup(
+        candidates,
+        classifyAtmoEntityRelaxed,
+        (eid) => {
+          const deviceId = hass.entities[eid]?.device_id;
+          const device = hass.devices[deviceId];
+          return device?.config_entries?.[0] || "default";
+        },
+        (eid) => {
+          const deviceId = hass.entities[eid]?.device_id;
+          return hass.devices[deviceId];
+        },
+      );
+
+      if (result.locations.size > 0) {
+        if (debug) {
+          console.debug("[ATMO] Discovery tier 1 result:", result.locations.size, "locations");
+          for (const [locId, loc] of result.locations) {
+            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+          }
+        }
+        return result;
+      }
+    }
+  }
+
+  // --- Tier 2: Entity-registry scan (secondary) ---
   if (hass.entities) {
     const candidates = Object.entries(hass.entities)
-      .filter(([, entry]) =>
+      .filter(([eid, entry]) =>
         entry.platform === "atmofrance" &&
-        !entry.entity_category
+        !entry.entity_category &&
+        isRelevant(eid)
       )
-      .map(([eid]) => eid)
-      .filter((id) => !/_j_\d+$/.test(id) && !id.includes("concentration_"));
+      .map(([eid]) => eid);
 
-    if (candidates.length > 0) {
-      entityIds = candidates;
-      usedRegistry = true;
-      if (debug) console.debug("[ATMO] Discovery: using hass.entities, found", candidates.length, "candidates");
+    if (candidates.length) {
+      if (debug) console.debug("[ATMO] Discovery tier 2 (entity-registry): found", candidates.length, "candidates");
+
+      classifyAndGroup(
+        candidates,
+        classifyAtmoEntity,
+        (eid) => {
+          if (hass.entities[eid]?.device_id && hass.devices) {
+            const device = hass.devices[hass.entities[eid].device_id];
+            if (device?.config_entries?.length) return device.config_entries[0];
+          }
+          return "default";
+        },
+        (eid) => {
+          const deviceId = hass.entities[eid]?.device_id;
+          return deviceId && hass.devices ? hass.devices[deviceId] : undefined;
+        },
+      );
+
+      if (result.locations.size > 0) {
+        if (debug) {
+          console.debug("[ATMO] Discovery tier 2 result:", result.locations.size, "locations");
+          for (const [locId, loc] of result.locations) {
+            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+          }
+        }
+        return result;
+      }
     }
   }
 
-  // Fallback: regex scan (matches both prefixed and non-prefixed patterns)
-  if (!entityIds.length && hass.states) {
-    const atmoFallbackRe = /^sensor\.(?:\w+_)?(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/;
-    entityIds = Object.keys(hass.states).filter((id) =>
+  // --- Tier 3: Regex fallback ---
+  if (hass.states) {
+    // (?:\w+_)* handles multi-word prefixes like "chambray_les_tours_"
+    const atmoFallbackRe = /^sensor\.(?:\w+_)*(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/;
+    const candidates = Object.keys(hass.states).filter((id) =>
       typeof id === "string" &&
       atmoFallbackRe.test(id) &&
-      !/_j_\d+$/.test(id) &&
-      !id.includes("concentration_"),
+      isRelevant(id),
     );
-    if (debug) console.debug("[ATMO] Discovery: using regex fallback, found", entityIds.length, "candidates");
-  }
-
-  if (!entityIds.length) return result;
-
-  // Group by config_entry_id
-  for (const eid of entityIds) {
-    const state = hass.states?.[eid];
-    if (!state) continue;
-
-    const allergenKey = classifyAtmoEntity(eid);
-    if (!allergenKey) {
-      if (debug) console.debug("[ATMO] Could not classify entity:", eid);
-      continue;
+    if (candidates.length) {
+      if (debug) console.debug("[ATMO] Discovery tier 3 (regex fallback): found", candidates.length, "candidates");
+      classifyAndGroup(
+        candidates,
+        classifyAtmoEntity,
+        () => "default",
+        () => undefined,
+      );
     }
-
-    // Resolve config_entry_id via device lookup (same pattern as GPL)
-    let configEntryId = "default";
-    if (usedRegistry && hass.entities?.[eid]?.device_id && hass.devices) {
-      const deviceId = hass.entities[eid].device_id;
-      const device = hass.devices[deviceId];
-      if (device?.config_entries?.length) {
-        configEntryId = device.config_entries[0];
-      }
-    }
-
-    if (!result.locations.has(configEntryId)) {
-      // Label: prefer "Nom de la zone" attribute, then device name
-      let label = "Auto";
-      const zoneName = state.attributes?.["Nom de la zone"];
-      if (zoneName) {
-        label = zoneName;
-      } else if (usedRegistry && hass.entities?.[eid]?.device_id && hass.devices) {
-        const device = hass.devices[hass.entities[eid].device_id];
-        if (device?.name) label = device.name;
-      }
-      result.locations.set(configEntryId, { label, entities: new Map() });
-    }
-
-    result.locations.get(configEntryId).entities.set(allergenKey, eid);
   }
 
   if (debug) {
-    console.debug("[ATMO] Discovery result:", result.locations.size, "locations");
+    console.debug("[ATMO] Discovery final result:", result.locations.size, "locations");
     for (const [locId, loc] of result.locations) {
       console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
     }

--- a/src/adapters/atmo.js
+++ b/src/adapters/atmo.js
@@ -100,7 +100,129 @@ export const stubConfigATMO = {
 export const ATMO_ALLERGENS = [...stubConfigATMO.allergens];
 
 /**
+ * Classify an Atmo France entity by its entity_id.
+ * Returns the canonical allergen key (e.g. "birch", "pm25") or null.
+ */
+function classifyAtmoEntity(entityId) {
+  const id = entityId.replace(/^sensor\./, "");
+
+  // Summary entities (most specific first)
+  if (id.includes("qualite_globale_pollen")) return "allergy_risk";
+  if (id.includes("qualite_globale") && !id.includes("qualite_globale_pollen")) return "qualite_globale";
+
+  // Pollen: niveau_{fr_slug}
+  for (const [canonical, frSlug] of Object.entries(ATMO_ALLERGEN_MAP)) {
+    if (canonical === "allergy_risk" || canonical === "qualite_globale") continue;
+    if (ATMO_POLLUTION_ALLERGENS.has(canonical)) continue;
+    if (id.includes(`niveau_${frSlug}`)) return canonical;
+  }
+
+  // Pollution: {fr_slug} without niveau_ or concentration_ prefix
+  for (const canonical of ATMO_POLLUTION_ALLERGENS) {
+    const frSlug = ATMO_ALLERGEN_MAP[canonical];
+    if (id.includes(frSlug) && !id.includes(`niveau_${frSlug}`) && !id.includes(`concentration_${frSlug}`)) {
+      return canonical;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Discover all Atmo France sensors using hass.entities (primary) or regex (fallback).
+ *
+ * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
+ *
+ * Primary: hass.entities -> filter platform === "atmofrance", no entity_category
+ * Fallback: hass.states -> regex scan for known Atmo entity patterns
+ */
+export function discoverAtmoSensors(hass, debug = false) {
+  const result = { locations: new Map() };
+  if (!hass) return result;
+
+  let entityIds = [];
+  let usedRegistry = false;
+
+  // Primary: hass.entities (entity registry)
+  if (hass.entities) {
+    const candidates = Object.entries(hass.entities)
+      .filter(([, entry]) =>
+        entry.platform === "atmofrance" &&
+        !entry.entity_category
+      )
+      .map(([eid]) => eid)
+      .filter((id) => !/_j_\d+$/.test(id) && !id.includes("concentration_"));
+
+    if (candidates.length > 0) {
+      entityIds = candidates;
+      usedRegistry = true;
+      if (debug) console.debug("[ATMO] Discovery: using hass.entities, found", candidates.length, "candidates");
+    }
+  }
+
+  // Fallback: regex scan (matches both prefixed and non-prefixed patterns)
+  if (!entityIds.length && hass.states) {
+    entityIds = Object.keys(hass.states).filter((id) =>
+      typeof id === "string" &&
+      /(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:^sensor\.(?:\w+_)?(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre))|qualite_globale(?:_pollen)?)_/.test(id) &&
+      !/_j_\d+$/.test(id) &&
+      !id.includes("concentration_"),
+    );
+    if (debug) console.debug("[ATMO] Discovery: using regex fallback, found", entityIds.length, "candidates");
+  }
+
+  if (!entityIds.length) return result;
+
+  // Group by config_entry_id
+  for (const eid of entityIds) {
+    const state = hass.states?.[eid];
+    if (!state) continue;
+
+    const allergenKey = classifyAtmoEntity(eid);
+    if (!allergenKey) {
+      if (debug) console.debug("[ATMO] Could not classify entity:", eid);
+      continue;
+    }
+
+    // Resolve config_entry_id via device lookup (same pattern as GPL)
+    let configEntryId = "default";
+    if (usedRegistry && hass.entities?.[eid]?.device_id && hass.devices) {
+      const deviceId = hass.entities[eid].device_id;
+      const device = hass.devices[deviceId];
+      if (device?.config_entries?.length) {
+        configEntryId = device.config_entries[0];
+      }
+    }
+
+    if (!result.locations.has(configEntryId)) {
+      // Label: prefer "Nom de la zone" attribute, then device name
+      let label = "Auto";
+      const zoneName = state.attributes?.["Nom de la zone"];
+      if (zoneName) {
+        label = zoneName;
+      } else if (usedRegistry && hass.entities?.[eid]?.device_id && hass.devices) {
+        const device = hass.devices[hass.entities[eid].device_id];
+        if (device?.name) label = device.name;
+      }
+      result.locations.set(configEntryId, { label, entities: new Map() });
+    }
+
+    result.locations.get(configEntryId).entities.set(allergenKey, eid);
+  }
+
+  if (debug) {
+    console.debug("[ATMO] Discovery result:", result.locations.size, "locations");
+    for (const [locId, loc] of result.locations) {
+      console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Detect location slug from available Atmo France entities.
+ * Legacy fallback for slug-based configs without hass.entities.
  */
 function detectLocation(hass, debug) {
   // Try pollen entities first (most reliable pattern)
@@ -169,19 +291,12 @@ function buildEntityId(allergen, location, forecast) {
 
 export function resolveEntityIds(cfg, hass, debug = false) {
   const map = new Map();
-  let location = cfg.location || "";
-  if (location === "manual") {
-    // Manual mode handled per allergen below
-  } else if (!location) {
-    location = detectLocation(hass, debug) || "";
-  }
 
-  for (const allergen of cfg.allergens || []) {
-    const frSlug = ATMO_ALLERGEN_MAP[allergen];
-    if (!frSlug) continue;
-
-    let sensorId;
-    if (cfg.location === "manual") {
+  if (cfg.location === "manual") {
+    // Manual mode: prefix/suffix based lookup
+    for (const allergen of cfg.allergens || []) {
+      const frSlug = ATMO_ALLERGEN_MAP[allergen];
+      if (!frSlug) continue;
       const prefix = normalizeManualPrefix(cfg.entity_prefix);
       const suffix = cfg.entity_suffix || "";
       let stem;
@@ -194,36 +309,67 @@ export function resolveEntityIds(cfg, hass, debug = false) {
       } else {
         stem = `niveau_${frSlug}`;
       }
-      sensorId = resolveManualEntity(hass, prefix, stem, suffix);
+      const sensorId = resolveManualEntity(hass, prefix, stem, suffix);
       if (!sensorId) continue;
-    } else {
-      if (!location) continue;
-      sensorId = buildEntityId(allergen, location, false);
-      if (!sensorId || !hass.states[sensorId]) {
-        let prefix;
-        if (allergen === "allergy_risk") {
-          prefix = `sensor.qualite_globale_pollen_`;
-        } else if (allergen === "qualite_globale") {
-          prefix = `sensor.qualite_globale_`;
-        } else if (ATMO_POLLUTION_ALLERGENS.has(allergen)) {
-          prefix = `sensor.${frSlug}_`;
-        } else {
-          prefix = `sensor.niveau_${frSlug}_`;
-        }
-        const candidates = Object.keys(hass.states).filter((id) => {
-          if (!id.startsWith(prefix) || id.includes("_j_")) return false;
-          if (allergen === "qualite_globale" && id.includes("qualite_globale_pollen")) return false;
-          return true;
-        });
-        if (candidates.length === 1) sensorId = candidates[0];
-        else continue;
+      if (debug) console.debug(`[ATMO:resolveEntityIds] manual: '${allergen}' -> '${sensorId}'`);
+      map.set(allergen, sensorId);
+    }
+    return map;
+  }
+
+  // Discovery-based resolution (handles prefixed entity IDs)
+  const discovery = discoverAtmoSensors(hass, debug);
+  const location = cfg.location || "";
+  let discoveredEntities = null;
+
+  if (location && discovery.locations.has(location)) {
+    // Config entry ID match (new-style config)
+    discoveredEntities = discovery.locations.get(location).entities;
+  } else if (!location && discovery.locations.size) {
+    // Auto-detect: use first discovered location
+    discoveredEntities = discovery.locations.values().next().value.entities;
+  }
+
+  if (discoveredEntities) {
+    for (const allergen of cfg.allergens || []) {
+      const sensorId = discoveredEntities.get(allergen);
+      if (sensorId && hass.states?.[sensorId]) {
+        if (debug) console.debug(`[ATMO:resolveEntityIds] discovery: '${allergen}' -> '${sensorId}'`);
+        map.set(allergen, sensorId);
       }
     }
-    if (debug) {
-      console.debug(
-        `[ATMO:resolveEntityIds] allergen: '${allergen}', sensorId: '${sensorId}'`,
-      );
+    return map;
+  }
+
+  // Slug fallback (backward compat for location: "nice" style configs)
+  const slugLocation = location || detectLocation(hass, debug) || "";
+  if (!slugLocation) return map;
+
+  for (const allergen of cfg.allergens || []) {
+    const frSlug = ATMO_ALLERGEN_MAP[allergen];
+    if (!frSlug) continue;
+
+    let sensorId = buildEntityId(allergen, slugLocation, false);
+    if (!sensorId || !hass.states[sensorId]) {
+      let pfx;
+      if (allergen === "allergy_risk") {
+        pfx = `sensor.qualite_globale_pollen_`;
+      } else if (allergen === "qualite_globale") {
+        pfx = `sensor.qualite_globale_`;
+      } else if (ATMO_POLLUTION_ALLERGENS.has(allergen)) {
+        pfx = `sensor.${frSlug}_`;
+      } else {
+        pfx = `sensor.niveau_${frSlug}_`;
+      }
+      const candidates = Object.keys(hass.states).filter((id) => {
+        if (!id.startsWith(pfx) || id.includes("_j_")) return false;
+        if (allergen === "qualite_globale" && id.includes("qualite_globale_pollen")) return false;
+        return true;
+      });
+      if (candidates.length === 1) sensorId = candidates[0];
+      else continue;
     }
+    if (debug) console.debug(`[ATMO:resolveEntityIds] slug fallback: '${allergen}' -> '${sensorId}'`);
     map.set(allergen, sensorId);
   }
   return map;
@@ -274,14 +420,6 @@ export async function fetchForecast(hass, config) {
     return { state: raw, display_state: Math.min(raw, 6), state_text: libelle || noInfoLabel };
   };
 
-  // Resolve location (also used for J+1 forecast entities)
-  let location = config.location || "";
-  if (location === "manual") {
-    // Manual mode handled by resolveEntityIds
-  } else if (!location) {
-    location = detectLocation(hass, debug) || "";
-  }
-
   const entityMap = resolveEntityIds(config, hass, debug);
 
   const today = new Date();
@@ -317,22 +455,13 @@ export async function fetchForecast(hass, config) {
       const todayVal = testVal(sensor.state);
       const todayLibelle = sensor.attributes?.["Libellé"] || "";
 
-      // J+1 forecast
+      // J+1 forecast: always derive from {sensorId}_j_1 (works for prefixed entities)
       let tomorrowVal = -1;
       let tomorrowLibelle = "";
-      if (location !== "manual") {
-        const j1Id = buildEntityId(allergen, location, true);
-        if (j1Id && hass.states[j1Id]) {
-          tomorrowVal = testVal(hass.states[j1Id].state);
-          tomorrowLibelle = hass.states[j1Id].attributes?.["Libellé"] || "";
-        }
-      } else {
-        // Manual mode: try {sensorId}_j_1
-        const j1Id = `${sensorId}_j_1`;
-        if (hass.states[j1Id]) {
-          tomorrowVal = testVal(hass.states[j1Id].state);
-          tomorrowLibelle = hass.states[j1Id].attributes?.["Libellé"] || "";
-        }
+      const j1Id = `${sensorId}_j_1`;
+      if (hass.states[j1Id]) {
+        tomorrowVal = testVal(hass.states[j1Id].state);
+        tomorrowLibelle = hass.states[j1Id].attributes?.["Libellé"] || "";
       }
 
       // Build level entries with per-entity Libellé

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -9,6 +9,7 @@ import { findAvailableSensors } from "./utils/sensors.js";
 import { filterSensorsPostFetch } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 import { PLU_ALIAS_MAP } from "./adapters/plu.js";
+import { discoverAtmoSensors } from "./adapters/atmo.js";
 import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
 import { discoverGpSensors } from "./adapters/gp/index.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
@@ -1530,40 +1531,22 @@ class PollenPrognosCard extends LitElement {
 
         loc = title || cfg.location || "";
       } else if (integration === "atmo") {
-        // Atmo France: extract location from sensor attributes (pollen + pollution)
-        const atmoRe = /^sensor\.(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_(.+?)(?:_j_\d+)?$/;
-        const atmoEntities = Object.values(hass.states).filter(
-          (s) =>
-            s &&
-            typeof s === "object" &&
-            typeof s.entity_id === "string" &&
-            atmoRe.test(s.entity_id),
-        );
+        // Atmo France: use discovery to resolve location title
+        const atmoDiscovery = discoverAtmoSensors(hass, false);
         const wantedLocation =
           cfg.location && cfg.location !== "manual"
-            ? cfg.location.toLowerCase()
+            ? cfg.location
             : "";
 
-        let match = null;
-        if (wantedLocation) {
-          match = atmoEntities.find((s) => {
-            const m = s.entity_id.match(atmoRe);
-            return m && m[1] === wantedLocation;
-          });
-        } else if (atmoEntities.length) {
-          match = atmoEntities[0];
+        let title = "";
+        if (wantedLocation && atmoDiscovery.locations.has(wantedLocation)) {
+          title = atmoDiscovery.locations.get(wantedLocation).label;
+        } else if (atmoDiscovery.locations.size) {
+          title = atmoDiscovery.locations.values().next().value.label;
         }
 
-        let title = "";
-        if (match) {
-          const attr = match.attributes || {};
-          title =
-            attr["Nom de la zone"] ||
-            cfg.location ||
-            "";
-          if (title) {
-            title = title.charAt(0).toUpperCase() + title.slice(1);
-          }
+        if (title) {
+          title = title.charAt(0).toUpperCase() + title.slice(1);
         }
 
         loc = title || cfg.location || "";

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -813,23 +813,9 @@ class PollenPrognosCardEditor extends LitElement {
         return pluAllergenSlugs.has(allergenSlug);
       },
     );
-    // Atmo France: use hass.entities (primary) or regex (fallback)
-    let atmoStates = [];
-    if (hass.entities) {
-      atmoStates = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === "atmofrance" && !entry.entity_category)
-        .map(([eid]) => eid)
-        .filter((id) => !/_j_\d+$/.test(id) && !id.includes("concentration_"));
-    }
-    if (!atmoStates.length) {
-      atmoStates = Object.keys(hass.states).filter(
-        (id) =>
-          typeof id === "string" &&
-          /(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
-          !/_j_\d+$/.test(id) &&
-          !id.includes("concentration_"),
-      );
-    }
+    // Atmo France: discovery-based detection (same function used for location list)
+    const atmoDiscovery = discoverAtmoSensors(hass, false);
+    const atmoDetected = atmoDiscovery.locations.size > 0;
     // GPL: use hass.entities (primary) or attribution (fallback)
     let gplStates = [];
     if (hass.entities) {
@@ -866,12 +852,12 @@ class PollenPrognosCardEditor extends LitElement {
       else if (peuStates.length) integration = "peu";
       else if (dwdStates.length) integration = "dwd";
       else if (silamStates.length) integration = "silam";
-      else if (atmoStates.length) integration = "atmo";
+      else if (atmoDetected) integration = "atmo";
       else if (gpStates.length) integration = "gp";
       else if (gplStates.length) integration = "gpl";
       this._userConfig.integration = integration;
       if (this.debug)
-        console.debug("[Editor] autodetect:", { pp: ppStates.length, plu: pluStates.length, peu: peuStates.length, dwd: dwdStates.length, silam: silamStates.length, atmo: atmoStates.length, gp: gpStates.length, gpl: gplStates.length, chosen: integration });
+        console.debug("[Editor] autodetect:", { pp: ppStates.length, plu: pluStates.length, peu: peuStates.length, dwd: dwdStates.length, silam: silamStates.length, atmo: atmoDiscovery.locations.size, gp: gpStates.length, gpl: gplStates.length, chosen: integration });
     }
 
     // 1.1) GPL discovery — always run so render() and auto-select have data
@@ -1110,8 +1096,7 @@ class PollenPrognosCardEditor extends LitElement {
         ),
       );
 
-      // Collect Atmo France locations via discovery (handles prefixed entity IDs)
-      const atmoDiscovery = discoverAtmoSensors(hass, false);
+      // Collect Atmo France locations (reuse discovery from autodetect above)
       this.installedAtmoLocations = Array.from(atmoDiscovery.locations.entries())
         .map(([configEntryId, loc]) => [configEntryId, loc.label]);
 

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -18,7 +18,7 @@ import { PEU_ALLERGENS } from "./adapters/peu.js";
 import { SILAM_ALLERGENS } from "./adapters/silam.js";
 import { stubConfigKleenex } from "./adapters/kleenex/index.js";
 import { stubConfigPLU, PLU_ALIAS_MAP } from "./adapters/plu.js";
-import { ATMO_ALLERGENS, ATMO_ALLERGEN_MAP } from "./adapters/atmo.js";
+import { ATMO_ALLERGENS, ATMO_ALLERGEN_MAP, discoverAtmoSensors } from "./adapters/atmo.js";
 import { GPL_BASE_ALLERGENS, GPL_ATTRIBUTION, discoverGplSensors, discoverGplAllergens } from "./adapters/gpl/index.js";
 import { GP_BASE_ALLERGENS, discoverGpSensors, discoverGpAllergens } from "./adapters/gp/index.js";
 import {
@@ -813,12 +813,23 @@ class PollenPrognosCardEditor extends LitElement {
         return pluAllergenSlugs.has(allergenSlug);
       },
     );
-    const atmoStates = Object.keys(hass.states).filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
-        !/_j_\d+$/.test(id),
-    );
+    // Atmo France: use hass.entities (primary) or regex (fallback)
+    let atmoStates = [];
+    if (hass.entities) {
+      atmoStates = Object.entries(hass.entities)
+        .filter(([, entry]) => entry.platform === "atmofrance" && !entry.entity_category)
+        .map(([eid]) => eid)
+        .filter((id) => !/_j_\d+$/.test(id) && !id.includes("concentration_"));
+    }
+    if (!atmoStates.length) {
+      atmoStates = Object.keys(hass.states).filter(
+        (id) =>
+          typeof id === "string" &&
+          /(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
+          !/_j_\d+$/.test(id) &&
+          !id.includes("concentration_"),
+      );
+    }
     // GPL: use hass.entities (primary) or attribution (fallback)
     let gplStates = [];
     if (hass.entities) {
@@ -1099,25 +1110,10 @@ class PollenPrognosCardEditor extends LitElement {
         ),
       );
 
-      // Collect Atmo France locations (pollen + pollution entities)
-      const atmoLocationRe = /^sensor\.(?:niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_(.+?)(?:_j_\d+)?$/;
-      this.installedAtmoLocations = Array.from(
-        new Map(
-          atmoStates
-            .map((id) => {
-              const m = id.match(atmoLocationRe);
-              if (!m) return null;
-              const locationSlug = m[1];
-              const entity = hass.states[id];
-              const title =
-                entity?.attributes?.["Nom de la zone"] ||
-                locationSlug.charAt(0).toUpperCase() +
-                  locationSlug.slice(1).replace(/_/g, " ");
-              return [locationSlug, title];
-            })
-            .filter((entry) => entry !== null),
-        ),
-      );
+      // Collect Atmo France locations via discovery (handles prefixed entity IDs)
+      const atmoDiscovery = discoverAtmoSensors(hass, false);
+      this.installedAtmoLocations = Array.from(atmoDiscovery.locations.entries())
+        .map(([configEntryId, loc]) => [configEntryId, loc.label]);
 
       // 4) Auto-välj första region/stad om användaren inte satt något
       if (!this._initDone) {

--- a/test/adapters/atmo.test.js
+++ b/test/adapters/atmo.test.js
@@ -7,6 +7,7 @@ import {
   ATMO_POLLUTION_ALLERGENS,
   discoverAtmoSensors,
   resolveEntityIds,
+  classifyAtmoEntityRelaxed,
 } from "../../src/adapters/atmo.js";
 import { createHass, assertSensorShape } from "../helpers.js";
 
@@ -940,8 +941,13 @@ function makePrefixedHass(prefix, location, allergenStates, configEntryId) {
       entities[j1Id] = { platform: "atmofrance", device_id: deviceId };
     }
   }
+  const cityLabel = location.charAt(0).toUpperCase() + location.slice(1);
   const devices = {
-    [deviceId]: { name: `Atmo France - ${location.charAt(0).toUpperCase() + location.slice(1)}`, config_entries: [configEntryId] },
+    [deviceId]: {
+      name: "Atmo France",
+      config_entries: [configEntryId],
+      identifiers: [["atmofrance", `Test-${cityLabel}`]],
+    },
   };
   return createHass(states, { language: "fr", entities, devices });
 }
@@ -977,7 +983,7 @@ describe("discoverAtmoSensors", () => {
         },
         devices: {
           ...hass1.devices,
-          device_nice: { name: "Atmo France - Nice", config_entries: ["entry_nice"] },
+          device_nice: { name: "Atmo France", config_entries: ["entry_nice"], identifiers: [["atmofrance", "AtmoSud-Nice"]] },
         },
       },
     );
@@ -1145,5 +1151,203 @@ describe("fetchForecast with prefixed entities", () => {
     expect(result[0].entity_id).toBe("sensor.niveau_bouleau_nice");
     expect(result[0].day0.state).toBe(4);
     expect(result[0].day1.state).toBe(2);
+  });
+});
+
+describe("classifyAtmoEntityRelaxed", () => {
+  it("matches standard niveau_ entities", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_ambroisie_nice")).toBe("ragweed");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_bouleau_paris")).toBe("birch");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_gramine_nice")).toBe("grass");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_olivier_nice")).toBe("olive");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_armoise_nice")).toBe("mugwort");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_aulne_nice")).toBe("alder");
+  });
+
+  it("matches old-style niveau_alerte_ entities", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_alerte_ambroisie_nice")).toBe("ragweed");
+    expect(classifyAtmoEntityRelaxed("sensor.niveau_alerte_bouleau_paris")).toBe("birch");
+  });
+
+  it("matches bare allergen slug (no niveau_ prefix)", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.ambroisie_nice")).toBe("ragweed");
+    expect(classifyAtmoEntityRelaxed("sensor.bouleau_paris")).toBe("birch");
+  });
+
+  it("matches prefixed entities (HA disambiguation)", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.chambray_les_tours_niveau_ambroisie_chambray_les_tours")).toBe("ragweed");
+    expect(classifyAtmoEntityRelaxed("sensor.plouha_niveau_bouleau_plouha")).toBe("birch");
+  });
+
+  it("rejects concentration entities", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.concentration_ambroisie_nice")).toBeNull();
+    expect(classifyAtmoEntityRelaxed("sensor.chambray_les_tours_concentration_bouleau_chambray_les_tours")).toBeNull();
+  });
+
+  it("classifies summary entities", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.qualite_globale_pollen_nice")).toBe("allergy_risk");
+    expect(classifyAtmoEntityRelaxed("sensor.chambray_les_tours_qualite_globale_pollen_chambray_les_tours")).toBe("allergy_risk");
+    expect(classifyAtmoEntityRelaxed("sensor.qualite_globale_nice")).toBe("qualite_globale");
+  });
+
+  it("classifies pollution entities", () => {
+    expect(classifyAtmoEntityRelaxed("sensor.pm25_nice")).toBe("pm25");
+    expect(classifyAtmoEntityRelaxed("sensor.ozone_nice")).toBe("ozone");
+    expect(classifyAtmoEntityRelaxed("sensor.dioxyde_d_azote_nice")).toBe("no2");
+    expect(classifyAtmoEntityRelaxed("sensor.dioxyde_de_soufre_nice")).toBe("so2");
+  });
+});
+
+describe("discoverAtmoSensors: device-based discovery", () => {
+  it("discovers entities via device identifiers (tier 1)", () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 2],
+      ["pm25", 4, 3],
+    ], "entry_toulouse");
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("entry_toulouse")).toBe(true);
+    const loc = result.locations.get("entry_toulouse");
+    expect(loc.entities.get("birch")).toBe("sensor.toulouse_niveau_bouleau_toulouse");
+    expect(loc.entities.get("pm25")).toBe("sensor.toulouse_pm25_toulouse");
+  });
+
+  it("discovers multi-word prefix entities via device path", () => {
+    const states = {
+      "sensor.chambray_les_tours_niveau_ambroisie_chambray_les_tours": {
+        state: "3", attributes: { "Libellé": "", "Nom de la zone": "Chambray-lès-Tours" },
+      },
+      "sensor.chambray_les_tours_niveau_bouleau_chambray_les_tours": {
+        state: "5", attributes: { "Libellé": "", "Nom de la zone": "Chambray-lès-Tours" },
+      },
+      "sensor.chambray_les_tours_qualite_globale_pollen_chambray_les_tours": {
+        state: "4", attributes: { "Libellé": "", "Nom de la zone": "Chambray-lès-Tours" },
+      },
+    };
+    const entities = {};
+    for (const eid of Object.keys(states)) {
+      entities[eid] = { platform: "atmofrance", device_id: "dev_chambray" };
+    }
+    const devices = {
+      dev_chambray: {
+        name: "Atmo France",
+        config_entries: ["entry_chambray"],
+        identifiers: [["atmofrance", "Lig'Air-Chambray-lès-Tours"]],
+      },
+    };
+    const hass = createHass(states, { language: "fr", entities, devices });
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("entry_chambray")).toBe(true);
+    const loc = result.locations.get("entry_chambray");
+    expect(loc.entities.get("ragweed")).toBe("sensor.chambray_les_tours_niveau_ambroisie_chambray_les_tours");
+    expect(loc.entities.get("birch")).toBe("sensor.chambray_les_tours_niveau_bouleau_chambray_les_tours");
+    expect(loc.entities.get("allergy_risk")).toBe("sensor.chambray_les_tours_qualite_globale_pollen_chambray_les_tours");
+  });
+
+  it("resolves label from device identifier (city after first dash)", () => {
+    const states = {
+      "sensor.pfx_niveau_bouleau_city": { state: "3", attributes: { "Libellé": "", "Nom de la zone": "Some Admin Zone" } },
+    };
+    const entities = {
+      "sensor.pfx_niveau_bouleau_city": { platform: "atmofrance", device_id: "d1" },
+    };
+    const devices = {
+      d1: {
+        name: "Atmo France",
+        config_entries: ["e1"],
+        identifiers: [["atmofrance", "Air Breizh-Plouha"]],
+      },
+    };
+    const hass = createHass(states, { language: "fr", entities, devices });
+
+    const result = discoverAtmoSensors(hass);
+    // Identifier city takes precedence over "Nom de la zone"
+    expect(result.locations.get("e1").label).toBe("Plouha");
+  });
+
+  it("resolves label from device name_by_user (highest priority)", () => {
+    const states = {
+      "sensor.pfx_niveau_bouleau_city": { state: "3", attributes: { "Libellé": "", "Nom de la zone": "Zone Name" } },
+    };
+    const entities = {
+      "sensor.pfx_niveau_bouleau_city": { platform: "atmofrance", device_id: "d1" },
+    };
+    const devices = {
+      d1: {
+        name: "Atmo France",
+        name_by_user: "Mon Emplacement",
+        config_entries: ["e1"],
+        identifiers: [["atmofrance", "Test-City"]],
+      },
+    };
+    const hass = createHass(states, { language: "fr", entities, devices });
+
+    const result = discoverAtmoSensors(hass);
+    // name_by_user wins over identifier and zone name
+    expect(result.locations.get("e1").label).toBe("Mon Emplacement");
+  });
+
+  it("falls back to Nom de la zone when no device info", () => {
+    const states = {
+      "sensor.niveau_bouleau_nice": { state: "3", attributes: { "Libellé": "", "Nom de la zone": "Nice" } },
+    };
+    // Tier 3 fallback: no entities, no devices
+    const hass = createHass(states, { language: "fr", entities: undefined });
+
+    const result = discoverAtmoSensors(hass);
+    expect(result.locations.get("default").label).toBe("Nice");
+  });
+
+  it("falls back to tier 2 when no devices have atmofrance identifiers", () => {
+    const states = {
+      "sensor.niveau_bouleau_nice": { state: "3", attributes: { "Libellé": "" } },
+    };
+    const entities = {
+      "sensor.niveau_bouleau_nice": { platform: "atmofrance", device_id: "d1" },
+    };
+    const devices = {
+      d1: { name: "Something Else", config_entries: ["e1"] },
+    };
+    const hass = createHass(states, { language: "fr", entities, devices });
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("e1")).toBe(true);
+    expect(result.locations.get("e1").entities.get("birch")).toBe("sensor.niveau_bouleau_nice");
+  });
+
+  it("falls back to tier 3 (regex) when hass.entities is unavailable", () => {
+    const states = {
+      "sensor.niveau_bouleau_nice": { state: "3", attributes: { "Libellé": "" } },
+      "sensor.pm25_nice": { state: "2", attributes: {} },
+    };
+    const hass = createHass(states, { language: "fr", entities: undefined });
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("default")).toBe(true);
+    expect(result.locations.get("default").entities.get("birch")).toBe("sensor.niveau_bouleau_nice");
+  });
+
+  it("regex fallback handles multi-word prefix", () => {
+    const states = {
+      "sensor.chambray_les_tours_niveau_bouleau_chambray_les_tours": {
+        state: "3", attributes: { "Libellé": "" },
+      },
+    };
+    const hass = createHass(states, { language: "fr", entities: undefined });
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.get("default").entities.get("birch"))
+      .toBe("sensor.chambray_les_tours_niveau_bouleau_chambray_les_tours");
   });
 });

--- a/test/adapters/atmo.test.js
+++ b/test/adapters/atmo.test.js
@@ -5,6 +5,8 @@ import {
   ATMO_ALLERGENS,
   ATMO_ALLERGEN_MAP,
   ATMO_POLLUTION_ALLERGENS,
+  discoverAtmoSensors,
+  resolveEntityIds,
 } from "../../src/adapters/atmo.js";
 import { createHass, assertSensorShape } from "../helpers.js";
 
@@ -910,5 +912,238 @@ describe("ATMO adapter: fetchForecast", () => {
 
       expect(result[0].allergenShort).toBe("Bou.");
     });
+  });
+});
+
+// Helper: create a hass mock with prefixed entity IDs (multi-instance pattern)
+function makePrefixedHass(prefix, location, allergenStates, configEntryId) {
+  const states = {};
+  const entities = {};
+  const deviceId = `device_${location}`;
+  for (const [allergen, todayVal, tomorrowVal] of allergenStates) {
+    const frSlug = ATMO_ALLERGEN_MAP[allergen];
+    let todayId;
+    if (allergen === "allergy_risk") {
+      todayId = `sensor.${prefix}_qualite_globale_pollen_${location}`;
+    } else if (allergen === "qualite_globale") {
+      todayId = `sensor.${prefix}_qualite_globale_${location}`;
+    } else if (ATMO_POLLUTION_ALLERGENS.has(allergen)) {
+      todayId = `sensor.${prefix}_${frSlug}_${location}`;
+    } else {
+      todayId = `sensor.${prefix}_niveau_${frSlug}_${location}`;
+    }
+    const j1Id = `${todayId}_j_1`;
+    states[todayId] = { state: String(todayVal), attributes: { "Libellé": "", "Nom de la zone": location.charAt(0).toUpperCase() + location.slice(1) } };
+    entities[todayId] = { platform: "atmofrance", device_id: deviceId };
+    if (tomorrowVal !== undefined) {
+      states[j1Id] = { state: String(tomorrowVal), attributes: { "Libellé": "" } };
+      entities[j1Id] = { platform: "atmofrance", device_id: deviceId };
+    }
+  }
+  const devices = {
+    [deviceId]: { name: `Atmo France - ${location.charAt(0).toUpperCase() + location.slice(1)}`, config_entries: [configEntryId] },
+  };
+  return createHass(states, { language: "fr", entities, devices });
+}
+
+describe("discoverAtmoSensors", () => {
+  it("discovers entities grouped by config_entry_id via hass.entities", () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 2],
+      ["pm25", 4, 3],
+    ], "entry_toulouse");
+
+    const result = discoverAtmoSensors(hass);
+
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("entry_toulouse")).toBe(true);
+    const loc = result.locations.get("entry_toulouse");
+    expect(loc.entities.get("birch")).toBe("sensor.toulouse_niveau_bouleau_toulouse");
+    expect(loc.entities.get("pm25")).toBe("sensor.toulouse_pm25_toulouse");
+  });
+
+  it("discovers multiple locations from different config entries", () => {
+    const hass1 = makePrefixedHass("toulouse", "toulouse", [["birch", 3, 2]], "entry_toulouse");
+    const hass2 = makeHass("nice", [["birch", 4, 3]]);
+    // Merge: nice uses non-prefixed entities, add entity registry entries for nice
+    const merged = createHass(
+      { ...hass1.states, ...hass2.states },
+      {
+        language: "fr",
+        entities: {
+          ...hass1.entities,
+          "sensor.niveau_bouleau_nice": { platform: "atmofrance", device_id: "device_nice" },
+          "sensor.niveau_bouleau_nice_j_1": { platform: "atmofrance", device_id: "device_nice" },
+        },
+        devices: {
+          ...hass1.devices,
+          device_nice: { name: "Atmo France - Nice", config_entries: ["entry_nice"] },
+        },
+      },
+    );
+
+    const result = discoverAtmoSensors(merged);
+
+    expect(result.locations.size).toBe(2);
+    expect(result.locations.has("entry_toulouse")).toBe(true);
+    expect(result.locations.has("entry_nice")).toBe(true);
+  });
+
+  it("classifies all allergen types correctly", () => {
+    const hass = makePrefixedHass("pfx", "city", [
+      ["birch", 3, 2],
+      ["ragweed", 2, 1],
+      ["mugwort", 1, 0],
+      ["alder", 2, 1],
+      ["grass", 3, 2],
+      ["olive", 1, 0],
+      ["allergy_risk", 4, 3],
+      ["qualite_globale", 3, 2],
+      ["pm25", 2, 1],
+      ["pm10", 3, 2],
+      ["ozone", 1, 0],
+      ["no2", 2, 1],
+      ["so2", 1, 0],
+    ], "entry_city");
+
+    const result = discoverAtmoSensors(hass);
+    const entities = result.locations.get("entry_city").entities;
+
+    expect(entities.size).toBe(13);
+    expect(entities.get("birch")).toContain("niveau_bouleau");
+    expect(entities.get("allergy_risk")).toContain("qualite_globale_pollen");
+    expect(entities.get("qualite_globale")).toMatch(/qualite_globale_city$/);
+    expect(entities.get("pm25")).toContain("pm25");
+    expect(entities.get("no2")).toContain("dioxyde_d_azote");
+  });
+
+  it("excludes concentration entities", () => {
+    const states = {
+      "sensor.toulouse_concentration_ambroisie_toulouse": { state: "42", attributes: {} },
+      "sensor.toulouse_niveau_bouleau_toulouse": { state: "3", attributes: { "Libellé": "" } },
+    };
+    const entities = {
+      "sensor.toulouse_concentration_ambroisie_toulouse": { platform: "atmofrance", device_id: "d1" },
+      "sensor.toulouse_niveau_bouleau_toulouse": { platform: "atmofrance", device_id: "d1" },
+    };
+    const hass = createHass(states, {
+      language: "fr",
+      entities,
+      devices: { d1: { name: "Test", config_entries: ["e1"] } },
+    });
+
+    const result = discoverAtmoSensors(hass);
+    const loc = result.locations.get("e1");
+
+    expect(loc.entities.has("birch")).toBe(true);
+    // concentration entity should not produce a ragweed entry
+    expect(loc.entities.has("ragweed")).toBe(false);
+  });
+
+  it("falls back to regex scan when hass.entities is unavailable", () => {
+    const states = {
+      "sensor.niveau_bouleau_nice": { state: "3", attributes: { "Libellé": "" } },
+      "sensor.pm25_nice": { state: "2", attributes: {} },
+    };
+    const hass = createHass(states, { language: "fr", entities: undefined });
+
+    const result = discoverAtmoSensors(hass);
+
+    // Falls back to "default" grouping (no config_entry_id)
+    expect(result.locations.size).toBe(1);
+    expect(result.locations.has("default")).toBe(true);
+    expect(result.locations.get("default").entities.get("birch")).toBe("sensor.niveau_bouleau_nice");
+  });
+});
+
+describe("resolveEntityIds with discovery (prefixed entities)", () => {
+  it("resolves prefixed entities via config_entry_id", () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 2],
+      ["pm25", 4, 3],
+      ["allergy_risk", 2, 1],
+    ], "entry_toulouse");
+
+    const config = makeConfig({
+      location: "entry_toulouse",
+      allergens: ["birch", "pm25", "allergy_risk"],
+    });
+
+    const map = resolveEntityIds(config, hass);
+
+    expect(map.get("birch")).toBe("sensor.toulouse_niveau_bouleau_toulouse");
+    expect(map.get("pm25")).toBe("sensor.toulouse_pm25_toulouse");
+    expect(map.get("allergy_risk")).toBe("sensor.toulouse_qualite_globale_pollen_toulouse");
+  });
+
+  it("auto-detects prefixed location when location is empty", () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 2],
+    ], "entry_toulouse");
+
+    const config = makeConfig({ location: "", allergens: ["birch"] });
+
+    const map = resolveEntityIds(config, hass);
+
+    expect(map.get("birch")).toBe("sensor.toulouse_niveau_bouleau_toulouse");
+  });
+
+  it("falls back to slug-based resolution for old configs", () => {
+    const hass = makeHass("nice", [["birch", 3, 2]]);
+    const config = makeConfig({ location: "nice", allergens: ["birch"] });
+
+    const map = resolveEntityIds(config, hass);
+
+    expect(map.get("birch")).toBe("sensor.niveau_bouleau_nice");
+  });
+});
+
+describe("fetchForecast with prefixed entities", () => {
+  it("returns correct data for prefixed entity IDs", async () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 2],
+      ["grass", 5, 4],
+    ], "entry_toulouse");
+
+    const config = makeConfig({
+      location: "entry_toulouse",
+      allergens: ["birch", "grass"],
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    expect(result.length).toBe(2);
+    expect(result[0].entity_id).toContain("toulouse_niveau_");
+    expect(result[0].day0.state).toBeGreaterThan(0);
+    expect(result[0].day1.state).toBeGreaterThan(0);
+  });
+
+  it("reads j+1 forecast from {entity_id}_j_1 for prefixed entities", async () => {
+    const hass = makePrefixedHass("toulouse", "toulouse", [
+      ["birch", 3, 5],
+    ], "entry_toulouse");
+
+    const config = makeConfig({
+      location: "entry_toulouse",
+      allergens: ["birch"],
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    expect(result[0].day0.state).toBe(3);
+    expect(result[0].day1.state).toBe(5);
+  });
+
+  it("handles mixed prefixed and non-prefixed locations", async () => {
+    // Nice (non-prefixed) via old slug config still works
+    const hass = makeHass("nice", [["birch", 4, 2]]);
+    const config = makeConfig({ location: "nice", allergens: ["birch"] });
+
+    const result = await fetchForecast(hass, config);
+
+    expect(result.length).toBe(1);
+    expect(result[0].entity_id).toBe("sensor.niveau_bouleau_nice");
+    expect(result[0].day0.state).toBe(4);
+    expect(result[0].day1.state).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- Add `discoverAtmoSensors()` using `hass.entities` (platform === "atmofrance") grouped by `config_entry_id`, following the GPL adapter pattern
- Update `resolveEntityIds` to try discovery first, with slug-based fallback for backward compatibility
- Derive j+1 forecast from `{entity_id}_j_1` instead of `buildEntityId` (works for both prefixed and non-prefixed entities)
- Update editor detection and location dropdown to use discovery
- Use discovery for card auto-title resolution (no more raw config_entry_id in header)

## Background

When users add multiple Atmo France config entries, HA prefixes entity IDs with the config entry name:
- First instance: `sensor.niveau_bouleau_nice`
- Second instance: `sensor.toulouse_niveau_bouleau_toulouse`

The previous regex-based detection only matched the non-prefixed pattern, causing the editor location dropdown to be empty and the card to fail to find entities.

## Test plan

- [x] All 703 tests pass (11 new tests for discovery and prefixed entities)
- [x] Verified in hass-test (HA 2026.4.2) with both Nice (non-prefixed) and Toulouse (prefixed)
- [x] Editor dropdown shows both locations with correct labels
- [x] Card auto-title shows location name, not config_entry_id
- [x] Backward compat: existing `location: "nice"` slug configs still work

Fixes #200