### PR TITLE
Adopt device-based entity discovery across adapters (#202)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,11 @@ Each adapter exports a `stubConfig*` object with all possible configuration opti
 1. Create `src/adapters/newintegration.js` (or a subdirectory with `index.js` for larger adapters)
 2. Export: `stubConfig*`, `fetchForecast(hass, config)`, `resolveEntityIds(cfg, hass, debug?)`
 3. Use shared helpers from `src/utils/adapter-helpers.js` (getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames)
-4. Register in `src/adapter-registry.js`
-5. Add adapter-specific allergen aliases to `src/constants.js` (e.g. `NEW_ALIASES`) and include in `ALLERGEN_TRANSLATION` spread
-6. Update editor (`src/pollenprognos-editor.js`) to handle integration-specific config fields
-7. Add contract tests in `test/adapters/newintegration.test.js`
+4. For entity discovery, prefer `discoverEntitiesByDevice(hass, opts)` from `src/utils/adapter-helpers.js`. It runs a three-tier cascade (device identifiers → platform scan → regex/selector fallback) and returns `{ locations: Map<locationKey, { label, entities: Map }>, tierUsed }`. Pair with `resolveLocationByKey(discovery, cfgLocation, { slugExtractor })` and `findLocationBySlug(...)` for backward-compatible config resolution. See `src/adapters/atmo.js` or `src/adapters/pp.js` for reference wrappers.
+5. Register in `src/adapter-registry.js`
+6. Add adapter-specific allergen aliases to `src/constants.js` (e.g. `NEW_ALIASES`) and include in `ALLERGEN_TRANSLATION` spread
+7. Update editor (`src/pollenprognos-editor.js`) to handle integration-specific config fields
+8. Add contract tests in `test/adapters/newintegration.test.js`
 
 ### Modifying Display Layout
 - Lit template is in `render()` method of `src/pollenprognos-card.js`

--- a/src/adapters/atmo.js
+++ b/src/adapters/atmo.js
@@ -3,7 +3,7 @@ import { t } from "../i18n.js";
 import { toCanonicalAllergenKey } from "../constants.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, findLocationBySlug } from "../utils/adapter-helpers.js";
 
 // Mapping from canonical allergen names to French entity slugs used by Atmo France
 export const ATMO_ALLERGEN_MAP = {
@@ -183,6 +183,39 @@ function resolveAtmoLabel(state, device) {
 }
 
 /**
+ * Discover all Atmo France sensors, grouped by location (config entry).
+ *
+ * Thin wrapper around discoverEntitiesByDevice with Atmo-specific classifiers,
+ * label resolver, and fallback regex. Returns the same shape as before:
+ *   { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
+ *
+ * Three-tier discovery:
+ *   1. Device-based: hass.devices (identifiers containing "atmofrance") -> entities by device_id
+ *   2. Entity-registry: hass.entities filtered by platform === "atmofrance"
+ *   3. Regex fallback: hass.states scanned for known Atmo entity patterns
+ */
+export function discoverAtmoSensors(hass, debug = false) {
+  if (!hass) return { locations: new Map() };
+
+  // (?:\w+_)* handles multi-word prefixes like "chambray_les_tours_".
+  // (?:alerte_)? keeps legacy niveau_alerte_{slug} entities in scope.
+  const atmoFallbackRe = /^sensor\.(?:\w+_)*(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/;
+
+  const { locations } = discoverEntitiesByDevice(hass, {
+    platform: "atmofrance",
+    classify: (eid) => classifyAtmoEntity(eid),
+    classifyRelaxed: (eid) => classifyAtmoEntityRelaxed(eid),
+    isRelevant: (eid) => !/_j_\d+$/.test(eid) && !eid.includes("concentration_"),
+    resolveLabel: (ctx) => resolveAtmoLabel(ctx.state, ctx.device),
+    fallbackRegex: atmoFallbackRe,
+    debug,
+    logTag: "ATMO",
+  });
+
+  return { locations };
+}
+
+/**
  * Resolve a legacy slug-style location (e.g. "nice") to its config_entry_id
  * in a discovery result. Returns null if no match is found.
  *
@@ -191,174 +224,8 @@ function resolveAtmoLabel(state, device) {
  * and prefixed (`sensor.toulouse_niveau_bouleau_toulouse`) entity formats.
  */
 export function findAtmoLocationBySlug(discovery, slug) {
-  if (!slug || !discovery?.locations) return null;
-  const needle = `_${String(slug).toLowerCase()}`;
-  const needleJ1 = `${needle}_j_1`;
-  for (const [configEntryId, loc] of discovery.locations) {
-    for (const eid of loc.entities.values()) {
-      const lid = String(eid).toLowerCase();
-      if (lid.endsWith(needle) || lid.endsWith(needleJ1)) return configEntryId;
-    }
-  }
-  return null;
-}
-
-/**
- * Discover all Atmo France sensors.
- *
- * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
- *
- * Three-tier discovery:
- *   1. Device-based: hass.devices (identifiers containing "atmofrance") -> entities by device_id
- *   2. Entity-registry: hass.entities filtered by platform === "atmofrance"
- *   3. Regex fallback: hass.states scanned for known Atmo entity patterns
- */
-export function discoverAtmoSensors(hass, debug = false) {
-  const result = { locations: new Map() };
-  if (!hass) return result;
-
-  // Helper: classify and group a set of entity IDs into result.locations
-  const classifyAndGroup = (entityIds, classifier, getConfigEntryId, getDevice) => {
-    for (const eid of entityIds) {
-      const state = hass.states?.[eid];
-      if (!state) continue;
-
-      const allergenKey = classifier(eid);
-      if (!allergenKey) {
-        if (debug) console.debug("[ATMO] Could not classify entity:", eid);
-        continue;
-      }
-
-      const configEntryId = getConfigEntryId(eid);
-      if (!result.locations.has(configEntryId)) {
-        const device = getDevice(eid);
-        const label = resolveAtmoLabel(state, device);
-        result.locations.set(configEntryId, { label, entities: new Map() });
-      }
-      result.locations.get(configEntryId).entities.set(allergenKey, eid);
-    }
-  };
-
-  const isRelevant = (eid) => !/_j_\d+$/.test(eid) && !eid.includes("concentration_");
-
-  // --- Tier 1: Device-based discovery ---
-  if (hass.devices && hass.entities) {
-    const atmoDeviceIds = Object.entries(hass.devices)
-      .filter(([, dev]) =>
-        dev.identifiers?.some((tuple) => Array.isArray(tuple) && tuple[0] === "atmofrance")
-      )
-      .map(([devId]) => devId);
-
-    if (atmoDeviceIds.length) {
-      if (debug) console.debug("[ATMO] Discovery tier 1 (device-based): found", atmoDeviceIds.length, "devices");
-
-      // Build device-id set for fast lookup
-      const deviceIdSet = new Set(atmoDeviceIds);
-
-      const candidates = Object.entries(hass.entities)
-        .filter(([eid, entry]) =>
-          deviceIdSet.has(entry.device_id) &&
-          !entry.entity_category &&
-          isRelevant(eid)
-        )
-        .map(([eid]) => eid);
-
-      classifyAndGroup(
-        candidates,
-        classifyAtmoEntityRelaxed,
-        (eid) => {
-          const deviceId = hass.entities[eid]?.device_id;
-          const device = hass.devices[deviceId];
-          return device?.config_entries?.[0] || "default";
-        },
-        (eid) => {
-          const deviceId = hass.entities[eid]?.device_id;
-          return hass.devices[deviceId];
-        },
-      );
-
-      if (result.locations.size > 0) {
-        if (debug) {
-          console.debug("[ATMO] Discovery tier 1 result:", result.locations.size, "locations");
-          for (const [locId, loc] of result.locations) {
-            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-          }
-        }
-        return result;
-      }
-    }
-  }
-
-  // --- Tier 2: Entity-registry scan (secondary) ---
-  if (hass.entities) {
-    const candidates = Object.entries(hass.entities)
-      .filter(([eid, entry]) =>
-        entry.platform === "atmofrance" &&
-        !entry.entity_category &&
-        isRelevant(eid)
-      )
-      .map(([eid]) => eid);
-
-    if (candidates.length) {
-      if (debug) console.debug("[ATMO] Discovery tier 2 (entity-registry): found", candidates.length, "candidates");
-
-      classifyAndGroup(
-        candidates,
-        classifyAtmoEntity,
-        (eid) => {
-          if (hass.entities[eid]?.device_id && hass.devices) {
-            const device = hass.devices[hass.entities[eid].device_id];
-            if (device?.config_entries?.length) return device.config_entries[0];
-          }
-          return "default";
-        },
-        (eid) => {
-          const deviceId = hass.entities[eid]?.device_id;
-          return deviceId && hass.devices ? hass.devices[deviceId] : undefined;
-        },
-      );
-
-      if (result.locations.size > 0) {
-        if (debug) {
-          console.debug("[ATMO] Discovery tier 2 result:", result.locations.size, "locations");
-          for (const [locId, loc] of result.locations) {
-            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-          }
-        }
-        return result;
-      }
-    }
-  }
-
-  // --- Tier 3: Regex fallback ---
-  if (hass.states) {
-    // (?:\w+_)* handles multi-word prefixes like "chambray_les_tours_".
-    // (?:alerte_)? keeps legacy niveau_alerte_{slug} entities in scope.
-    const atmoFallbackRe = /^sensor\.(?:\w+_)*(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/;
-    const candidates = Object.keys(hass.states).filter((id) =>
-      typeof id === "string" &&
-      atmoFallbackRe.test(id) &&
-      isRelevant(id),
-    );
-    if (candidates.length) {
-      if (debug) console.debug("[ATMO] Discovery tier 3 (regex fallback): found", candidates.length, "candidates");
-      classifyAndGroup(
-        candidates,
-        classifyAtmoEntity,
-        () => "default",
-        () => undefined,
-      );
-    }
-  }
-
-  if (debug) {
-    console.debug("[ATMO] Discovery final result:", result.locations.size, "locations");
-    for (const [locId, loc] of result.locations) {
-      console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-    }
-  }
-
-  return result;
+  const match = findLocationBySlug(discovery, slug, { suffixExtras: ["", "_j_1"] });
+  return match ? match[0] : null;
 }
 
 /**

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -83,7 +83,11 @@ function extractRegionIdFromEntityId(entityId) {
 function extractRegionLabel(entityId) {
   const regionId = extractRegionIdFromEntityId(entityId);
   if (regionId === null) return null;
-  return DWD_REGIONS[Number(regionId)] || `Region ${regionId}`;
+  // DWD_REGIONS is not a bijection (e.g. 11 and 12 both map to
+  // "Schleswig-Holstein und Hamburg"). Prefix with region ID so the label
+  // stays unique per region in editor dropdowns when tier 3 fallback runs.
+  const name = DWD_REGIONS[Number(regionId)];
+  return name ? `${regionId} ${name}` : `Region ${regionId}`;
 }
 
 /**

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -1,7 +1,7 @@
 import { normalizeDWD } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 import { DWD_REGIONS } from "../constants.js";
 
 const DOMAIN = "dwd_pollenflug";
@@ -215,9 +215,17 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   const discovery = discoverDwdSensors(hass, debug);
 
   if (discovery.locations.size > 0) {
-    const match = resolveLocationByKey(discovery, cfg.region_id, {
+    let match = resolveLocationByKey(discovery, cfg.region_id, {
       slugExtractor: extractRegionIdFromEntityId,
     });
+
+    // Stale-config recovery: a saved ULID region_id from a removed/renamed
+    // integration won't be in the discovered locations. Retry with autodetect
+    // semantics so the card still finds sensors instead of silently going
+    // empty and then template-falling back to "sensor.pollenflug_*_{ULID}".
+    if (!match && isConfigEntryId(cfg.region_id)) {
+      match = resolveLocationByKey(discovery, "");
+    }
 
     if (match) {
       const [, location] = match;

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -156,7 +156,7 @@ export function discoverDwdSensors(hass, debug = false) {
      */
     fallbackRegex: /^sensor\.pollenflug_.+_\d+$/,
     debug,
-    logTag: "[DWD]",
+    logTag: "DWD",
   });
 
   return { locations, tierUsed };

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -83,11 +83,8 @@ function extractRegionIdFromEntityId(entityId) {
 function extractRegionLabel(entityId) {
   const regionId = extractRegionIdFromEntityId(entityId);
   if (regionId === null) return null;
-  // DWD_REGIONS is not a bijection (e.g. 11 and 12 both map to
-  // "Schleswig-Holstein und Hamburg"). Prefix with region ID so the label
-  // stays unique per region in editor dropdowns when tier 3 fallback runs.
   const name = DWD_REGIONS[Number(regionId)];
-  return name ? `${regionId} ${name}` : `Region ${regionId}`;
+  return name || `Region ${regionId}`;
 }
 
 /**

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -135,13 +135,21 @@ export function discoverDwdSensors(hass, debug = false) {
      */
     isRelevant: (eid) => eid.startsWith("sensor.pollenflug_"),
     /**
-     * resolveLabel: prefer device name, then fall back to the region name
-     * derived from the region ID in the entity ID.
+     * resolveLabel priority:
+     *   1. device.name_by_user -- explicit user override always wins.
+     *   2. Region name derived from the numeric suffix in the entity ID.
+     *      The DWD integration sets a generic device.name ("Pollenflug
+     *      Gefahrenindex") that is identical for every region, so region
+     *      derivation must outrank device.name to produce usable titles.
+     *   3. device.name -- last-resort generic label.
+     *   4. "Auto" fallback.
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      const regionLabel = extractRegionLabel(ctx.entityId);
+      if (regionLabel) return regionLabel;
       if (ctx.device?.name) return ctx.device.name;
-      return extractRegionLabel(ctx.entityId) || "Auto";
+      return "Auto";
     },
     /**
      * resolveLocationKey:

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -1,7 +1,8 @@
 import { normalizeDWD } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
+import { DWD_REGIONS } from "../constants.js";
 
 const DOMAIN = "dwd_pollenflug";
 const ATTR_VAL_TOMORROW = "state_tomorrow";
@@ -60,30 +61,169 @@ export const stubConfigDWD = {
   },
 };
 
+/**
+ * Extract the numeric region ID from a DWD entity ID.
+ * "sensor.pollenflug_erle_50" -> "50"
+ * Returns null if no trailing numeric segment is found.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractRegionIdFromEntityId(entityId) {
+  return entityId.match(/_(\d+)$/)?.[1] || null;
+}
+
+/**
+ * Extract a human-readable region label from a DWD entity ID by looking up
+ * the region ID in DWD_REGIONS. Falls back to "Region {id}" for unknown IDs.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractRegionLabel(entityId) {
+  const regionId = extractRegionIdFromEntityId(entityId);
+  if (regionId === null) return null;
+  return DWD_REGIONS[Number(regionId)] || `Region ${regionId}`;
+}
+
+/**
+ * Discover all DWD Pollenflug sensors, grouped by region.
+ *
+ * Uses three-tier discovery via discoverEntitiesByDevice:
+ *   Tier 1: device-based (hass.devices with identifiers["dwd_pollenflug", ...])
+ *   Tier 2: entity-registry scan by platform === "dwd_pollenflug" or "pollenflug"
+ *   Tier 3: regex fallback scanning hass.states for sensor.pollenflug_*
+ *
+ * NOTE: The official HA integration platform string is assumed to be
+ * "dwd_pollenflug". The array ["dwd_pollenflug", "pollenflug"] is used as a
+ * defensive default in case some installations use the shorter name. Tier 3
+ * (regex fallback) guarantees discovery regardless of the actual platform name.
+ *
+ * In tier 3 the region ID (numeric suffix) is used as the location key so that
+ * cfg.region_id = "50" matches entities like sensor.pollenflug_erle_50.
+ *
+ * @param {object}  hass
+ * @param {boolean} [debug=false]
+ * @returns {{ locations: Map<string, { label: string, entities: Map<string, string> }>, tierUsed: number }}
+ */
+export function discoverDwdSensors(hass, debug = false) {
+  if (!hass) return { locations: new Map(), tierUsed: 0 };
+
+  const { locations, tierUsed } = discoverEntitiesByDevice(hass, {
+    platform: ["dwd_pollenflug", "pollenflug"],
+    /**
+     * Strict classifier: derive the normalized allergen key from the entity ID.
+     * DWD entity IDs follow the pattern sensor.pollenflug_{allergen}_{region_id}.
+     * The allergen segment may contain underscores; region_id is always numeric.
+     */
+    classify: (eid) => {
+      const m = eid.match(/^sensor\.pollenflug_(.+)_(\d+)$/);
+      if (!m) return null;
+      return normalizeDWD(m[1]);
+    },
+    classifyRelaxed: (eid) => {
+      const m = eid.match(/^sensor\.pollenflug_(.+)_(\d+)$/);
+      if (!m) return null;
+      return normalizeDWD(m[1]);
+    },
+    /**
+     * isRelevant: quick pre-filter before classify runs.
+     */
+    isRelevant: (eid) => eid.startsWith("sensor.pollenflug_"),
+    /**
+     * resolveLabel: prefer device name, then fall back to the region name
+     * derived from the region ID in the entity ID.
+     */
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      if (ctx.device?.name) return ctx.device.name;
+      return extractRegionLabel(ctx.entityId) || "Auto";
+    },
+    /**
+     * resolveLocationKey:
+     *   - Tier 3 (regex fallback): use the numeric region ID as the location key
+     *     so that cfg.region_id = "50" resolves directly via exact key match.
+     *   - Tier 1/2 (device/registry): use config_entry_id as stable location key.
+     */
+    resolveLocationKey: (ctx) => {
+      if (ctx.tier === 3) {
+        return extractRegionIdFromEntityId(ctx.entityId) || "default";
+      }
+      return ctx.device?.config_entries?.[0] || "default";
+    },
+    /**
+     * fallbackRegex: matches the standard DWD entity ID pattern used in tier 3.
+     */
+    fallbackRegex: /^sensor\.pollenflug_.+_\d+$/,
+    debug,
+    logTag: "[DWD]",
+  });
+
+  return { locations, tierUsed };
+}
+
 export function resolveEntityIds(cfg, hass, debug = false) {
   const map = new Map();
+
+  // --- Path 1: Manual mode ---
+  if (cfg.region_id === "manual") {
+    const prefix = normalizeManualPrefix(cfg.entity_prefix);
+    for (const allergen of cfg.allergens || []) {
+      const rawKey = normalizeDWD(allergen);
+      const sensorId = resolveManualEntity(hass, prefix, rawKey, cfg.entity_suffix || "");
+      if (!sensorId) continue;
+      if (debug) {
+        console.debug(
+          `[DWD:resolveEntityIds] manual allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
+        );
+      }
+      map.set(rawKey, sensorId);
+    }
+    return map;
+  }
+
+  // --- Path 2: Device-based discovery (tier 1/2) or regex fallback (tier 3) ---
+  const discovery = discoverDwdSensors(hass, debug);
+
+  if (discovery.locations.size > 0) {
+    const match = resolveLocationByKey(discovery, cfg.region_id, {
+      slugExtractor: extractRegionIdFromEntityId,
+    });
+
+    if (match) {
+      const [, location] = match;
+      for (const allergen of cfg.allergens || []) {
+        const rawKey = normalizeDWD(allergen);
+        const eid = location.entities.get(rawKey);
+        if (!eid) continue;
+        if (debug) {
+          console.debug(
+            `[DWD:resolveEntityIds] discovery allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${eid}'`,
+          );
+        }
+        map.set(rawKey, eid);
+      }
+
+      if (map.size > 0) return map;
+    }
+  }
+
+  // --- Path 3: Template fallback (legacy / when discovery yields nothing) ---
   for (const allergen of cfg.allergens || []) {
     const rawKey = normalizeDWD(allergen);
-    let sensorId;
-    if (cfg.region_id === "manual") {
-      const prefix = normalizeManualPrefix(cfg.entity_prefix);
-      sensorId = resolveManualEntity(hass, prefix, rawKey, cfg.entity_suffix || "");
-      if (!sensorId) continue;
-    } else {
-      sensorId = cfg.region_id
-        ? `sensor.pollenflug_${rawKey}_${cfg.region_id}`
-        : null;
-      if (!sensorId || !hass.states[sensorId]) {
-        const candidates = Object.keys(hass.states).filter((id) =>
-          id.startsWith(`sensor.pollenflug_${rawKey}_`),
-        );
-        if (candidates.length === 1) sensorId = candidates[0];
-        else continue;
-      }
+    let sensorId = cfg.region_id
+      ? `sensor.pollenflug_${rawKey}_${cfg.region_id}`
+      : null;
+    if (!sensorId || !hass.states[sensorId]) {
+      const candidates = Object.keys(hass.states).filter((id) =>
+        id.startsWith(`sensor.pollenflug_${rawKey}_`),
+      );
+      if (candidates.length === 1) sensorId = candidates[0];
+      else continue;
     }
     if (debug) {
       console.debug(
-        `[DWD:resolveEntityIds] allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
+        `[DWD:resolveEntityIds] template fallback allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
       );
     }
     map.set(rawKey, sensorId);

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -168,6 +168,26 @@ export function discoverDwdSensors(hass, debug = false) {
     logTag: "DWD",
   });
 
+  // Disambiguate duplicate labels. DWD_REGIONS is not a bijection: several
+  // region IDs share the same name (e.g. 121/122/123/124 all "Bayern").
+  // When discovery surfaces two or more locations with identical labels,
+  // append the region ID in parens so the editor dropdown can distinguish
+  // them. Unique labels stay clean ("Brandenburg und Berlin").
+  const labelCounts = new Map();
+  for (const loc of locations.values()) {
+    labelCounts.set(loc.label, (labelCounts.get(loc.label) || 0) + 1);
+  }
+  for (const loc of locations.values()) {
+    if ((labelCounts.get(loc.label) || 0) <= 1) continue;
+    const anyEntityId = loc.entities.values().next().value;
+    const regionId = anyEntityId
+      ? extractRegionIdFromEntityId(anyEntityId)
+      : null;
+    if (regionId) {
+      loc.label = `${loc.label} (${regionId})`;
+    }
+  }
+
   return { locations, tierUsed };
 }
 

--- a/src/adapters/gp/discovery.js
+++ b/src/adapters/gp/discovery.js
@@ -1,5 +1,5 @@
 // src/adapters/gp/discovery.js
-import { normalizeManualPrefix } from "../../utils/adapter-helpers.js";
+import { normalizeManualPrefix, discoverEntitiesByDevice, resolveLocationByKey } from "../../utils/adapter-helpers.js";
 import { GP_DOMAIN, GP_DISPLAY_NAME_MAP, GP_COLLISION_PLANTS, GP_BASE_ALLERGENS } from "./constants.js";
 
 // Regex to extract pollen code from unique_id.
@@ -76,105 +76,55 @@ export function classifySensor(state, entityEntry) {
 /**
  * Discover all google_pollen sensors.
  *
- * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
+ * Uses discoverEntitiesByDevice with three tiers:
+ *   Tier 1: device.identifiers match "google_pollen" (strict device-based)
+ *   Tier 2: entry.platform === "google_pollen" (entity-registry scan)
+ *   Tier 3: entity_id prefix "sensor.google_pollen_" (fallback)
  *
- * Primary: hass.entities with platform === "google_pollen", no entity_category
- * Fallback: hass.states where entity_id starts with "sensor.google_pollen_"
+ * Collision handling: when two sensors share the same allergen key
+ * (e.g. Swedish "Gräs" maps to both grass_cat category and graminales plant),
+ * the second sensor is reclassified as a plant via classifySensorAsPlant.
+ *
+ * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
  */
 export function discoverGpSensors(hass, debug = false) {
-  const result = { locations: new Map() };
-  if (!hass) return result;
+  if (!hass) return { locations: new Map() };
 
-  let entityIds = [];
-  let usedPrimary = false;
+  const { locations } = discoverEntitiesByDevice(hass, {
+    platform: GP_DOMAIN,
 
-  // Primary: hass.entities (entity registry)
-  if (hass.entities) {
-    const candidates = Object.entries(hass.entities)
-      .filter(([, entry]) =>
-        entry.platform === GP_DOMAIN &&
-        !entry.entity_category
-      )
-      .map(([eid]) => eid);
+    // Strict classifier: unique_id preferred, then display_name lookup.
+    classify: (_eid, { state, entry }) => classifySensor(state, entry),
 
-    if (candidates.length > 0) {
-      entityIds = candidates;
-      usedPrimary = true;
-      if (debug) console.debug("[GP] Discovery: using hass.entities, found", candidates.length, "candidates");
-    }
-  }
+    // Relaxed classifier (tier 1): same logic -- classifySensor handles both paths.
+    classifyRelaxed: (_eid, { state, entry }) => classifySensor(state, entry),
 
-  // Fallback: entity_id prefix scan
-  if (!entityIds.length && hass.states) {
-    entityIds = Object.keys(hass.states).filter((eid) =>
+    // Skip diagnostic and config-flow entities.
+    excludeEntry: (entry) => !!(entry && entry.entity_category),
+
+    // Collision: when a key is already taken, reclassify the new sensor as a plant.
+    // This handles the case where two sensors share a localized display_name
+    // (e.g. Swedish "Gräs" = GRASS category + GRAMINALES plant).
+    onCollision: (ctx, { existingKey, locEntities }) => {
+      const alt = classifySensorAsPlant(ctx.state, ctx.entry);
+      if (alt && alt !== existingKey && !locEntities.has(alt)) {
+        if (debug) console.debug("[GP] Collision on", existingKey, "-> reclassified as", alt, "for", ctx.entityId);
+        return alt;
+      }
+      if (debug) console.debug("[GP] Collision: duplicate key", existingKey, "for", ctx.entityId, "(skipped)");
+      return null;
+    },
+
+    // Fallback: prefix scan for tier 3.
+    fallbackSelector: (h) => Object.keys(h.states).filter((eid) =>
       eid.startsWith("sensor.google_pollen_")
-    );
-    if (debug) console.debug("[GP] Discovery: using prefix fallback, found", entityIds.length, "candidates");
-  }
+    ),
 
-  if (!entityIds.length) return result;
+    debug,
+    logTag: "GP",
+  });
 
-  // Group by config_entry_id (primary) or device_id
-  for (const eid of entityIds) {
-    const state = hass.states[eid];
-    if (!state) continue;
-
-    const entityEntry = usedPrimary ? hass.entities?.[eid] : undefined;
-    let allergenKey = classifySensor(state, entityEntry);
-    if (!allergenKey) {
-      if (debug) console.debug("[GP] Could not classify sensor:", eid);
-      continue;
-    }
-
-    // Resolve config_entry_id for location grouping
-    let configEntryId = "default";
-    if (usedPrimary && hass.entities?.[eid]?.device_id && hass.devices) {
-      const deviceId = hass.entities[eid].device_id;
-      const device = hass.devices[deviceId];
-      if (device?.config_entries?.length) {
-        configEntryId = device.config_entries[0];
-      }
-    }
-
-    if (!result.locations.has(configEntryId)) {
-      let label = "Auto";
-      if (usedPrimary && hass.entities?.[eid]?.device_id && hass.devices) {
-        const deviceId = hass.entities[eid].device_id;
-        const device = hass.devices[deviceId];
-        label = device?.name_by_user || device?.name || label;
-      } else {
-        const friendly = state.attributes?.friendly_name || "";
-        if (friendly) label = friendly;
-      }
-      result.locations.set(configEntryId, { label, entities: new Map() });
-    }
-
-    // Handle collision: when two sensors share the same slugified display_name
-    // (e.g. Swedish "Gräs" = both GRASS category and GRAMINALES plant), the
-    // first gets the category key; the second retries as a plant.
-    const locEntities = result.locations.get(configEntryId).entities;
-    if (locEntities.has(allergenKey)) {
-      const altKey = classifySensorAsPlant(state, entityEntry);
-      if (altKey && altKey !== allergenKey && !locEntities.has(altKey)) {
-        if (debug) console.debug("[GP] Collision on", allergenKey, "-> reclassified as", altKey, "for", eid);
-        allergenKey = altKey;
-      } else {
-        if (debug) console.debug("[GP] Collision: duplicate key", allergenKey, "for", eid, "(skipped)");
-        continue;
-      }
-    }
-
-    locEntities.set(allergenKey, eid);
-  }
-
-  if (debug) {
-    console.debug("[GP] Discovery result:", result.locations.size, "locations");
-    for (const [locId, loc] of result.locations) {
-      console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-    }
-  }
-
-  return result;
+  return { locations };
 }
 
 /**
@@ -254,13 +204,8 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
   let discoveredEntities = null;
   if (configEntryId !== "manual") {
-    let location;
-    if (configEntryId && discovery.locations.has(configEntryId)) {
-      location = discovery.locations.get(configEntryId);
-    } else if (discovery.locations.size) {
-      location = discovery.locations.values().next().value;
-    }
-    if (location) discoveredEntities = location.entities;
+    const match = resolveLocationByKey(discovery, configEntryId);
+    if (match) discoveredEntities = match[1].entities;
   }
 
   for (const allergen of cfg.allergens || []) {

--- a/src/adapters/gp/discovery.js
+++ b/src/adapters/gp/discovery.js
@@ -1,5 +1,5 @@
 // src/adapters/gp/discovery.js
-import { normalizeManualPrefix, discoverEntitiesByDevice, resolveLocationByKey } from "../../utils/adapter-helpers.js";
+import { normalizeManualPrefix, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
 import { GP_DOMAIN, GP_DISPLAY_NAME_MAP, GP_COLLISION_PLANTS, GP_BASE_ALLERGENS } from "./constants.js";
 
 // Regex to extract pollen code from unique_id.
@@ -204,7 +204,14 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
   let discoveredEntities = null;
   if (configEntryId !== "manual") {
-    const match = resolveLocationByKey(discovery, configEntryId);
+    let match = resolveLocationByKey(discovery, configEntryId);
+    // Stale-config recovery: a saved ULID that no longer matches any
+    // discovered location (e.g. integration reinstalled, tier 3 collapsed
+    // into a single "default" bucket) used to silently produce an empty map.
+    // Retry with autodetect semantics so legacy/changed configs still work.
+    if (!match && configEntryId && isConfigEntryId(configEntryId)) {
+      match = resolveLocationByKey(discovery, "");
+    }
     if (match) discoveredEntities = match[1].entities;
   }
 

--- a/src/adapters/gpl/discovery.js
+++ b/src/adapters/gpl/discovery.js
@@ -64,6 +64,35 @@ export function discoverGplSensors(hass, debug = false) {
         return s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s);
       }),
 
+    /**
+     * resolveLabel priority for GPL:
+     *   1. device.name_by_user -- explicit user override.
+     *   2. device.name with the "- Pollentyper (lat, lon)" suffix stripped,
+     *      since the HA integration names devices "{user-name} - Pollentyper
+     *      ({lat}, {lon})". Without stripping, the label becomes a useless
+     *      coordinate-laden title in both editor dropdown and card header.
+     *   3. device.name as-is (defensive).
+     *   4. friendly_name from state.attributes.
+     *   5. "Auto" fallback.
+     */
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      const raw = ctx.device?.name;
+      if (typeof raw === "string" && raw.trim()) {
+        // Strip " - Pollentyper (...)" / " - Pollen types (...)" /
+        // " - Pollentypen (...)" suffixes the upstream integration appends.
+        const cleaned = raw
+          .replace(/\s*[-–—]\s*pollen\s*(?:typer|typen|types)\s*\([^)]*\)\s*$/i, "")
+          .trim();
+        if (cleaned) return cleaned;
+        return raw.trim();
+      }
+      if (ctx.state?.attributes?.friendly_name) {
+        return ctx.state.attributes.friendly_name;
+      }
+      return "Auto";
+    },
+
     debug,
     logTag: "GPL",
   });

--- a/src/adapters/gpl/discovery.js
+++ b/src/adapters/gpl/discovery.js
@@ -1,6 +1,6 @@
 // src/adapters/gpl/discovery.js
 import { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS } from "./constants.js";
-import { discoverEntitiesByDevice, resolveLocationByKey } from "../../utils/adapter-helpers.js";
+import { discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
 
 /**
  * Classify a GPL sensor by its attributes.
@@ -187,7 +187,14 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
   let discoveredEntities = null;
   if (configEntryId !== "manual") {
-    const resolved = resolveLocationByKey(discovery, configEntryId);
+    let resolved = resolveLocationByKey(discovery, configEntryId);
+    // Stale-config recovery: a saved ULID that no longer matches any
+    // discovered location (e.g. integration reinstalled, tier 3 collapsed
+    // into a single "default" bucket) used to silently produce an empty map.
+    // Retry with autodetect semantics so legacy/changed configs still work.
+    if (!resolved && configEntryId && isConfigEntryId(configEntryId)) {
+      resolved = resolveLocationByKey(discovery, "");
+    }
     if (resolved) discoveredEntities = resolved[1].entities;
   }
 

--- a/src/adapters/gpl/discovery.js
+++ b/src/adapters/gpl/discovery.js
@@ -1,5 +1,6 @@
 // src/adapters/gpl/discovery.js
 import { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS } from "./constants.js";
+import { discoverEntitiesByDevice, resolveLocationByKey } from "../../utils/adapter-helpers.js";
 
 /**
  * Classify a GPL sensor by its attributes.
@@ -27,100 +28,47 @@ export function isGplDataSensor(state) {
 }
 
 /**
- * Discover all GPL sensors using hass.entities (primary) or attribution (fallback).
+ * Discover all GPL sensors using the shared discoverEntitiesByDevice helper.
  *
  * Returns: { locations: Map<configEntryId, { label: string, entities: Map<allergenKey, entityId> }> }
  *
- * Primary path: hass.entities -> filter platform === "pollenlevels", no entity_category
- * Fallback path: hass.states -> filter attribution === GPL_ATTRIBUTION, exclude date/timestamp
+ * Tier 1: device identifier match (platform "pollenlevels" in device.identifiers).
+ * Tier 2: entity registry scan filtering by entry.platform === "pollenlevels".
+ * Tier 3: attribution scan -- filters states by GPL_ATTRIBUTION attribute.
  */
 export function discoverGplSensors(hass, debug = false) {
-  const result = { locations: new Map() };
-  if (!hass) return result;
+  if (!hass) return { locations: new Map() };
 
-  // Collect candidate entity IDs
-  let entityIds = [];
-  let usedPrimary = false;
+  const { locations } = discoverEntitiesByDevice(hass, {
+    platform: "pollenlevels",
 
-  // Primary: hass.entities (entity registry)
-  if (hass.entities) {
-    const candidates = Object.entries(hass.entities)
-      .filter(([, entry]) =>
-        entry.platform === "pollenlevels" &&
-        !entry.entity_category
-      )
-      .map(([eid]) => eid);
+    // classify is used in tier 2 and tier 3; reads state.attributes.code or icon
+    classify: (eid, { state }) => {
+      if (!isGplDataSensor(state)) return null;
+      return classifySensor(state);
+    },
 
-    if (candidates.length > 0) {
-      entityIds = candidates;
-      usedPrimary = true;
-      if (debug) console.debug("[GPL] Discovery: using hass.entities, found", candidates.length, "candidates");
-    }
-  }
+    // classifyRelaxed used in tier 1 -- same logic, no relaxation needed for GPL
+    classifyRelaxed: (eid, { state }) => {
+      if (!isGplDataSensor(state)) return null;
+      return classifySensor(state);
+    },
 
-  // Fallback: attribution scan
-  if (!entityIds.length && hass.states) {
-    entityIds = Object.keys(hass.states).filter((eid) => {
-      const s = hass.states[eid];
-      return s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s);
-    });
-    if (debug) console.debug("[GPL] Discovery: using attribution fallback, found", entityIds.length, "candidates");
-  }
+    // isRelevant: additional pre-classification filter (device_class check handled in classify)
+    isRelevant: (eid, { state }) => isGplDataSensor(state),
 
-  if (!entityIds.length) return result;
+    // fallbackSelector: tier 3 uses attribution attribute instead of entity ID regex
+    fallbackSelector: (h) =>
+      Object.keys(h.states).filter((eid) => {
+        const s = h.states[eid];
+        return s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s);
+      }),
 
-  // Group by config_entry_id
-  for (const eid of entityIds) {
-    const state = hass.states[eid];
-    if (!state) continue;
+    debug,
+    logTag: "GPL",
+  });
 
-    // Filter out meta sensors in both paths
-    if (!isGplDataSensor(state)) continue;
-
-    // Classify sensor
-    const allergenKey = classifySensor(state);
-    if (!allergenKey) {
-      if (debug) console.debug("[GPL] Could not classify sensor:", eid);
-      continue;
-    }
-
-    // Resolve config_entry_id
-    let configEntryId = "default";
-    if (usedPrimary && hass.entities?.[eid]?.device_id && hass.devices) {
-      const deviceId = hass.entities[eid].device_id;
-      const device = hass.devices[deviceId];
-      if (device?.config_entries?.length) {
-        configEntryId = device.config_entries[0];
-      }
-    }
-
-    // Get or create location entry
-    if (!result.locations.has(configEntryId)) {
-      // Generate label from device name or "Auto"
-      let label = "Auto";
-      if (usedPrimary && hass.entities?.[eid]?.device_id && hass.devices) {
-        const deviceId = hass.entities[eid].device_id;
-        const device = hass.devices[deviceId];
-        label = device?.name_by_user || device?.name || label;
-      } else {
-        // Fallback: try friendly_name from first sensor
-        const friendly = state.attributes?.friendly_name || "";
-        if (friendly) label = friendly;
-      }
-      result.locations.set(configEntryId, { label, entities: new Map() });
-    }
-
-    result.locations.get(configEntryId).entities.set(allergenKey, eid);
-  }
-
-  if (debug) {
-    console.debug("[GPL] Discovery result:", result.locations.size, "locations");
-    for (const [locId, loc] of result.locations) {
-      console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-    }
-  }
-
-  return result;
+  return { locations };
 }
 
 /**
@@ -210,13 +158,8 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
   let discoveredEntities = null;
   if (configEntryId !== "manual") {
-    let location;
-    if (configEntryId && discovery.locations.has(configEntryId)) {
-      location = discovery.locations.get(configEntryId);
-    } else if (discovery.locations.size) {
-      location = discovery.locations.values().next().value;
-    }
-    if (location) discoveredEntities = location.entities;
+    const resolved = resolveLocationByKey(discovery, configEntryId);
+    if (resolved) discoveredEntities = resolved[1].entities;
   }
 
   for (const allergen of cfg.allergens || []) {

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -125,7 +125,7 @@ function extractPeuLocationSlug(eid, allergenKey) {
  * @param {string} eid
  * @returns {string|null}
  */
-function extractPeuLocationSlugFromEntityId(eid) {
+export function extractPeuLocationSlugFromEntityId(eid) {
   const allergen = classifyPeuEntity(eid);
   if (!allergen) return null;
   return extractPeuLocationSlug(eid, allergen);

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -81,15 +81,15 @@ const PEU_PREFIX = "sensor.polleninformation_";
  * @param {string} eid
  * @returns {string|null}
  */
+// Precomputed longest-first whitelist. Sorting once at module load avoids
+// reallocating and re-sorting on every classifier invocation during discovery.
+const PEU_ALLERGEN_SUFFIXES_LONGEST_FIRST = [...PEU_ALLERGENS, "allergy_risk_hourly"]
+  .sort((a, b) => b.length - a.length);
+
 function classifyPeuEntity(eid) {
   if (!eid.startsWith(PEU_PREFIX)) return null;
   const rest = eid.substring(PEU_PREFIX.length);
-  // Sort longest allergen name first to prevent shorter names from matching
-  // a suffix that is actually part of a longer allergen name.
-  const allergens = [...PEU_ALLERGENS, "allergy_risk_hourly"].sort(
-    (a, b) => b.length - a.length,
-  );
-  for (const allergen of allergens) {
+  for (const allergen of PEU_ALLERGEN_SUFFIXES_LONGEST_FIRST) {
     const suffix = `_${allergen}`;
     if (rest.endsWith(suffix) && rest.length > suffix.length) {
       return allergen;

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -203,7 +203,7 @@ export function discoverPeuSensors(hass, debug = false) {
      */
     fallbackRegex: /^sensor\.polleninformation_.+$/,
     debug,
-    logTag: "[PEU]",
+    logTag: "PEU",
   });
 
   return { locations, tierUsed };

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -4,7 +4,7 @@ import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
 import { indexToLevel } from "./silam.js";
 import { slugify } from "../utils/slugify.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
 
 // Skapa stubConfigPEU – allergener enligt din sensor.py, i engelsk slugform!
 export const stubConfigPEU = {
@@ -66,6 +66,149 @@ export const stubConfigPEU = {
 // All possible allergens for the PEU integration
 export const PEU_ALLERGENS = ["allergy_risk", ...stubConfigPEU.allergens];
 
+const PEU_PREFIX = "sensor.polleninformation_";
+
+/**
+ * Classify a PEU entity ID using a whitelist of known allergen keys.
+ *
+ * Probes the longest suffix first to avoid greedy-split collisions when
+ * allergen names contain underscores (e.g. "allergy_risk_hourly" must not
+ * be classified as "allergy_risk" with an extra "_hourly" location suffix).
+ *
+ * Returns the allergen key string, or null if the entity ID does not match
+ * any known PEU allergen pattern.
+ *
+ * @param {string} eid
+ * @returns {string|null}
+ */
+function classifyPeuEntity(eid) {
+  if (!eid.startsWith(PEU_PREFIX)) return null;
+  const rest = eid.substring(PEU_PREFIX.length);
+  // Sort longest allergen name first to prevent shorter names from matching
+  // a suffix that is actually part of a longer allergen name.
+  const allergens = [...PEU_ALLERGENS, "allergy_risk_hourly"].sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const allergen of allergens) {
+    const suffix = `_${allergen}`;
+    if (rest.endsWith(suffix) && rest.length > suffix.length) {
+      return allergen;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the location slug from a PEU entity ID given a known allergen key.
+ * "sensor.polleninformation_wien_birch" + "birch" -> "wien"
+ *
+ * Returns null if the entity ID does not follow the expected pattern.
+ *
+ * @param {string} eid
+ * @param {string} allergenKey
+ * @returns {string|null}
+ */
+function extractPeuLocationSlug(eid, allergenKey) {
+  if (!eid.startsWith(PEU_PREFIX)) return null;
+  const rest = eid.substring(PEU_PREFIX.length);
+  const suffix = `_${allergenKey}`;
+  if (!rest.endsWith(suffix) || rest.length <= suffix.length) return null;
+  return rest.slice(0, rest.length - suffix.length);
+}
+
+/**
+ * Extract the location slug from a PEU entity ID by running classifyPeuEntity
+ * to discover the allergen key, then stripping it from the tail.
+ *
+ * Returns null if the entity ID cannot be classified.
+ *
+ * @param {string} eid
+ * @returns {string|null}
+ */
+function extractPeuLocationSlugFromEntityId(eid) {
+  const allergen = classifyPeuEntity(eid);
+  if (!allergen) return null;
+  return extractPeuLocationSlug(eid, allergen);
+}
+
+/**
+ * Prettify a PEU location slug for display.
+ * "wien" -> "Wien", "new_york" -> "New_york"
+ *
+ * Returns null when no slug can be extracted.
+ *
+ * @param {string} eid
+ * @returns {string|null}
+ */
+function extractPeuLocationLabel(eid) {
+  const slug = extractPeuLocationSlugFromEntityId(eid);
+  if (!slug) return null;
+  return slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+/**
+ * Discover all PEU (Polleninformation EU) sensors, grouped by location/device.
+ *
+ * Uses three-tier discovery via discoverEntitiesByDevice:
+ *   Tier 1: device-based (hass.devices with identifiers["polleninformation", ...])
+ *   Tier 2: entity-registry scan by platform === "polleninformation"
+ *   Tier 3: regex fallback scanning hass.states for sensor.polleninformation_*
+ *
+ * The whitelist classifier (classifyPeuEntity) avoids greedy-regex collisions
+ * by probing allergen suffixes from longest to shortest. allergy_risk_hourly
+ * is stored under its own key so that mode-mapping in resolveEntityIds can
+ * look it up directly.
+ *
+ * @param {object}  hass
+ * @param {boolean} [debug=false]
+ * @returns {{ locations: Map<string, { label: string, entities: Map<string, string> }>, tierUsed: number }}
+ */
+export function discoverPeuSensors(hass, debug = false) {
+  if (!hass) return { locations: new Map(), tierUsed: 0 };
+
+  const { locations, tierUsed } = discoverEntitiesByDevice(hass, {
+    platform: ["polleninformation"],
+    /**
+     * Strict classifier: use the whitelist to extract the allergen key.
+     * Returns null for entity IDs that do not match any known allergen.
+     */
+    classify: (eid) => classifyPeuEntity(eid),
+    classifyRelaxed: (eid) => classifyPeuEntity(eid),
+    /**
+     * isRelevant: quick pre-filter before classify runs.
+     */
+    isRelevant: (eid) => eid.startsWith(PEU_PREFIX),
+    /**
+     * resolveLabel: prefer device name, fall back to prettified location slug.
+     */
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      if (ctx.device?.name) return ctx.device.name;
+      return extractPeuLocationLabel(ctx.entityId) || "Auto";
+    },
+    /**
+     * resolveLocationKey:
+     *   - Tier 3 (state fallback): use location slug from entity ID as key
+     *     so that cfg.location = "wien" matches directly via exact key match.
+     *   - Tier 1/2 (device/registry): use config_entry_id as stable location key.
+     */
+    resolveLocationKey: (ctx) => {
+      if (ctx.tier === 3) {
+        return extractPeuLocationSlugFromEntityId(ctx.entityId) || "default";
+      }
+      return ctx.device?.config_entries?.[0] || "default";
+    },
+    /**
+     * fallbackRegex: matches all PEU entity IDs; classifier filters further.
+     */
+    fallbackRegex: /^sensor\.polleninformation_.+$/,
+    debug,
+    logTag: "[PEU]",
+  });
+
+  return { locations, tierUsed };
+}
+
 function detectLocation(cfg, hass) {
   if (cfg.location === "manual") return "";
   let locationSlug = slugify(cfg.location || "");
@@ -83,57 +226,101 @@ function detectLocation(cfg, hass) {
 
 export function resolveEntityIds(cfg, hass, debug = false) {
   const map = new Map();
-  const locationSlug = detectLocation(cfg, hass);
   const mode = cfg.mode || stubConfigPEU.mode;
+
+  // --- Path 1: Manual mode ---
+  if (cfg.location === "manual") {
+    const prefix = normalizeManualPrefix(cfg.entity_prefix);
+    for (const allergen of cfg.allergens || []) {
+      const allergenSlug = allergen;
+      const coreSlug =
+        mode !== "daily" && allergenSlug === "allergy_risk"
+          ? "allergy_risk_hourly"
+          : allergenSlug;
+      const sensorId = resolveManualEntity(hass, prefix, coreSlug, cfg.entity_suffix || "");
+      if (!sensorId) continue;
+      if (debug) {
+        console.debug(
+          `[PEU:resolveEntityIds] manual allergen: '${allergen}', coreSlug: '${coreSlug}', sensorId: '${sensorId}'`,
+        );
+      }
+      map.set(allergenSlug, sensorId);
+    }
+    return map;
+  }
+
+  // --- Path 2: Device-based discovery (tier 1/2) or state fallback (tier 3) ---
+  const discovery = discoverPeuSensors(hass, debug);
+
+  if (discovery.locations.size > 0) {
+    const match = resolveLocationByKey(discovery, cfg.location, {
+      slugExtractor: extractPeuLocationSlugFromEntityId,
+    });
+
+    if (match) {
+      const [, location] = match;
+      for (const allergen of cfg.allergens || []) {
+        const allergenSlug = allergen;
+        // Mode mapping: in non-daily modes, allergy_risk sensor is the hourly variant.
+        const lookupKey =
+          mode !== "daily" && allergenSlug === "allergy_risk"
+            ? "allergy_risk_hourly"
+            : allergenSlug;
+        const eid = location.entities.get(lookupKey);
+        if (!eid) continue;
+        if (debug) {
+          console.debug(
+            `[PEU:resolveEntityIds] discovery allergen: '${allergen}', lookupKey: '${lookupKey}', sensorId: '${eid}'`,
+          );
+        }
+        map.set(allergenSlug, eid);
+      }
+
+      if (map.size > 0) return map;
+    }
+  }
+
+  // --- Path 3: Template fallback (legacy / when discovery yields nothing) ---
+  const locationSlug = detectLocation(cfg, hass);
   const peuStates = Object.keys(hass.states).filter((id) =>
-    id.startsWith("sensor.polleninformation_"),
+    id.startsWith(PEU_PREFIX),
   );
 
   for (const allergen of cfg.allergens || []) {
     const allergenSlug = allergen;
     let sensorId;
-    if (cfg.location === "manual") {
-      const prefix = normalizeManualPrefix(cfg.entity_prefix);
-      const coreSlug =
-        mode !== "daily" && allergenSlug === "allergy_risk"
-          ? "allergy_risk_hourly"
-          : allergenSlug;
-      sensorId = resolveManualEntity(hass, prefix, coreSlug, cfg.entity_suffix || "");
-      if (!sensorId) continue;
+    if (mode !== "daily" && allergenSlug === "allergy_risk") {
+      sensorId = locationSlug
+        ? `${PEU_PREFIX}${locationSlug}_allergy_risk_hourly`
+        : null;
     } else {
-      if (mode !== "daily" && allergenSlug === "allergy_risk") {
-        sensorId = locationSlug
-          ? `sensor.polleninformation_${locationSlug}_allergy_risk_hourly`
-          : null;
-      } else {
-        sensorId = locationSlug
-          ? `sensor.polleninformation_${locationSlug}_${allergenSlug}`
-          : null;
-      }
-      if (!sensorId || !hass.states[sensorId]) {
-        const cands = peuStates.filter((id) => {
-          const match = id.match(/^sensor\.polleninformation_(.+)_(.+)$/);
-          if (!match) return false;
-          const loc = match[1];
-          const allg = match[2];
-          if (mode !== "daily" && allergenSlug === "allergy_risk") {
-            return (
-              (!locationSlug || loc === locationSlug) &&
-              allg === "allergy_risk_hourly"
-            );
-          }
+      sensorId = locationSlug
+        ? `${PEU_PREFIX}${locationSlug}_${allergenSlug}`
+        : null;
+    }
+    if (!sensorId || !hass.states[sensorId]) {
+      const cands = peuStates.filter((id) => {
+        const match = id.match(/^sensor\.polleninformation_(.+)_(.+)$/);
+        if (!match) return false;
+        const loc = match[1];
+        const allg = match[2];
+        if (mode !== "daily" && allergenSlug === "allergy_risk") {
           return (
             (!locationSlug || loc === locationSlug) &&
-            allg === allergenSlug
+            allg === "allergy_risk_hourly"
           );
-        });
-        if (cands.length === 1) sensorId = cands[0];
-        else continue;
-      }
+        }
+        return (
+          (!locationSlug || loc === locationSlug) &&
+          allg === allergenSlug
+        );
+      });
+      if (cands.length === 1) sensorId = cands[0];
+      else continue;
     }
     if (debug) {
       console.debug(
-        `[PEU:resolveEntityIds] allergen: '${allergen}', locationSlug: '${locationSlug}', sensorId: '${sensorId}'`,
+        `[PEU:resolveEntityIds] template fallback allergen: '${allergen}', locationSlug: '${locationSlug}', sensorId: '${sensorId}'`,
       );
     }
     map.set(allergenSlug, sensorId);

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -179,11 +179,39 @@ export function discoverPeuSensors(hass, debug = false) {
      */
     isRelevant: (eid) => eid.startsWith(PEU_PREFIX),
     /**
-     * resolveLabel: prefer device name, fall back to prettified location slug.
+     * resolveLabel priority:
+     *   1. device.name_by_user -- explicit user override.
+     *   2. state.attributes.location_title -- integration's clean location
+     *      name when exposed.
+     *   3. device.name with the "Polleninformation " prefix stripped and
+     *      parenthesised wrappers unwrapped ("Polleninformation (Hamburg)"
+     *      → "Hamburg"), since the HA integration often packages the
+     *      location inside a generic device name.
+     *   4. device.name as-is (uncommon but defensive).
+     *   5. Prettified location slug from entity ID.
+     *   6. "Auto" fallback.
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
-      if (ctx.device?.name) return ctx.device.name;
+
+      const attrTitle = ctx.state?.attributes?.location_title;
+      if (typeof attrTitle === "string" && attrTitle.trim()) {
+        return attrTitle.trim();
+      }
+
+      const rawName = ctx.device?.name;
+      if (typeof rawName === "string" && rawName.trim()) {
+        // Strip a leading "Polleninformation" (any case, optional separators)
+        // and unwrap a trailing "(location)" if present.
+        const stripped = rawName
+          .replace(/^\s*polleninformation\b[\s:\-–—]*/i, "")
+          .trim();
+        const paren = stripped.match(/^\(([^)]+)\)$/);
+        if (paren) return paren[1].trim();
+        if (stripped) return stripped;
+        return rawName.trim();
+      }
+
       return extractPeuLocationLabel(ctx.entityId) || "Auto";
     },
     /**

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -4,7 +4,7 @@ import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
 import { indexToLevel } from "./silam.js";
 import { slugify } from "../utils/slugify.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 
 // Skapa stubConfigPEU – allergener enligt din sensor.py, i engelsk slugform!
 export const stubConfigPEU = {
@@ -239,7 +239,11 @@ export function discoverPeuSensors(hass, debug = false) {
 
 function detectLocation(cfg, hass) {
   if (cfg.location === "manual") return "";
-  let locationSlug = slugify(cfg.location || "");
+  // Treat a config_entry_id as autodetect: slugify() would otherwise produce
+  // a non-empty locationSlug from the ULID, blocking the entity-id scan below
+  // when tier 1/2 discovery has already failed (e.g. unknown platform slug).
+  const locCfg = isConfigEntryId(cfg.location) ? "" : cfg.location;
+  let locationSlug = slugify(locCfg || "");
   if (!locationSlug) {
     const peuStates = Object.keys(hass.states).filter((id) =>
       id.startsWith("sensor.polleninformation_"),

--- a/src/adapters/plu.js
+++ b/src/adapters/plu.js
@@ -98,7 +98,7 @@ export function discoverPluSensors(hass, debug = false) {
     resolveLocationKey: () => "default",
     fallbackRegex: null,
     debug,
-    logTag: "[PLU]",
+    logTag: "PLU",
   });
 }
 

--- a/src/adapters/plu.js
+++ b/src/adapters/plu.js
@@ -3,7 +3,7 @@ import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
 import { slugify } from "../utils/slugify.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, meetsThreshold, resolveAllergenNames } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, meetsThreshold, resolveAllergenNames, discoverEntitiesByDevice } from "../utils/adapter-helpers.js";
 
 const SENSOR_PREFIX = "sensor.pollen_";
 
@@ -39,6 +39,68 @@ export const PLU_ALIAS_MAP = Object.entries(RAW_ALIAS_NAMES).reduce(
   },
   {},
 );
+
+// Reverse alias map: slug-alias (or canonical key) -> canonical allergen key.
+// Built once at module load from PLU_ALIAS_MAP.
+// Allows classifyPluEntity to identify both canonical ("birch") and alias
+// ("betula", "bouleau") entity ID suffixes.
+const PLU_REVERSE_ALIAS = (() => {
+  const map = {};
+  for (const [canonical, aliases] of Object.entries(PLU_ALIAS_MAP)) {
+    for (const alias of aliases) map[alias] = canonical;
+    // Ensure canonical itself is covered (already in aliases, but explicit is safer)
+    map[canonical] = canonical;
+  }
+  return map;
+})();
+
+/**
+ * Classify a PLU entity ID to a canonical allergen key.
+ *
+ * PLU sensors follow the pattern sensor.pollen_{alias}.
+ * The alias can be the canonical English key ("birch"), a slugified Latin name
+ * ("betula"), a slugified French name ("bouleau"), etc.
+ *
+ * @param {string} eid - Entity ID.
+ * @returns {string|null} - Canonical allergen key or null if unrecognized.
+ */
+function classifyPluEntity(eid) {
+  if (!eid.startsWith(SENSOR_PREFIX)) return null;
+  const rest = eid.substring(SENSOR_PREFIX.length);
+  return PLU_REVERSE_ALIAS[rest] || null;
+}
+
+/**
+ * Discover Pollen.lu sensors using two-tier device-based discovery.
+ *
+ * Tier 1: device registry (hass.devices) — entities linked to a pollen_lu device.
+ * Tier 2: entity registry (hass.entities) — entries with platform "pollen_lu" or "pollenlu".
+ * Tier 3: disabled (fallbackRegex: null) — alias-probe in resolveEntityIds is the fallback.
+ *
+ * NOTE: PLU has no location dimension; all entities map to a single "default"
+ * location key. The platform name is assumed to be "pollen_lu" based on the
+ * typical HA custom-integration naming convention. "pollenlu" is included as a
+ * defensive alternative.
+ *
+ * @param {object}  hass
+ * @param {boolean} [debug=false]
+ * @returns {{ locations: Map<string, { label: string, entities: Map<string, string> }>, tierUsed: number }}
+ */
+export function discoverPluSensors(hass, debug = false) {
+  if (!hass) return { locations: new Map(), tierUsed: 0 };
+
+  return discoverEntitiesByDevice(hass, {
+    platform: ["pollen_lu", "pollenlu"],
+    classify: classifyPluEntity,
+    classifyRelaxed: classifyPluEntity,
+    isRelevant: (eid) => eid.startsWith(SENSOR_PREFIX),
+    resolveLabel: (ctx) => ctx.device?.name_by_user || ctx.device?.name || "Pollen.lu",
+    resolveLocationKey: () => "default",
+    fallbackRegex: null,
+    debug,
+    logTag: "[PLU]",
+  });
+}
 
 // Default thresholds per allergen (fallback when sensor attributes are missing)
 const DEFAULT_THRESHOLDS = {
@@ -101,6 +163,28 @@ function resolveSensorId(hass, canonical, debug) {
 }
 
 export function resolveEntityIds(cfg, hass, debug = false) {
+  // --- Path 1: Device-based discovery (tier 1/2) ---
+  const discovery = discoverPluSensors(hass, debug);
+  if (discovery.locations.size > 0) {
+    const first = discovery.locations.entries().next();
+    if (!first.done) {
+      const [, location] = first.value;
+      const map = new Map();
+      for (const allergen of cfg.allergens || []) {
+        if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;
+        const eid = location.entities.get(allergen);
+        if (eid) map.set(allergen, eid);
+      }
+      if (map.size > 0) {
+        if (debug) console.debug("[PLU] resolveEntityIds via discovery:", map.size, "entities");
+        return map;
+      }
+    }
+  }
+
+  // --- Path 2: Alias-probe fallback ---
+  // Iterates PLU_ALIAS_MAP to find sensor.pollen_{alias} in hass.states.
+  // Preserves multilingual alias support (Latin, French, German, English names).
   const map = new Map();
   for (const allergen of cfg.allergens || []) {
     if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -1,6 +1,8 @@
 import { normalize } from "../utils/normalize.js";
+import { slugify } from "../utils/slugify.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
+import { PP_POSSIBLE_CITIES } from "../constants.js";
 import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 
 export const stubConfigPP = {
@@ -51,16 +53,19 @@ export const stubConfigPP = {
 
 /**
  * Extract a prettified city name from a PP entity ID.
- * "sensor.pollen_goteborg_bjork" -> "Goteborg"
+ * "sensor.pollen_goteborg_bjork" -> "Göteborg" when the slug matches a
+ * canonical city in PP_POSSIBLE_CITIES (preserving diacritics), otherwise
+ * falls back to "Goteborg" via simple capitalization.
  * Returns null if the entity ID does not match the expected pattern.
  *
  * @param {string} entityId
  * @returns {string|null}
  */
 function extractCityFromEntityId(entityId) {
-  const m = entityId.match(/^sensor\.pollen_(.+)_[^_]+$/);
-  if (!m) return null;
-  const slug = m[1];
+  const slug = extractCitySlugFromEntityId(entityId);
+  if (!slug) return null;
+  const canonical = PP_POSSIBLE_CITIES.find((c) => slugify(c) === slug);
+  if (canonical) return canonical;
   return slug.charAt(0).toUpperCase() + slug.slice(1);
 }
 

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -1,7 +1,7 @@
 import { normalize } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 
 export const stubConfigPP = {
   integration: "pp",
@@ -163,7 +163,11 @@ export function discoverPpSensors(hass, debug = false) {
 
 function detectCity(cfg, hass) {
   if (cfg.city === "manual") return "";
-  let cityKey = normalize(cfg.city || "");
+  // Treat a config_entry_id as autodetect: normalize() would otherwise produce
+  // a non-empty cityKey from the ULID, blocking the entity-id scan below when
+  // tier 1/2 discovery has already failed (e.g. unknown platform slug).
+  const cityCfg = isConfigEntryId(cfg.city) ? "" : cfg.city;
+  let cityKey = normalize(cityCfg || "");
   if (!cityKey) {
     const ppStates = Object.keys(hass.states).filter(
       (id) =>

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -115,11 +115,27 @@ export function discoverPpSensors(hass, debug = false) {
      */
     isRelevant: (eid) => eid.startsWith("sensor.pollen_"),
     /**
-     * resolveLabel: use device name when available, fall back to city slug from entity ID.
+     * resolveLabel priority:
+     *   1. device.name_by_user -- explicit user override.
+     *   2. device.name with a leading "Pollenprognos" prefix stripped
+     *      ("Pollenprognos Visby" → "Visby"), since the HA integration
+     *      packages the city inside a generic device name.
+     *   3. device.name as-is (defensive).
+     *   4. Prettified city slug from entity ID.
+     *   5. "Auto" fallback.
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
-      if (ctx.device?.name) return ctx.device.name;
+
+      const rawName = ctx.device?.name;
+      if (typeof rawName === "string" && rawName.trim()) {
+        const stripped = rawName
+          .replace(/^\s*pollenprognos\b[\s:\-–—]*/i, "")
+          .trim();
+        if (stripped) return stripped;
+        return rawName.trim();
+      }
+
       return extractCityFromEntityId(ctx.entityId) || "Auto";
     },
     /**

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -2,7 +2,7 @@ import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { PP_POSSIBLE_CITIES } from "../constants.js";
+import { PP_POSSIBLE_CITIES, PP_ALLERGEN_SLUGS } from "../constants.js";
 import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 
 export const stubConfigPP = {
@@ -70,16 +70,54 @@ function extractCityFromEntityId(entityId) {
 }
 
 /**
- * Extract the city slug from a PP entity ID.
+ * Extract the city slug from a PP entity ID by stripping a recognized
+ * allergen suffix. PP allergen slugs may contain underscores (e.g.
+ * "salg_och_viden"), so a naive `_[^_]+$` split would misclassify the
+ * city. PP_ALLERGEN_SLUGS is sorted longest-first to ensure the longest
+ * matching suffix wins.
+ *
  * "sensor.pollen_goteborg_bjork" -> "goteborg"
- * Returns null if the entity ID does not match the expected pattern.
+ * "sensor.pollen_visby_salg_och_viden" -> "visby"
+ * Returns null if the entity ID does not match the expected pattern or
+ * its suffix isn't a known allergen.
  *
  * @param {string} entityId
  * @returns {string|null}
  */
-function extractCitySlugFromEntityId(entityId) {
-  const m = entityId.match(/^sensor\.pollen_(.+)_[^_]+$/);
-  return m ? m[1] : null;
+export function extractCitySlugFromEntityId(entityId) {
+  const prefix = "sensor.pollen_";
+  if (!entityId.startsWith(prefix)) return null;
+  const remainder = entityId.slice(prefix.length);
+  for (const allergenSlug of PP_ALLERGEN_SLUGS) {
+    const suffix = `_${allergenSlug}`;
+    if (remainder.endsWith(suffix)) {
+      const citySlug = remainder.slice(0, -suffix.length);
+      return citySlug || null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the allergen slug from a PP entity ID using the same suffix
+ * whitelist as extractCitySlugFromEntityId. Returns the canonical
+ * (master) key via normalize() so callers can look it up directly in
+ * cfg.allergens.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractAllergenKeyFromEntityId(entityId) {
+  const prefix = "sensor.pollen_";
+  if (!entityId.startsWith(prefix)) return null;
+  const remainder = entityId.slice(prefix.length);
+  for (const allergenSlug of PP_ALLERGEN_SLUGS) {
+    const suffix = `_${allergenSlug}`;
+    if (remainder.endsWith(suffix)) {
+      return normalize(allergenSlug);
+    }
+  }
+  return null;
 }
 
 /**
@@ -107,14 +145,11 @@ export function discoverPpSensors(hass, debug = false) {
     platform: ["pollenprognos"],
     /**
      * Strict classifier: derive the canonical allergen key from the entity ID.
-     * PP entity IDs follow the pattern sensor.pollen_{city}_{allergen}.
-     * The allergen is the last underscore-separated segment.
+     * PP entity IDs follow the pattern sensor.pollen_{city}_{allergen}, but
+     * the allergen slug can contain underscores (e.g. "salg_och_viden"), so
+     * use a longest-suffix whitelist match rather than splitting on `_`.
      */
-    classify: (eid) => {
-      const m = eid.match(/^sensor\.pollen_(.+)_([^_]+)$/);
-      if (!m) return null;
-      return normalize(m[2]);
-    },
+    classify: (eid) => extractAllergenKeyFromEntityId(eid),
     /**
      * isRelevant: quick pre-filter before classify runs.
      */
@@ -156,9 +191,13 @@ export function discoverPpSensors(hass, debug = false) {
       return ctx.device?.config_entries?.[0] || "default";
     },
     /**
-     * fallbackRegex: matches the standard PP entity ID pattern used in tier 3.
+     * fallbackSelector: tier 3 uses the same allergen-suffix whitelist as
+     * the classifier so multi-word allergen slugs are matched correctly.
      */
-    fallbackRegex: /^sensor\.pollen_.+_[^_]+$/,
+    fallbackSelector: (h) =>
+      Object.keys(h.states).filter(
+        (id) => extractAllergenKeyFromEntityId(id) !== null,
+      ),
     debug,
     logTag: "PP",
   });
@@ -174,14 +213,13 @@ function detectCity(cfg, hass) {
   const cityCfg = isConfigEntryId(cfg.city) ? "" : cfg.city;
   let cityKey = normalize(cityCfg || "");
   if (!cityKey) {
+    // Use the allergen-suffix whitelist to handle multi-word slugs like
+    // "salg_och_viden" correctly when extracting the city.
     const ppStates = Object.keys(hass.states).filter(
-      (id) =>
-        id.startsWith("sensor.pollen_") &&
-        /^sensor\.pollen_(.+)_[^_]+$/.test(id),
+      (id) => extractCitySlugFromEntityId(id) !== null,
     );
     if (ppStates.length) {
-      const m = ppStates[0].match(/^sensor\.pollen_(.+)_[^_]+$/);
-      cityKey = m ? m[1] : "";
+      cityKey = extractCitySlugFromEntityId(ppStates[0]) || "";
     }
   }
   return cityKey;
@@ -212,10 +250,7 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
   if (discovery.locations.size > 0) {
     const match = resolveLocationByKey(discovery, cfg.city, {
-      slugExtractor: (eid) => {
-        const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
-        return m ? m[1] : null;
-      },
+      slugExtractor: extractCitySlugFromEntityId,
     });
 
     if (match) {

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -1,7 +1,7 @@
 import { normalize } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity } from "../utils/adapter-helpers.js";
+import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey } from "../utils/adapter-helpers.js";
 
 export const stubConfigPP = {
   integration: "pp",
@@ -49,6 +49,102 @@ export const stubConfigPP = {
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },
 };
 
+/**
+ * Extract a prettified city name from a PP entity ID.
+ * "sensor.pollen_goteborg_bjork" -> "Goteborg"
+ * Returns null if the entity ID does not match the expected pattern.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractCityFromEntityId(entityId) {
+  const m = entityId.match(/^sensor\.pollen_(.+)_[^_]+$/);
+  if (!m) return null;
+  const slug = m[1];
+  return slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
+/**
+ * Extract the city slug from a PP entity ID.
+ * "sensor.pollen_goteborg_bjork" -> "goteborg"
+ * Returns null if the entity ID does not match the expected pattern.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractCitySlugFromEntityId(entityId) {
+  const m = entityId.match(/^sensor\.pollen_(.+)_[^_]+$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Discover all Pollenprognos sensors, grouped by city/device.
+ *
+ * Uses three-tier discovery via discoverEntitiesByDevice:
+ *   Tier 1: device-based (hass.devices with identifiers["pollenprognos", ...])
+ *   Tier 2: entity-registry scan by platform === "pollenprognos"
+ *   Tier 3: regex fallback scanning hass.states for sensor.pollen_*
+ *
+ * NOTE: The HA integration platform string "pollenprognos" is an assumption
+ * based on the integration name. If the integration uses a different identifier
+ * (e.g. after a rename), tier 1 and tier 2 will yield no results and tier 3
+ * (regex fallback) will still provide discovery. Pass an array like
+ * ["pollenprognos", "other_name"] to support multiple platform names.
+ *
+ * @param {object}  hass
+ * @param {boolean} [debug=false]
+ * @returns {{ locations: Map<string, { label: string, entities: Map<string, string> }>, tierUsed: number }}
+ */
+export function discoverPpSensors(hass, debug = false) {
+  if (!hass) return { locations: new Map(), tierUsed: 0 };
+
+  const { locations, tierUsed } = discoverEntitiesByDevice(hass, {
+    platform: ["pollenprognos"],
+    /**
+     * Strict classifier: derive the canonical allergen key from the entity ID.
+     * PP entity IDs follow the pattern sensor.pollen_{city}_{allergen}.
+     * The allergen is the last underscore-separated segment.
+     */
+    classify: (eid) => {
+      const m = eid.match(/^sensor\.pollen_(.+)_([^_]+)$/);
+      if (!m) return null;
+      return normalize(m[2]);
+    },
+    /**
+     * isRelevant: quick pre-filter before classify runs.
+     */
+    isRelevant: (eid) => eid.startsWith("sensor.pollen_"),
+    /**
+     * resolveLabel: use device name when available, fall back to city slug from entity ID.
+     */
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      if (ctx.device?.name) return ctx.device.name;
+      return extractCityFromEntityId(ctx.entityId) || "Auto";
+    },
+    /**
+     * resolveLocationKey:
+     *   - Tier 3 (regex fallback): use city slug from entity ID as location key
+     *     to preserve backwards compatibility with slug-based city configs.
+     *   - Tier 1/2 (device/registry): use config_entry_id as stable location key.
+     */
+    resolveLocationKey: (ctx) => {
+      if (ctx.tier === 3) {
+        return extractCitySlugFromEntityId(ctx.entityId) || "default";
+      }
+      return ctx.device?.config_entries?.[0] || "default";
+    },
+    /**
+     * fallbackRegex: matches the standard PP entity ID pattern used in tier 3.
+     */
+    fallbackRegex: /^sensor\.pollen_.+_[^_]+$/,
+    debug,
+    logTag: "[PP]",
+  });
+
+  return { locations, tierUsed };
+}
+
 function detectCity(cfg, hass) {
   if (cfg.city === "manual") return "";
   let cityKey = normalize(cfg.city || "");
@@ -68,31 +164,69 @@ function detectCity(cfg, hass) {
 
 export function resolveEntityIds(cfg, hass, debug = false) {
   const map = new Map();
-  const cityKey = detectCity(cfg, hass);
 
+  // --- Path 1: Manual mode ---
+  if (cfg.city === "manual") {
+    const prefix = normalizeManualPrefix(cfg.entity_prefix);
+    for (const allergen of cfg.allergens || []) {
+      const rawKey = normalize(allergen);
+      const sensorId = resolveManualEntity(hass, prefix, rawKey, cfg.entity_suffix || "");
+      if (!sensorId) continue;
+      if (debug) {
+        console.debug(
+          `[PP:resolveEntityIds] manual allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
+        );
+      }
+      map.set(rawKey, sensorId);
+    }
+    return map;
+  }
+
+  // --- Path 2: Device-based discovery (tier 1/2) or regex fallback (tier 3) ---
+  const discovery = discoverPpSensors(hass, debug);
+
+  if (discovery.locations.size > 0) {
+    const match = resolveLocationByKey(discovery, cfg.city, {
+      slugExtractor: (eid) => {
+        const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
+        return m ? m[1] : null;
+      },
+    });
+
+    if (match) {
+      const [, location] = match;
+      for (const allergen of cfg.allergens || []) {
+        const rawKey = normalize(allergen);
+        const eid = location.entities.get(rawKey);
+        if (!eid) continue;
+        if (debug) {
+          console.debug(
+            `[PP:resolveEntityIds] discovery allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${eid}'`,
+          );
+        }
+        map.set(rawKey, eid);
+      }
+
+      if (map.size > 0) return map;
+    }
+  }
+
+  // --- Path 3: Template fallback (legacy / when discovery yields nothing) ---
+  const cityKey = detectCity(cfg, hass);
   for (const allergen of cfg.allergens || []) {
     const rawKey = normalize(allergen);
-    let sensorId;
-    if (cfg.city === "manual") {
-      const prefix = normalizeManualPrefix(cfg.entity_prefix);
-      sensorId = resolveManualEntity(hass, prefix, rawKey, cfg.entity_suffix || "");
-      if (!sensorId) continue;
-    } else {
-      sensorId = cityKey ? `sensor.pollen_${cityKey}_${rawKey}` : null;
-      if (!sensorId || !hass.states[sensorId]) {
-        const base = cityKey
-          ? `sensor.pollen_${cityKey}_`
-          : "sensor.pollen_";
-        const cands = Object.keys(hass.states).filter(
-          (id) => id.startsWith(base) && id.endsWith(`_${rawKey}`),
-        );
-        if (cands.length === 1) sensorId = cands[0];
-        else continue;
-      }
+    let sensorId = cityKey ? `sensor.pollen_${cityKey}_${rawKey}` : null;
+    if (!sensorId || !hass.states[sensorId]) {
+      const base = cityKey ? `sensor.pollen_${cityKey}_` : "sensor.pollen_";
+      const cands = Object.keys(hass.states).filter(
+        (id) => id.startsWith(base) && id.endsWith(`_${rawKey}`),
+      );
+      if (cands.length === 1) sensorId = cands[0];
+      else continue;
     }
     if (debug) {
       console.debug(
-        `[PP:resolveEntityIds] allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
+        `[PP:resolveEntityIds] template fallback allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,
       );
     }
     map.set(rawKey, sensorId);

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -139,7 +139,7 @@ export function discoverPpSensors(hass, debug = false) {
      */
     fallbackRegex: /^sensor\.pollen_.+_[^_]+$/,
     debug,
-    logTag: "[PP]",
+    logTag: "PP",
   });
 
   return { locations, tierUsed };

--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,16 @@ const PP_ALIASES = {
   salg_och_viden: "willow",
 };
 
+/**
+ * PP allergen slugs (entity-id suffixes), sorted longest first so callers
+ * can use longest-suffix matching to extract a city slug from
+ * `sensor.pollen_{city}_{allergen}` even when the allergen contains
+ * underscores (e.g. "salg_och_viden").
+ */
+export const PP_ALLERGEN_SLUGS = Object.keys(PP_ALIASES).sort(
+  (a, b) => b.length - a.length,
+);
+
 const DWD_ALIASES = {
   erle: "alder",
   ambrosia: "ragweed",

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -6,12 +6,18 @@ import { svgs, getSvgContent } from "./pollenprognos-svgs.js";
 import { t, detectLang } from "./i18n.js";
 import { getAdapter, getStubConfig } from "./adapter-registry.js";
 import { findAvailableSensors } from "./utils/sensors.js";
-import { filterSensorsPostFetch } from "./utils/adapter-helpers.js";
+import {
+  filterSensorsPostFetch,
+  resolveLocationByKey,
+} from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 import { PLU_ALIAS_MAP } from "./adapters/plu.js";
 import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
 import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
 import { discoverGpSensors } from "./adapters/gp/index.js";
+import { discoverPpSensors } from "./adapters/pp.js";
+import { discoverDwdSensors } from "./adapters/dwd.js";
+import { discoverPeuSensors } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import {
   findSilamWeatherEntity,
@@ -1359,52 +1365,54 @@ class PollenPrognosCard extends LitElement {
     } else {
       let loc = "";
       if (integration === "dwd") {
-        loc =
-          cfg.region_id && cfg.region_id !== "manual"
-            ? DWD_REGIONS[cfg.region_id] || cfg.region_id
-            : "";
+        // Resolve title via shared discovery so config_entry_id keys, legacy
+        // numeric region_id slugs and user-customized device names all render
+        // the friendly location name instead of the raw config value.
+        const dwdDiscovery = discoverDwdSensors(hass, false);
+        const wantedLocation =
+          cfg.region_id && cfg.region_id !== "manual" ? cfg.region_id : "";
+        const match = resolveLocationByKey(dwdDiscovery, wantedLocation, {
+          slugExtractor: (eid) => {
+            const m = eid.match(/_(\d+)$/);
+            return m ? m[1] : null;
+          },
+        });
+        if (match) {
+          loc = match[1].label;
+        } else if (wantedLocation) {
+          loc = DWD_REGIONS[wantedLocation] || wantedLocation;
+        }
       } else if (integration === "peu") {
-        // Collect all PEU entities to determine location automatically.
-        const peuEntities = Object.values(hass.states).filter(
-          (s) =>
-            s &&
-            typeof s === "object" &&
-            typeof s.entity_id === "string" &&
-            s.entity_id.startsWith("sensor.polleninformation_"),
-        );
-        const wantedSlug =
-          cfg.location && cfg.location !== "manual"
-            ? slugify(cfg.location)
-            : "";
-        let title = "";
-        let match = null;
-        if (wantedSlug) {
-          // Find entity matching the configured location slug.
-          match = peuEntities.find((s) => {
-            const attr = s.attributes || {};
-            const slug =
-              attr.location_slug ||
-              s.entity_id
-                .replace("sensor.polleninformation_", "")
-                .replace(/_[^_]+$/, "");
-            return slugify(slug) === wantedSlug;
-          });
-        } else {
-          // No location configured – determine if all sensors belong to one place.
-          const locations = Array.from(
-            new Set(
-              peuEntities.map((s) => {
-                const attr = s.attributes || {};
-                const slug =
-                  attr.location_slug ||
-                  s.entity_id
-                    .replace("sensor.polleninformation_", "")
-                    .replace(/_[^_]+$/, "");
-                return slugify(slug);
-              }),
-            ),
+        // Primary: resolve via shared discovery so config_entry_id keys and
+        // legacy lowercase slugs both produce the friendly location name.
+        const peuDiscovery = discoverPeuSensors(hass, false);
+        const wantedLocation =
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
+        const peuMatch = resolveLocationByKey(peuDiscovery, wantedLocation, {
+          slugExtractor: (eid) => {
+            const m = eid.match(/^sensor\.polleninformation_(.+?)_[a-z_]+$/);
+            return m ? m[1] : null;
+          },
+        });
+        if (peuMatch) {
+          loc = peuMatch[1].label;
+        } else if (cfg.location !== "manual") {
+          // Fallback: entity-state slug scan (for very old PEU integrations
+          // without device/entity registry entries).
+          const peuEntities = Object.values(hass.states).filter(
+            (s) =>
+              s &&
+              typeof s === "object" &&
+              typeof s.entity_id === "string" &&
+              s.entity_id.startsWith("sensor.polleninformation_"),
           );
-          if (locations.length === 1) {
+          const wantedSlug =
+            cfg.location && cfg.location !== "manual"
+              ? slugify(cfg.location)
+              : "";
+          let title = "";
+          let match = null;
+          if (wantedSlug) {
             match = peuEntities.find((s) => {
               const attr = s.attributes || {};
               const slug =
@@ -1412,18 +1420,43 @@ class PollenPrognosCard extends LitElement {
                 s.entity_id
                   .replace("sensor.polleninformation_", "")
                   .replace(/_[^_]+$/, "");
-              return slugify(slug) === locations[0];
+              return slugify(slug) === wantedSlug;
             });
+          } else {
+            const locations = Array.from(
+              new Set(
+                peuEntities.map((s) => {
+                  const attr = s.attributes || {};
+                  const slug =
+                    attr.location_slug ||
+                    s.entity_id
+                      .replace("sensor.polleninformation_", "")
+                      .replace(/_[^_]+$/, "");
+                  return slugify(slug);
+                }),
+              ),
+            );
+            if (locations.length === 1) {
+              match = peuEntities.find((s) => {
+                const attr = s.attributes || {};
+                const slug =
+                  attr.location_slug ||
+                  s.entity_id
+                    .replace("sensor.polleninformation_", "")
+                    .replace(/_[^_]+$/, "");
+                return slugify(slug) === locations[0];
+              });
+            }
           }
+          if (match) {
+            const attr = match.attributes || {};
+            title =
+              attr.location_title ||
+              attr.friendly_name?.match(/\((.*?)\)/)?.[1] ||
+              "";
+          }
+          loc = wantedSlug ? title || cfg.location || "" : title;
         }
-        if (match) {
-          const attr = match.attributes || {};
-          title =
-            attr.location_title ||
-            attr.friendly_name?.match(/\((.*?)\)/)?.[1] ||
-            "";
-        }
-        loc = wantedSlug ? title || cfg.location || "" : title;
       } else if (integration === "silam") {
         // Primärt: discovery-baserad title
         let title = "";
@@ -1585,19 +1618,13 @@ class PollenPrognosCard extends LitElement {
 
         loc = title || cfg.location || "";
       } else if (integration === "gpl") {
-        // Google Pollen Levels: extract location from discovery
+        // Google Pollen Levels: resolve via shared discovery so config_entry_id
+        // keys and legacy label slugs both produce the friendly location name.
         const gplDiscovery = discoverGplSensors(hass, false);
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? cfg.location
-            : "";
-
-        let title = "";
-        if (wantedLocation && gplDiscovery.locations.has(wantedLocation)) {
-          title = gplDiscovery.locations.get(wantedLocation).label;
-        } else if (gplDiscovery.locations.size) {
-          title = gplDiscovery.locations.values().next().value.label;
-        }
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
+        const gplMatch = resolveLocationByKey(gplDiscovery, wantedLocation);
+        let title = gplMatch ? gplMatch[1].label : "";
 
         // Clean up device name if it looks like a friendly_name with type suffix
         if (title) {
@@ -1612,19 +1639,13 @@ class PollenPrognosCard extends LitElement {
 
         loc = title || cfg.location || "";
       } else if (integration === "gp") {
-        // Google Pollen (svenove): reuse the discovery computed earlier in
-        // set hass() so we don't run a second registry/state scan per update.
+        // Google Pollen (svenove): resolve via shared discovery so
+        // config_entry_id keys and legacy label slugs both produce the
+        // friendly location name. Reuses gpDiscovery computed in set hass().
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? cfg.location
-            : "";
-
-        let title = "";
-        if (wantedLocation && gpDiscovery.locations.has(wantedLocation)) {
-          title = gpDiscovery.locations.get(wantedLocation).label;
-        } else if (gpDiscovery.locations.size) {
-          title = gpDiscovery.locations.values().next().value.label;
-        }
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
+        const gpMatch = resolveLocationByKey(gpDiscovery, wantedLocation);
+        const title = gpMatch ? gpMatch[1].label : "";
 
         loc = title || cfg.location || "";
       } else if (integration === "plu") {
@@ -1632,12 +1653,29 @@ class PollenPrognosCard extends LitElement {
         const translated = this._t("card.location.plu");
         loc = translated === "card.location.plu" ? "Luxembourg" : translated;
       } else {
-        // Pollenprognos integration (PP): resolve city automatically when unset.
-        const matchCity = (slug) =>
-          PP_POSSIBLE_CITIES.find((n) => slugify(n) === slug) || slug;
-        if (cfg.city && cfg.city !== "manual") {
-          loc = matchCity(cfg.city);
+        // Pollenprognos integration (PP): resolve city via shared discovery so
+        // config_entry_id keys, legacy city slugs and user-customized device
+        // names all render the friendly location name.
+        const ppDiscovery = discoverPpSensors(hass, false);
+        const wantedLocation =
+          cfg.city && cfg.city !== "manual" ? cfg.city : "";
+        const ppMatch = resolveLocationByKey(ppDiscovery, wantedLocation, {
+          slugExtractor: (eid) => {
+            const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
+            return m ? m[1] : null;
+          },
+        });
+        if (ppMatch) {
+          loc = ppMatch[1].label;
+        } else if (wantedLocation) {
+          // Fallback: legacy slug → canonical city name lookup.
+          const matchCity = (slug) =>
+            PP_POSSIBLE_CITIES.find((n) => slugify(n) === slug) || slug;
+          loc = matchCity(wantedLocation);
         } else {
+          // No city configured and no discovery: legacy state-scan fallback.
+          const matchCity = (slug) =>
+            PP_POSSIBLE_CITIES.find((n) => slugify(n) === slug) || slug;
           const ppStates = Object.keys(hass.states).filter((id) =>
             /^sensor\.pollen_(.+)_[^_]+$/.test(id),
           );
@@ -1648,11 +1686,7 @@ class PollenPrognosCard extends LitElement {
               ),
             ),
           );
-          if (cities.length === 1) {
-            loc = matchCity(cities[0]);
-          } else {
-            loc = "";
-          }
+          loc = cities.length === 1 ? matchCity(cities[0]) : "";
         }
       }
       nextHeader = loc

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1345,7 +1345,7 @@ class PollenPrognosCard extends LitElement {
       !cfg.location &&
       gplStates.length
     ) {
-      const gplDiscovery = discoverGplSensors(hass, this.debug);
+      const gplDiscovery = getGplDiscovery();
       const firstLocId = gplDiscovery.locations.keys().next().value;
       cfg.location = firstLocId || null;
       if (this.debug)

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -17,7 +17,7 @@ import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
 import { discoverGpSensors } from "./adapters/gp/index.js";
 import { discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { discoverDwdSensors } from "./adapters/dwd.js";
-import { discoverPeuSensors } from "./adapters/peu.js";
+import { discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import {
   findSilamWeatherEntity,
@@ -1417,10 +1417,7 @@ class PollenPrognosCard extends LitElement {
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const peuMatch = resolveLocationByKey(peuDiscovery, wantedLocation, {
-          slugExtractor: (eid) => {
-            const m = eid.match(/^sensor\.polleninformation_(.+?)_[a-z_]+$/);
-            return m ? m[1] : null;
-          },
+          slugExtractor: extractPeuLocationSlugFromEntityId,
         });
         if (peuMatch) {
           loc = peuMatch[1].label;

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1076,6 +1076,32 @@ class PollenPrognosCard extends LitElement {
       }
     }
 
+    // Discovery results for adapters whose header label resolution would
+    // otherwise re-scan the registry. SILAM, Atmo, and GP are already cached
+    // above; PP, DWD, PEU, and GPL go here so the header block can reuse the
+    // same result instead of calling discover*Sensors a second time per HA
+    // update.
+    let _ppDiscovery = null;
+    let _dwdDiscovery = null;
+    let _peuDiscovery = null;
+    let _gplDiscovery = null;
+    const getPpDiscovery = () => {
+      if (_ppDiscovery === null) _ppDiscovery = discoverPpSensors(hass, this.debug);
+      return _ppDiscovery;
+    };
+    const getDwdDiscovery = () => {
+      if (_dwdDiscovery === null) _dwdDiscovery = discoverDwdSensors(hass, this.debug);
+      return _dwdDiscovery;
+    };
+    const getPeuDiscovery = () => {
+      if (_peuDiscovery === null) _peuDiscovery = discoverPeuSensors(hass, this.debug);
+      return _peuDiscovery;
+    };
+    const getGplDiscovery = () => {
+      if (_gplDiscovery === null) _gplDiscovery = discoverGplSensors(hass, this.debug);
+      return _gplDiscovery;
+    };
+
     if (this.debug) {
       console.debug("Sensor states detected:");
       console.debug("PP:", ppStates);
@@ -1367,8 +1393,9 @@ class PollenPrognosCard extends LitElement {
       if (integration === "dwd") {
         // Resolve title via shared discovery so config_entry_id keys, legacy
         // numeric region_id slugs and user-customized device names all render
-        // the friendly location name instead of the raw config value.
-        const dwdDiscovery = discoverDwdSensors(hass, false);
+        // the friendly location name instead of the raw config value. Reuses
+        // the cached discovery from set hass() to avoid a second registry scan.
+        const dwdDiscovery = getDwdDiscovery();
         const wantedLocation =
           cfg.region_id && cfg.region_id !== "manual" ? cfg.region_id : "";
         const match = resolveLocationByKey(dwdDiscovery, wantedLocation, {
@@ -1385,7 +1412,8 @@ class PollenPrognosCard extends LitElement {
       } else if (integration === "peu") {
         // Primary: resolve via shared discovery so config_entry_id keys and
         // legacy lowercase slugs both produce the friendly location name.
-        const peuDiscovery = discoverPeuSensors(hass, false);
+        // Reuses cached discovery from set hass() to avoid a second scan.
+        const peuDiscovery = getPeuDiscovery();
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const peuMatch = resolveLocationByKey(peuDiscovery, wantedLocation, {
@@ -1620,7 +1648,8 @@ class PollenPrognosCard extends LitElement {
       } else if (integration === "gpl") {
         // Google Pollen Levels: resolve via shared discovery so config_entry_id
         // keys and legacy label slugs both produce the friendly location name.
-        const gplDiscovery = discoverGplSensors(hass, false);
+        // Reuses cached discovery from set hass() to avoid a second scan.
+        const gplDiscovery = getGplDiscovery();
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const gplMatch = resolveLocationByKey(gplDiscovery, wantedLocation);
@@ -1655,8 +1684,9 @@ class PollenPrognosCard extends LitElement {
       } else {
         // Pollenprognos integration (PP): resolve city via shared discovery so
         // config_entry_id keys, legacy city slugs and user-customized device
-        // names all render the friendly location name.
-        const ppDiscovery = discoverPpSensors(hass, false);
+        // names all render the friendly location name. Reuses cached discovery
+        // from set hass() to avoid a second scan.
+        const ppDiscovery = getPpDiscovery();
         const wantedLocation =
           cfg.city && cfg.city !== "manual" ? cfg.city : "";
         const ppMatch = resolveLocationByKey(ppDiscovery, wantedLocation, {

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -15,7 +15,7 @@ import { PLU_ALIAS_MAP } from "./adapters/plu.js";
 import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
 import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
 import { discoverGpSensors } from "./adapters/gp/index.js";
-import { discoverPpSensors } from "./adapters/pp.js";
+import { discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { discoverDwdSensors } from "./adapters/dwd.js";
 import { discoverPeuSensors } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
@@ -1690,10 +1690,7 @@ class PollenPrognosCard extends LitElement {
         const wantedLocation =
           cfg.city && cfg.city !== "manual" ? cfg.city : "";
         const ppMatch = resolveLocationByKey(ppDiscovery, wantedLocation, {
-          slugExtractor: (eid) => {
-            const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
-            return m ? m[1] : null;
-          },
+          slugExtractor: extractPpCitySlugFromEntityId,
         });
         if (ppMatch) {
           loc = ppMatch[1].label;
@@ -1704,16 +1701,15 @@ class PollenPrognosCard extends LitElement {
           loc = matchCity(wantedLocation);
         } else {
           // No city configured and no discovery: legacy state-scan fallback.
+          // Use the allergen-suffix whitelist so multi-word slugs like
+          // "salg_och_viden" don't truncate the city.
           const matchCity = (slug) =>
             PP_POSSIBLE_CITIES.find((n) => slugify(n) === slug) || slug;
-          const ppStates = Object.keys(hass.states).filter((id) =>
-            /^sensor\.pollen_(.+)_[^_]+$/.test(id),
-          );
           const cities = Array.from(
             new Set(
-              ppStates.map((id) =>
-                id.replace("sensor.pollen_", "").replace(/_[^_]+$/, ""),
-              ),
+              Object.keys(hass.states)
+                .map((id) => extractPpCitySlugFromEntityId(id))
+                .filter(Boolean),
             ),
           );
           loc = cities.length === 1 ? matchCity(cities[0]) : "";

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -983,6 +983,11 @@ class PollenPrognosCardEditor extends LitElement {
             this.installedPpLocations.push([cfgCity, loc.label]);
           }
         }
+        // Sort by label so dropdown order stays stable across HA restarts
+        // (Map iteration order tracks hass-registry insertion).
+        this.installedPpLocations.sort(([, a], [, b]) =>
+          String(a).localeCompare(String(b), undefined, { sensitivity: "base" }),
+        );
         // Keep installedCities in sync (used by setConfig legacy path)
         this.installedCities = this.installedPpLocations.map(([, label]) => label);
       } else {
@@ -1023,6 +1028,17 @@ class PollenPrognosCardEditor extends LitElement {
             this.installedDwdLocations.push([cfgRegion, loc.label]);
           }
         }
+        // Sort numerically when all keys are digit strings (legacy region IDs),
+        // otherwise by label, so dropdown order stays stable across HA restarts.
+        const allNumeric = this.installedDwdLocations.every(([k]) =>
+          /^\d+$/.test(String(k)),
+        );
+        this.installedDwdLocations.sort(
+          allNumeric
+            ? ([a], [b]) => Number(a) - Number(b)
+            : ([, a], [, b]) =>
+                String(a).localeCompare(String(b), undefined, { sensitivity: "base" }),
+        );
         // Keep installedRegionIds in sync (used by setConfig legacy path)
         this.installedRegionIds = this.installedDwdLocations.map(([key]) => key);
       } else {

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -599,11 +599,16 @@ class PollenPrognosCardEditor extends LitElement {
 
       // 16. Uppdatera listor för cities/regions om hass finns
       if (this._hass) {
-        // PP: use discovery helper, fall back to PP_POSSIBLE_CITIES filter
+        // PP: use discovery helper, fall back to PP_POSSIBLE_CITIES filter.
+        // Sort by label alphabetically so the dropdown order is stable across
+        // HA restarts (Map iteration order tracks hass-registry insertion).
         const ppDiscovery = discoverPpSensors(this._hass, false);
         if (ppDiscovery.locations.size > 0) {
           this.installedPpLocations = Array.from(ppDiscovery.locations.entries())
-            .map(([key, loc]) => [key, loc.label]);
+            .map(([key, loc]) => [key, loc.label])
+            .sort(([, a], [, b]) =>
+              String(a).localeCompare(String(b), undefined, { sensitivity: "base" }),
+            );
           this.installedCities = this.installedPpLocations.map(([, label]) => label);
         } else {
           const all = Object.keys(this._hass.states);
@@ -631,11 +636,19 @@ class PollenPrognosCardEditor extends LitElement {
           this.installedPpLocations = this.installedCities.map((city) => [city, city]);
         }
 
-        // DWD: use discovery helper, fall back to regex-based region IDs
+        // DWD: use discovery helper, fall back to regex-based region IDs.
+        // Sort numerically for region-ID keys (legacy tier 3) and by label
+        // for config_entry_id keys (tier 1/2), so the dropdown is stable.
         const dwdDiscovery = discoverDwdSensors(this._hass, false);
         if (dwdDiscovery.locations.size > 0) {
-          this.installedDwdLocations = Array.from(dwdDiscovery.locations.entries())
+          const entries = Array.from(dwdDiscovery.locations.entries())
             .map(([key, loc]) => [key, loc.label]);
+          const allNumeric = entries.every(([k]) => /^\d+$/.test(String(k)));
+          this.installedDwdLocations = allNumeric
+            ? entries.sort(([a], [b]) => Number(a) - Number(b))
+            : entries.sort(([, a], [, b]) =>
+                String(a).localeCompare(String(b), undefined, { sensitivity: "base" }),
+              );
           this.installedRegionIds = this.installedDwdLocations.map(([key]) => key);
         } else {
           const all = Object.keys(this._hass.states);
@@ -1023,11 +1036,15 @@ class PollenPrognosCardEditor extends LitElement {
         ]);
       }
 
-      // PEU: device-based discovery with legacy location slug fallback
+      // PEU: device-based discovery with legacy location slug fallback.
+      // Sort by label so the dropdown stays stable across HA restarts.
       const peuDiscovery = discoverPeuSensors(hass, false);
       if (peuDiscovery.locations.size > 0) {
         this.installedPeuLocations = Array.from(peuDiscovery.locations.entries())
-          .map(([key, loc]) => [key, loc.label]);
+          .map(([key, loc]) => [key, loc.label])
+          .sort(([, a], [, b]) =>
+            String(a).localeCompare(String(b), undefined, { sensitivity: "base" }),
+          );
         // Legacy compatibility: if config.location is a slug not present as a key,
         // expose it as an extra entry so the saved config remains visible.
         const cfgPeuLoc = this._config?.location;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -12,7 +12,7 @@ import { COSMETIC_FIELDS } from "./constants.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
-import { stubConfigPP, discoverPpSensors } from "./adapters/pp.js";
+import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { stubConfigDWD, discoverDwdSensors } from "./adapters/dwd.js";
 import { PEU_ALLERGENS, discoverPeuSensors } from "./adapters/peu.js";
 import { SILAM_ALLERGENS } from "./adapters/silam.js";
@@ -612,17 +612,14 @@ class PollenPrognosCardEditor extends LitElement {
           this.installedCities = this.installedPpLocations.map(([, label]) => label);
         } else {
           const all = Object.keys(this._hass.states);
+          // Use the allergen-suffix whitelist from pp.js so multi-word slugs
+          // like "salg_och_viden" don't truncate the city.
           const ppKeys = new Set(
             all
-              .filter(
-                (id) =>
-                  typeof id === "string" &&
-                  id.startsWith("sensor.pollen_") &&
-                  !id.startsWith("sensor.pollenflug_"),
-              )
               .map((id) =>
-                id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
-              ),
+                typeof id === "string" ? extractPpCitySlugFromEntityId(id) : null,
+              )
+              .filter(Boolean),
           );
           this.installedCities = PP_POSSIBLE_CITIES.filter((c) =>
             ppKeys.has(
@@ -991,12 +988,12 @@ class PollenPrognosCardEditor extends LitElement {
         // Keep installedCities in sync (used by setConfig legacy path)
         this.installedCities = this.installedPpLocations.map(([, label]) => label);
       } else {
-        // Fallback to PP_POSSIBLE_CITIES when discovery yields nothing
+        // Fallback to PP_POSSIBLE_CITIES when discovery yields nothing.
+        // Use the allergen-suffix whitelist so multi-word slugs like
+        // "salg_och_viden" don't truncate the city.
         const uniqKeys = Array.from(
           new Set(
-            ppStates.map((id) =>
-              id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
-            ),
+            ppStates.map((id) => extractPpCitySlugFromEntityId(id)).filter(Boolean),
           ),
         );
         this.installedCities = PP_POSSIBLE_CITIES.filter((city) =>

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -12,9 +12,9 @@ import { COSMETIC_FIELDS } from "./constants.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
-import { stubConfigPP } from "./adapters/pp.js";
-import { stubConfigDWD } from "./adapters/dwd.js";
-import { PEU_ALLERGENS } from "./adapters/peu.js";
+import { stubConfigPP, discoverPpSensors } from "./adapters/pp.js";
+import { stubConfigDWD, discoverDwdSensors } from "./adapters/dwd.js";
+import { PEU_ALLERGENS, discoverPeuSensors } from "./adapters/peu.js";
 import { SILAM_ALLERGENS } from "./adapters/silam.js";
 import { stubConfigKleenex } from "./adapters/kleenex/index.js";
 import { stubConfigPLU, PLU_ALIAS_MAP } from "./adapters/plu.js";
@@ -26,6 +26,7 @@ import {
   resolveDiscoveredLocation,
   isConfigEntryId,
 } from "./utils/silam.js";
+import { findLocationBySlug } from "./utils/adapter-helpers.js";
 
 import {
   PP_POSSIBLE_CITIES,
@@ -212,6 +213,8 @@ class PollenPrognosCardEditor extends LitElement {
       hass: { type: Object },
       installedCities: { type: Array },
       installedRegionIds: { type: Array },
+      installedPpLocations: { type: Array },
+      installedDwdLocations: { type: Array },
       _initDone: { type: Boolean },
       _selectedPhraseLang: { state: true },
       _tapType: { type: String },
@@ -261,6 +264,8 @@ class PollenPrognosCardEditor extends LitElement {
     this.installedAtmoLocations = [];
     this._prevIntegration = undefined;
     this.installedRegionIds = [];
+    this.installedPpLocations = [];
+    this.installedDwdLocations = [];
     this._initDone = false;
     // Ensure phrase language defaults to a sensible locale
     this._selectedPhraseLang = detectLang();
@@ -594,57 +599,77 @@ class PollenPrognosCardEditor extends LitElement {
 
       // 16. Uppdatera listor för cities/regions om hass finns
       if (this._hass) {
-        const all = Object.keys(this._hass.states);
-
-        this.installedRegionIds = Array.from(
-          new Set(
+        // PP: use discovery helper, fall back to PP_POSSIBLE_CITIES filter
+        const ppDiscovery = discoverPpSensors(this._hass, false);
+        if (ppDiscovery.locations.size > 0) {
+          this.installedPpLocations = Array.from(ppDiscovery.locations.entries())
+            .map(([key, loc]) => [key, loc.label]);
+          this.installedCities = this.installedPpLocations.map(([, label]) => label);
+        } else {
+          const all = Object.keys(this._hass.states);
+          const ppKeys = new Set(
             all
               .filter(
                 (id) =>
-                  typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+                  typeof id === "string" &&
+                  id.startsWith("sensor.pollen_") &&
+                  !id.startsWith("sensor.pollenflug_"),
               )
-              .map((id) => id.split("_").pop()),
-          ),
-        ).sort((a, b) => Number(a) - Number(b));
-
-        const ppKeys = new Set(
-          all
-            .filter(
-              (id) =>
-                typeof id === "string" &&
-                id.startsWith("sensor.pollen_") &&
-                !id.startsWith("sensor.pollenflug_"),
-            )
-            .map((id) =>
-              id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
+              .map((id) =>
+                id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
+              ),
+          );
+          this.installedCities = PP_POSSIBLE_CITIES.filter((c) =>
+            ppKeys.has(
+              c
+                .toLowerCase()
+                .replace(/[åä]/g, "a")
+                .replace(/ö/g, "o")
+                .replace(/[-\s]/g, "_"),
             ),
-        );
+          ).sort();
+          this.installedPpLocations = this.installedCities.map((city) => [city, city]);
+        }
 
-        this.installedCities = PP_POSSIBLE_CITIES.filter((c) =>
-          ppKeys.has(
-            c
-              .toLowerCase()
-              .replace(/[åä]/g, "a")
-              .replace(/ö/g, "o")
-              .replace(/[-\s]/g, "_"),
-          ),
-        ).sort();
+        // DWD: use discovery helper, fall back to regex-based region IDs
+        const dwdDiscovery = discoverDwdSensors(this._hass, false);
+        if (dwdDiscovery.locations.size > 0) {
+          this.installedDwdLocations = Array.from(dwdDiscovery.locations.entries())
+            .map(([key, loc]) => [key, loc.label]);
+          this.installedRegionIds = this.installedDwdLocations.map(([key]) => key);
+        } else {
+          const all = Object.keys(this._hass.states);
+          this.installedRegionIds = Array.from(
+            new Set(
+              all
+                .filter(
+                  (id) =>
+                    typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+                )
+                .map((id) => id.split("_").pop()),
+            ),
+          ).sort((a, b) => Number(a) - Number(b));
+          this.installedDwdLocations = this.installedRegionIds.map((id) => [
+            id,
+            `${id} — ${DWD_REGIONS[id] || id}`,
+          ]);
+        }
       }
       // 17. Auto-välj city/region om inte explicit
       if (!this._integrationExplicit) {
         if (
           integration === "dwd" &&
           !this._userConfig.region_id &&
-          this.installedRegionIds.length
+          this.installedDwdLocations.length
         ) {
-          this._config.region_id = this.installedRegionIds[0];
+          this._config.region_id = this.installedDwdLocations[0][0];
         }
         if (
           integration === "pp" &&
           !this._userConfig.city &&
-          this.installedCities.length
+          this.installedPpLocations.length
         ) {
-          this._config.city = this.installedCities[0];
+          this._config.city = this.installedPpLocations[0][0];
         }
         if (
           integration === "silam" &&
@@ -923,54 +948,137 @@ class PollenPrognosCardEditor extends LitElement {
     
     if (!deepEqual(this._config, merged)) {
       this._config = merged;
-      // 3) Fyll installerade regioner/städer
-      this.installedRegionIds = Array.from(
-        new Set(dwdStates.map((id) => id.split("_").pop())),
-      ).sort((a, b) => Number(a) - Number(b));
+      // 3) Fyll installerade regioner/städer via discovery helpers
 
-      const uniqKeys = Array.from(
-        new Set(
-          ppStates.map((id) =>
-            id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
+      // PP: device-based discovery with legacy slug fallback
+      const ppDiscovery = discoverPpSensors(hass, false);
+      if (ppDiscovery.locations.size > 0) {
+        this.installedPpLocations = Array.from(ppDiscovery.locations.entries())
+          .map(([key, loc]) => [key, loc.label]);
+        // Legacy compatibility: if config.city is a slug not present as a key,
+        // check if it matches via slug extractor and expose it as an extra entry.
+        const cfgCity = this._config?.city;
+        if (cfgCity && cfgCity !== "manual" && !ppDiscovery.locations.has(cfgCity)) {
+          const match = findLocationBySlug(ppDiscovery, cfgCity, {
+            slugExtractor: (eid) => {
+              const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
+              return m ? m[1] : null;
+            },
+          });
+          if (match) {
+            const [, loc] = match;
+            this.installedPpLocations.push([cfgCity, loc.label]);
+          }
+        }
+        // Keep installedCities in sync (used by setConfig legacy path)
+        this.installedCities = this.installedPpLocations.map(([, label]) => label);
+      } else {
+        // Fallback to PP_POSSIBLE_CITIES when discovery yields nothing
+        const uniqKeys = Array.from(
+          new Set(
+            ppStates.map((id) =>
+              id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
+            ),
           ),
-        ),
-      );
-      this.installedCities = PP_POSSIBLE_CITIES.filter((city) =>
-        uniqKeys.includes(
-          city
-            .toLowerCase()
-            .replace(/[åä]/g, "a")
-            .replace(/ö/g, "o")
-            .replace(/[-\s]/g, "_"),
-        ),
-      ).sort((a, b) => a.localeCompare(b));
+        );
+        this.installedCities = PP_POSSIBLE_CITIES.filter((city) =>
+          uniqKeys.includes(
+            city
+              .toLowerCase()
+              .replace(/[åä]/g, "a")
+              .replace(/ö/g, "o")
+              .replace(/[-\s]/g, "_"),
+          ),
+        ).sort((a, b) => a.localeCompare(b));
+        this.installedPpLocations = this.installedCities.map((city) => [city, city]);
+      }
 
-      this.installedPeuLocations = Array.from(
-        new Map(
-          Object.values(hass.states)
-            .filter(
-              (s) =>
-                s &&
-                typeof s === "object" &&
-                typeof s.entity_id === "string" &&
-                s.entity_id.startsWith("sensor.polleninformation_"),
-            )
-            .map((s) => {
-              const locationSlug =
-                s.attributes?.location_slug ||
-                s.entity_id
-                  .replace("sensor.polleninformation_", "")
-                  .replace(/_[^_]+$/, "");
-              const title =
-                s.attributes?.location_title ||
-                (typeof s.attributes?.friendly_name === "string"
-                  ? s.attributes.friendly_name.match(/\((.*?)\)/)?.[1]
-                  : undefined) ||
-                locationSlug;
-              return [locationSlug, title];
-            }),
-        ),
-      );
+      // DWD: device-based discovery with legacy region_id fallback
+      const dwdDiscovery = discoverDwdSensors(hass, false);
+      if (dwdDiscovery.locations.size > 0) {
+        this.installedDwdLocations = Array.from(dwdDiscovery.locations.entries())
+          .map(([key, loc]) => [key, loc.label]);
+        // Legacy compatibility: if config.region_id is a numeric ID not present as a key,
+        // expose it as an extra entry so the saved config remains visible.
+        const cfgRegion = this._config?.region_id;
+        if (cfgRegion && cfgRegion !== "manual" && !dwdDiscovery.locations.has(cfgRegion)) {
+          const match = findLocationBySlug(dwdDiscovery, cfgRegion, {
+            slugExtractor: (eid) => eid.match(/_(\d+)$/)?.[1] || null,
+          });
+          if (match) {
+            const [, loc] = match;
+            this.installedDwdLocations.push([cfgRegion, loc.label]);
+          }
+        }
+        // Keep installedRegionIds in sync (used by setConfig legacy path)
+        this.installedRegionIds = this.installedDwdLocations.map(([key]) => key);
+      } else {
+        // Fallback to regex-based region ID extraction
+        this.installedRegionIds = Array.from(
+          new Set(dwdStates.map((id) => id.split("_").pop())),
+        ).sort((a, b) => Number(a) - Number(b));
+        this.installedDwdLocations = this.installedRegionIds.map((id) => [
+          id,
+          `${id} — ${DWD_REGIONS[id] || id}`,
+        ]);
+      }
+
+      // PEU: device-based discovery with legacy location slug fallback
+      const peuDiscovery = discoverPeuSensors(hass, false);
+      if (peuDiscovery.locations.size > 0) {
+        this.installedPeuLocations = Array.from(peuDiscovery.locations.entries())
+          .map(([key, loc]) => [key, loc.label]);
+        // Legacy compatibility: if config.location is a slug not present as a key,
+        // expose it as an extra entry so the saved config remains visible.
+        const cfgPeuLoc = this._config?.location;
+        if (
+          cfgPeuLoc &&
+          cfgPeuLoc !== "manual" &&
+          !peuDiscovery.locations.has(cfgPeuLoc) &&
+          integration === "peu"
+        ) {
+          const match = findLocationBySlug(peuDiscovery, cfgPeuLoc, {
+            slugExtractor: (eid) => {
+              if (!eid.startsWith("sensor.polleninformation_")) return null;
+              const rest = eid.substring("sensor.polleninformation_".length);
+              const m = rest.match(/^(.+?)_[^_]+$/);
+              return m ? m[1] : null;
+            },
+          });
+          if (match) {
+            const [, loc] = match;
+            this.installedPeuLocations.push([cfgPeuLoc, loc.label]);
+          }
+        }
+      } else {
+        // Fallback to state-based location detection
+        this.installedPeuLocations = Array.from(
+          new Map(
+            Object.values(hass.states)
+              .filter(
+                (s) =>
+                  s &&
+                  typeof s === "object" &&
+                  typeof s.entity_id === "string" &&
+                  s.entity_id.startsWith("sensor.polleninformation_"),
+              )
+              .map((s) => {
+                const locationSlug =
+                  s.attributes?.location_slug ||
+                  s.entity_id
+                    .replace("sensor.polleninformation_", "")
+                    .replace(/_[^_]+$/, "");
+                const title =
+                  s.attributes?.location_title ||
+                  (typeof s.attributes?.friendly_name === "string"
+                    ? s.attributes.friendly_name.match(/\((.*?)\)/)?.[1]
+                    : undefined) ||
+                  locationSlug;
+                return [locationSlug, title];
+              }),
+          ),
+        );
+      }
       // Primärt: discovery-baserad SILAM location list
       if (silamDiscovery.locations.size > 0) {
         this.installedSilamLocations = Array.from(
@@ -1120,16 +1228,16 @@ class PollenPrognosCardEditor extends LitElement {
         if (
           integration === "dwd" &&
           !this._userConfig.region_id &&
-          this.installedRegionIds.length
+          this.installedDwdLocations.length
         ) {
-          this._config.region_id = this.installedRegionIds[0];
+          this._config.region_id = this.installedDwdLocations[0][0];
         }
         if (
           integration === "pp" &&
           !this._userConfig.city &&
-          this.installedCities.length
+          this.installedPpLocations.length
         ) {
-          this._config.city = this.installedCities[0];
+          this._config.city = this.installedPpLocations[0][0];
         }
         if (
           integration === "silam" &&
@@ -1725,9 +1833,9 @@ class PollenPrognosCardEditor extends LitElement {
                             value: "",
                             label: this._t("location_autodetect"),
                           },
-                          ...this.installedCities.map((city) => ({
-                            value: city,
-                            label: city,
+                          ...this.installedPpLocations.map(([key, label]) => ({
+                            value: key,
+                            label,
                           })),
                           {
                             value: "manual",
@@ -1921,9 +2029,9 @@ class PollenPrognosCardEditor extends LitElement {
                                   value: "",
                                   label: this._t("location_autodetect"),
                                 },
-                                ...this.installedRegionIds.map((id) => ({
-                                  value: id,
-                                  label: `${id} — ${DWD_REGIONS[id] || id}`,
+                                ...this.installedDwdLocations.map(([key, label]) => ({
+                                  value: key,
+                                  label,
                                 })),
                                 {
                                   value: "manual",

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -14,7 +14,7 @@ import { COSMETIC_FIELDS } from "./constants.js";
 import { getStubConfig } from "./adapter-registry.js";
 import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { stubConfigDWD, discoverDwdSensors } from "./adapters/dwd.js";
-import { PEU_ALLERGENS, discoverPeuSensors } from "./adapters/peu.js";
+import { PEU_ALLERGENS, discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { SILAM_ALLERGENS } from "./adapters/silam.js";
 import { stubConfigKleenex } from "./adapters/kleenex/index.js";
 import { stubConfigPLU, PLU_ALIAS_MAP } from "./adapters/plu.js";
@@ -970,10 +970,7 @@ class PollenPrognosCardEditor extends LitElement {
         const cfgCity = this._config?.city;
         if (cfgCity && cfgCity !== "manual" && !ppDiscovery.locations.has(cfgCity)) {
           const match = findLocationBySlug(ppDiscovery, cfgCity, {
-            slugExtractor: (eid) => {
-              const m = eid.match(/^sensor\.pollen_(.+)_[^_]+$/);
-              return m ? m[1] : null;
-            },
+            slugExtractor: extractPpCitySlugFromEntityId,
           });
           if (match) {
             const [, loc] = match;
@@ -1068,12 +1065,7 @@ class PollenPrognosCardEditor extends LitElement {
           integration === "peu"
         ) {
           const match = findLocationBySlug(peuDiscovery, cfgPeuLoc, {
-            slugExtractor: (eid) => {
-              if (!eid.startsWith("sensor.polleninformation_")) return null;
-              const rest = eid.substring("sensor.polleninformation_".length);
-              const m = rest.match(/^(.+?)_[^_]+$/);
-              return m ? m[1] : null;
-            },
+            slugExtractor: extractPeuLocationSlugFromEntityId,
           });
           if (match) {
             const [, loc] = match;

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -633,11 +633,12 @@ export function findLocationBySlug(discovery, slug, opts = {}) {
  * Resolve a location from a discovery result using a priority chain.
  *
  * Priority:
- *   1. Empty cfgLocation -> first location in the map (or null if empty).
+ *   1. Empty cfgLocation -> first location (numeric or lex sort, see body).
  *   2. Exact key match.
- *   3. Substring or exact match against location label.
+ *   3. Exact case-insensitive match against location label.
  *   4. findLocationBySlug fallback.
- *   5. null if nothing matches.
+ *   5. Fuzzy substring (case-insensitive) match against location label.
+ *   6. null if nothing matches.
  *
  * @param {{ locations: Map }} discovery    - Result from discoverEntitiesByDevice.
  * @param {string}             cfgLocation - Location value from card config.

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -289,3 +289,341 @@ export function filterSensorsPostFetch(sensors, cfg, availableSensors, hassState
 
   return filtered;
 }
+
+/**
+ * Discover HA entities grouped by device/location using a three-tier strategy.
+ *
+ * Tier 1 (device-based): Scan hass.devices for devices whose identifiers match
+ *   the given platform. Then collect entities from hass.entities whose device_id
+ *   belongs to one of those devices.
+ * Tier 2 (entity-registry): Scan hass.entities filtered by entry.platform.
+ *   Used when hass.devices is unavailable or tier 1 yields no results.
+ * Tier 3 (fallback): Scan hass.states using fallbackSelector or fallbackRegex.
+ *   Used when both tier 1 and tier 2 yield no results.
+ *
+ * @param {object} hass - Home Assistant state object.
+ * @param {object} opts
+ * @param {string|string[]} opts.platform
+ *   Platform name(s). Matched against entry.platform (tier 2) and against the
+ *   first element of each device.identifiers tuple (tier 1).
+ * @param {Function} opts.classify
+ *   (entityId, ctx) => string|null. Strict classifier used in tiers 2 and 3.
+ *   ctx = { state, entry?, device? }.
+ * @param {Function} [opts.classifyRelaxed]
+ *   (entityId, ctx) => string|null. Used only in tier 1. Defaults to opts.classify.
+ * @param {Function} [opts.isRelevant]
+ *   (entityId, ctx) => boolean. Pre-classification filter. Default: always true.
+ * @param {Function} [opts.excludeEntry]
+ *   (entry) => boolean. True means skip. Default: skip entries with entity_category.
+ * @param {Function} [opts.resolveLabel]
+ *   (ctx) => string. ctx includes { state, entry, device, entityId, tier, locationKey }.
+ *   Default: device.name_by_user || device.name || state.attributes.friendly_name || "Auto".
+ * @param {Function} [opts.resolveLocationKey]
+ *   (ctx) => string. Default: device.config_entries[0] || "default".
+ * @param {Function} [opts.onCollision]
+ *   (ctx, { existingKey, existingEntityId, locEntities }) => string|null.
+ *   Called when classify returns a key already present in the current location.
+ *   Return a new key or null to skip the entity.
+ * @param {RegExp|null} [opts.fallbackRegex]
+ *   Regex to filter hass.states keys in tier 3. Null disables tier 3 regex path.
+ * @param {Function} [opts.fallbackSelector]
+ *   (hass) => string[]. Alternative to fallbackRegex; overrides it when provided.
+ * @param {boolean} [opts.debug]
+ * @param {string}  [opts.logTag]
+ * @returns {{ locations: Map<string, { label: string, entities: Map<string, string>, deviceId?: string }>, tierUsed: 0|1|2|3 }}
+ */
+export function discoverEntitiesByDevice(hass, opts = {}) {
+  const {
+    platform,
+    classify,
+    classifyRelaxed,
+    isRelevant,
+    excludeEntry,
+    resolveLabel,
+    resolveLocationKey,
+    onCollision,
+    fallbackRegex,
+    fallbackSelector,
+    debug = false,
+  } = opts;
+
+  const platforms = Array.isArray(platform) ? platform : (platform ? [platform] : []);
+  const logTag = opts.logTag || (platforms.length > 0 ? platforms[0] : "discovery");
+  const classifyStrict = classify || (() => null);
+  const classifyTier1 = classifyRelaxed || classifyStrict;
+
+  const defaultExcludeEntry = (entry) => !!(entry !== null && entry !== undefined && entry.entity_category);
+  const shouldExclude = excludeEntry || defaultExcludeEntry;
+
+  const defaultIsRelevant = () => true;
+  const checkRelevant = isRelevant || defaultIsRelevant;
+
+  const defaultResolveLabel = (ctx) => {
+    const { device, state } = ctx;
+    if (device !== null && device !== undefined && device.name_by_user) return device.name_by_user;
+    if (device !== null && device !== undefined && device.name) return device.name;
+    if (state !== null && state !== undefined && state.attributes !== null && state.attributes !== undefined) {
+      if (state.attributes.friendly_name) return state.attributes.friendly_name;
+    }
+    return "Auto";
+  };
+  const getLabel = resolveLabel || defaultResolveLabel;
+
+  const defaultResolveLocationKey = (ctx) => {
+    const { device } = ctx;
+    if (device !== null && device !== undefined) {
+      const entries = device.config_entries;
+      if (Array.isArray(entries) && entries.length > 0) return entries[0];
+    }
+    return "default";
+  };
+  const getLocationKey = resolveLocationKey || defaultResolveLocationKey;
+
+  const locations = new Map();
+
+  /**
+   * Add a single classified entity to locations.
+   * @param {string}      eid
+   * @param {string|null} allergenKey
+   * @param {object}      ctx          - { state, entry, device, entityId, tier }
+   */
+  const addEntity = (eid, allergenKey, ctx) => {
+    if (allergenKey === null || allergenKey === undefined) return;
+
+    const locationKey = getLocationKey({ ...ctx, locationKey: undefined });
+    const enrichedCtx = { ...ctx, locationKey };
+
+    if (!locations.has(locationKey)) {
+      const label = getLabel(enrichedCtx);
+      const loc = { label, entities: new Map() };
+      if (ctx.device !== null && ctx.device !== undefined && ctx.deviceId !== null && ctx.deviceId !== undefined) {
+        loc.deviceId = ctx.deviceId;
+      }
+      locations.set(locationKey, loc);
+    }
+
+    const locEntities = locations.get(locationKey).entities;
+    if (locEntities.has(allergenKey)) {
+      if (onCollision) {
+        const newKey = onCollision(enrichedCtx, {
+          existingKey: allergenKey,
+          existingEntityId: locEntities.get(allergenKey),
+          locEntities,
+        });
+        if (newKey !== null && newKey !== undefined) {
+          locEntities.set(newKey, eid);
+        }
+      }
+      // If no onCollision or it returned null, skip silently
+    } else {
+      locEntities.set(allergenKey, eid);
+    }
+  };
+
+  // --- Tier 1: Device-based discovery ---
+  if (hass !== null && hass !== undefined && hass.devices !== null && hass.devices !== undefined && hass.entities !== null && hass.entities !== undefined) {
+    // Find devices whose identifiers contain a matching platform as first element
+    const matchingDeviceIds = new Set();
+    for (const [devId, dev] of Object.entries(hass.devices)) {
+      if (dev === null || dev === undefined) continue;
+      const identifiers = dev.identifiers;
+      if (!Array.isArray(identifiers)) continue;
+      for (const tuple of identifiers) {
+        if (Array.isArray(tuple) && platforms.includes(tuple[0])) {
+          matchingDeviceIds.add(devId);
+          break;
+        }
+      }
+    }
+
+    if (matchingDeviceIds.size > 0) {
+      if (debug) console.debug(`[${logTag}] Discovery tier 1 (device-based): found`, matchingDeviceIds.size, "devices");
+
+      for (const [eid, entry] of Object.entries(hass.entities)) {
+        if (entry === null || entry === undefined) continue;
+        if (!matchingDeviceIds.has(entry.device_id)) continue;
+        if (shouldExclude(entry)) continue;
+
+        const state = hass.states !== null && hass.states !== undefined ? hass.states[eid] : undefined;
+        if (state === null || state === undefined) continue;
+
+        const deviceId = entry.device_id;
+        const device = hass.devices[deviceId];
+        const ctx = { state, entry, device, deviceId, entityId: eid, tier: 1 };
+
+        if (!checkRelevant(eid, ctx)) continue;
+
+        const allergenKey = classifyTier1(eid, ctx);
+        addEntity(eid, allergenKey, ctx);
+      }
+
+      if (locations.size > 0) {
+        if (debug) {
+          console.debug(`[${logTag}] Discovery tier 1 result:`, locations.size, "locations");
+          for (const [locId, loc] of locations) {
+            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+          }
+        }
+        return { locations, tierUsed: 1 };
+      }
+    }
+  }
+
+  // --- Tier 2: Entity-registry scan ---
+  if (hass !== null && hass !== undefined && hass.entities !== null && hass.entities !== undefined) {
+    for (const [eid, entry] of Object.entries(hass.entities)) {
+      if (entry === null || entry === undefined) continue;
+      if (!platforms.includes(entry.platform)) continue;
+      if (shouldExclude(entry)) continue;
+
+      const state = hass.states !== null && hass.states !== undefined ? hass.states[eid] : undefined;
+      if (state === null || state === undefined) continue;
+
+      const deviceId = entry.device_id;
+      const device = (deviceId !== null && deviceId !== undefined && hass.devices !== null && hass.devices !== undefined)
+        ? hass.devices[deviceId]
+        : undefined;
+      const ctx = { state, entry, device, deviceId, entityId: eid, tier: 2 };
+
+      if (!checkRelevant(eid, ctx)) continue;
+
+      const allergenKey = classifyStrict(eid, ctx);
+      addEntity(eid, allergenKey, ctx);
+    }
+
+    if (locations.size > 0) {
+      if (debug) {
+        console.debug(`[${logTag}] Discovery tier 2 result:`, locations.size, "locations");
+        for (const [locId, loc] of locations) {
+          console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+        }
+      }
+      return { locations, tierUsed: 2 };
+    }
+  }
+
+  // --- Tier 3: Fallback (selector or regex) ---
+  if (hass !== null && hass !== undefined && hass.states !== null && hass.states !== undefined) {
+    let candidates = null;
+
+    if (typeof fallbackSelector === "function") {
+      candidates = fallbackSelector(hass);
+    } else if (fallbackRegex instanceof RegExp) {
+      candidates = Object.keys(hass.states).filter((eid) => fallbackRegex.test(eid));
+    }
+
+    if (candidates !== null && candidates.length > 0) {
+      if (debug) console.debug(`[${logTag}] Discovery tier 3 (fallback): found`, candidates.length, "candidates");
+
+      for (const eid of candidates) {
+        const state = hass.states[eid];
+        if (state === null || state === undefined) continue;
+
+        const ctx = { state, entry: undefined, device: undefined, deviceId: undefined, entityId: eid, tier: 3 };
+
+        if (!checkRelevant(eid, ctx)) continue;
+
+        const allergenKey = classifyStrict(eid, ctx);
+        addEntity(eid, allergenKey, ctx);
+      }
+    }
+  }
+
+  if (debug) {
+    console.debug(`[${logTag}] Discovery final result:`, locations.size, "locations");
+    for (const [locId, loc] of locations) {
+      console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
+    }
+  }
+
+  return { locations, tierUsed: locations.size > 0 ? 3 : 0 };
+}
+
+/**
+ * Find a location in a discovery result by matching entity IDs against a slug.
+ *
+ * Checks each entity ID using an optional slugExtractor, and also checks
+ * suffix variants like `_{slug}` and `_{slug}_j_1` (suffix extras).
+ *
+ * @param {{ locations: Map }} discovery       - Result from discoverEntitiesByDevice.
+ * @param {string}             slug            - Location slug to match against.
+ * @param {object}             [opts]
+ * @param {Function}           [opts.slugExtractor] - (entityId) => string|null. Custom slug extractor.
+ * @param {string[]}           [opts.suffixExtras]  - Additional suffixes to test. Default: ["", "_j_1"].
+ * @returns {[string, object]|null} - [locationKey, location] or null.
+ */
+export function findLocationBySlug(discovery, slug, opts = {}) {
+  if (slug === null || slug === undefined || !slug) return null;
+  if (discovery === null || discovery === undefined || !discovery.locations) return null;
+
+  const { slugExtractor, suffixExtras = ["", "_j_1"] } = opts;
+  const needle = String(slug).toLowerCase();
+  const suffixVariants = suffixExtras.map((s) => `_${needle}${s}`);
+
+  for (const [key, loc] of discovery.locations) {
+    for (const eid of loc.entities.values()) {
+      const lid = String(eid).toLowerCase();
+
+      // Custom extractor path
+      if (typeof slugExtractor === "function") {
+        const extracted = slugExtractor(eid);
+        if (extracted !== null && extracted !== undefined && String(extracted).toLowerCase() === needle) {
+          return [key, loc];
+        }
+      }
+
+      // Suffix variant path
+      for (const variant of suffixVariants) {
+        if (lid.endsWith(variant)) return [key, loc];
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a location from a discovery result using a priority chain.
+ *
+ * Priority:
+ *   1. Empty cfgLocation -> first location in the map (or null if empty).
+ *   2. Exact key match.
+ *   3. Substring or exact match against location label.
+ *   4. findLocationBySlug fallback.
+ *   5. null if nothing matches.
+ *
+ * @param {{ locations: Map }} discovery    - Result from discoverEntitiesByDevice.
+ * @param {string}             cfgLocation - Location value from card config.
+ * @param {object}             [opts]
+ * @param {Function}           [opts.slugExtractor] - Passed to findLocationBySlug.
+ * @returns {[string, object]|null} - [locationKey, location] or null.
+ */
+export function resolveLocationByKey(discovery, cfgLocation, opts = {}) {
+  if (discovery === null || discovery === undefined || !discovery.locations) return null;
+  const locs = discovery.locations;
+
+  // 1. Empty location -> first entry
+  if (!cfgLocation) {
+    const first = locs.entries().next();
+    return first.done ? null : [first.value[0], first.value[1]];
+  }
+
+  // 2. Exact key match
+  if (locs.has(cfgLocation)) {
+    return [cfgLocation, locs.get(cfgLocation)];
+  }
+
+  // 3. Label substring / exact match
+  for (const [key, loc] of locs) {
+    if (loc.label && (loc.label === cfgLocation || loc.label.includes(cfgLocation))) {
+      return [key, loc];
+    }
+  }
+
+  // 4. Slug fallback
+  const slugMatch = findLocationBySlug(discovery, cfgLocation, opts);
+  if (slugMatch !== null) return slugMatch;
+
+  // 5. No match
+  return null;
+}

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -3,7 +3,21 @@
 import { t, detectLang } from "../i18n.js";
 import { toCanonicalAllergenKey } from "../constants.js";
 import { normalize, normalizeDWD } from "./normalize.js";
-import { isConfigEntryId } from "./silam.js";
+
+/**
+ * Test if a value is a Home Assistant config_entry_id (ULID-format string,
+ * 26 Crockford base32 characters). Used by adapters to distinguish between
+ * new-style config_entry_id location keys and legacy slug configs.
+ *
+ * Defined here (rather than in silam.js) to avoid a circular dependency,
+ * since silam.js also imports discoverEntitiesByDevice from this module.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isConfigEntryId(value) {
+  return typeof value === "string" && /^[0-9A-Z]{26}$/i.test(value);
+}
 
 /**
  * Clamp a sensor value to a valid level range.
@@ -398,17 +412,31 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
       locations.set(locationKey, { label, entities: new Map() });
     }
 
+    const location = locations.get(locationKey);
+
     // Set/backfill deviceId whenever ctx provides one and the location is
     // still missing it. Backfill handles the case where the first entity in a
     // bucket had no deviceId but a later entity does. Downstream consumers
     // (e.g. SILAM weather-entity postprocess) rely on this field.
-    const location = locations.get(locationKey);
+    //
+    // Recompute the label when device context first becomes available: the
+    // first entity in this bucket may have produced a fallback label (e.g.
+    // friendly_name or "Auto") because it lacked device info; now that a
+    // later entity has the device, prefer the richer resolver output.
     if (
       (location.deviceId === null || location.deviceId === undefined) &&
       ctx.deviceId !== null &&
       ctx.deviceId !== undefined
     ) {
       location.deviceId = ctx.deviceId;
+      const updatedLabel = getLabel(enrichedCtx);
+      if (
+        updatedLabel !== null &&
+        updatedLabel !== undefined &&
+        updatedLabel !== location.label
+      ) {
+        location.label = updatedLabel;
+      }
     }
 
     const locEntities = location.entities;
@@ -419,11 +447,17 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
           existingEntityId: locEntities.get(allergenKey),
           locEntities,
         });
-        if (newKey !== null && newKey !== undefined) {
+        // Only accept a non-null new key that is not already in use. Overwriting
+        // would silently drop an existing sensor mapping.
+        if (
+          newKey !== null &&
+          newKey !== undefined &&
+          !locEntities.has(newKey)
+        ) {
           locEntities.set(newKey, eid);
         }
       }
-      // If no onCollision or it returned null, skip silently
+      // If no onCollision, it returned null, or the returned key collides, skip.
     } else {
       locEntities.set(allergenKey, eid);
     }
@@ -627,9 +661,14 @@ export function resolveLocationByKey(discovery, cfgLocation, opts = {}) {
     return [cfgLocation, locs.get(cfgLocation)];
   }
 
-  // 3. Label substring / exact match
+  // 3. Label substring / exact match (case-insensitive; mirrors SILAM's
+  // legacy resolveDiscoveredLocation so user-entered labels with different
+  // casing still resolve).
+  const cfgLower = String(cfgLocation).toLowerCase();
   for (const [key, loc] of locs) {
-    if (loc.label && (loc.label === cfgLocation || loc.label.includes(cfgLocation))) {
+    if (!loc.label) continue;
+    const labelLower = String(loc.label).toLowerCase();
+    if (labelLower === cfgLower || labelLower.includes(cfgLower)) {
       return [key, loc];
     }
   }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -648,35 +648,52 @@ export function resolveLocationByKey(discovery, cfgLocation, opts = {}) {
   // 1. Empty location -> pick first deterministically. Enumeration order of
   // hass.devices / hass.entities is insertion-order and stable within a
   // session, but can differ across HA restarts or integration reinstalls.
-  // Sort by locationKey so auto-select is reproducible.
+  // Sort numerically for all-digit keys (DWD region IDs), lexicographically
+  // otherwise, so auto-select is reproducible and intuitive.
   if (!cfgLocation) {
     if (locs.size === 0) return null;
-    const sortedKeys = Array.from(locs.keys()).sort();
+    const keys = Array.from(locs.keys());
+    const allNumeric = keys.every((k) => /^\d+$/.test(String(k)));
+    const sortedKeys = allNumeric
+      ? keys.sort((a, b) => Number(a) - Number(b))
+      : keys.sort();
     const key = sortedKeys[0];
     return [key, locs.get(key)];
   }
 
-  // 2. Exact key match
+  // 2. Exact key match.
   if (locs.has(cfgLocation)) {
     return [cfgLocation, locs.get(cfgLocation)];
   }
 
-  // 3. Label substring / exact match (case-insensitive; mirrors SILAM's
-  // legacy resolveDiscoveredLocation so user-entered labels with different
-  // casing still resolve).
+  // 3. Exact case-insensitive label equality. Quick, precise path for user
+  // configs that mirror the device name ("Hamburg" == label "Hamburg").
   const cfgLower = String(cfgLocation).toLowerCase();
   for (const [key, loc] of locs) {
     if (!loc.label) continue;
-    const labelLower = String(loc.label).toLowerCase();
-    if (labelLower === cfgLower || labelLower.includes(cfgLower)) {
+    if (String(loc.label).toLowerCase() === cfgLower) {
       return [key, loc];
     }
   }
 
-  // 4. Slug fallback
+  // 4. Slug fallback. Respects entity-ID structure via slugExtractor, so
+  // short/numeric configs like DWD region_id "50" resolve to entity suffix
+  // "_50" without being confused by fuzzy label matching.
   const slugMatch = findLocationBySlug(discovery, cfgLocation, opts);
   if (slugMatch !== null) return slugMatch;
 
-  // 5. No match
+  // 5. Fuzzy label includes (last resort). Kept so configs that were a
+  // substring of a legacy friendly_name still resolve when no slugExtractor
+  // is supplied. Placed after the slug match so specific entity-structure
+  // resolution wins over loose substring matches (e.g. region_id "50" must
+  // not bind to a label containing "150").
+  for (const [key, loc] of locs) {
+    if (!loc.label) continue;
+    if (String(loc.label).toLowerCase().includes(cfgLower)) {
+      return [key, loc];
+    }
+  }
+
+  // 6. No match.
   return null;
 }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -396,7 +396,10 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
     if (!locations.has(locationKey)) {
       const label = getLabel(enrichedCtx);
       const loc = { label, entities: new Map() };
-      if (ctx.device !== null && ctx.device !== undefined && ctx.deviceId !== null && ctx.deviceId !== undefined) {
+      // Set deviceId whenever we have one, even if hass.devices lookup failed
+      // (tier 2 can have entry.device_id populated without hass.devices). Downstream
+      // consumers (e.g. SILAM weather-entity postprocess) rely on this.
+      if (ctx.deviceId !== null && ctx.deviceId !== undefined) {
         loc.deviceId = ctx.deviceId;
       }
       locations.set(locationKey, loc);
@@ -602,10 +605,15 @@ export function resolveLocationByKey(discovery, cfgLocation, opts = {}) {
   if (discovery === null || discovery === undefined || !discovery.locations) return null;
   const locs = discovery.locations;
 
-  // 1. Empty location -> first entry
+  // 1. Empty location -> pick first deterministically. Enumeration order of
+  // hass.devices / hass.entities is insertion-order and stable within a
+  // session, but can differ across HA restarts or integration reinstalls.
+  // Sort by locationKey so auto-select is reproducible.
   if (!cfgLocation) {
-    const first = locs.entries().next();
-    return first.done ? null : [first.value[0], first.value[1]];
+    if (locs.size === 0) return null;
+    const sortedKeys = Array.from(locs.keys()).sort();
+    const key = sortedKeys[0];
+    return [key, locs.get(key)];
   }
 
   // 2. Exact key match

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -555,7 +555,11 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
     let candidates = null;
 
     if (typeof fallbackSelector === "function") {
-      candidates = fallbackSelector(hass);
+      const raw = fallbackSelector(hass);
+      // Be permissive: a misbehaving selector returning null/undefined or a
+      // non-array shouldn't crash discovery. Treat anything non-array as no
+      // candidates.
+      candidates = Array.isArray(raw) ? raw : null;
     } else if (fallbackRegex instanceof RegExp) {
       candidates = Object.keys(hass.states).filter((eid) => fallbackRegex.test(eid));
     }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -395,17 +395,23 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
 
     if (!locations.has(locationKey)) {
       const label = getLabel(enrichedCtx);
-      const loc = { label, entities: new Map() };
-      // Set deviceId whenever we have one, even if hass.devices lookup failed
-      // (tier 2 can have entry.device_id populated without hass.devices). Downstream
-      // consumers (e.g. SILAM weather-entity postprocess) rely on this.
-      if (ctx.deviceId !== null && ctx.deviceId !== undefined) {
-        loc.deviceId = ctx.deviceId;
-      }
-      locations.set(locationKey, loc);
+      locations.set(locationKey, { label, entities: new Map() });
     }
 
-    const locEntities = locations.get(locationKey).entities;
+    // Set/backfill deviceId whenever ctx provides one and the location is
+    // still missing it. Backfill handles the case where the first entity in a
+    // bucket had no deviceId but a later entity does. Downstream consumers
+    // (e.g. SILAM weather-entity postprocess) rely on this field.
+    const location = locations.get(locationKey);
+    if (
+      (location.deviceId === null || location.deviceId === undefined) &&
+      ctx.deviceId !== null &&
+      ctx.deviceId !== undefined
+    ) {
+      location.deviceId = ctx.deviceId;
+    }
+
+    const locEntities = location.entities;
     if (locEntities.has(allergenKey)) {
       if (onCollision) {
         const newKey = onCollision(enrichedCtx, {

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -6,8 +6,12 @@ import { normalize, normalizeDWD } from "./normalize.js";
 
 /**
  * Test if a value is a Home Assistant config_entry_id (ULID-format string,
- * 26 Crockford base32 characters). Used by adapters to distinguish between
- * new-style config_entry_id location keys and legacy slug configs.
+ * 26 Crockford base32 characters). Crockford base32 excludes I, L, O, U to
+ * avoid ambiguity with 1/0 and offensive substrings, so the regex rejects
+ * those letters as well as the literal characters.
+ *
+ * Used by adapters to distinguish between new-style config_entry_id location
+ * keys and legacy slug configs.
  *
  * Defined here (rather than in silam.js) to avoid a circular dependency,
  * since silam.js also imports discoverEntitiesByDevice from this module.
@@ -16,7 +20,7 @@ import { normalize, normalizeDWD } from "./normalize.js";
  * @returns {boolean}
  */
 export function isConfigEntryId(value) {
-  return typeof value === "string" && /^[0-9A-Z]{26}$/i.test(value);
+  return typeof value === "string" && /^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$/i.test(value);
 }
 
 /**

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -6,9 +6,10 @@ import { normalize, normalizeDWD } from "./normalize.js";
 
 /**
  * Test if a value is a Home Assistant config_entry_id (ULID-format string,
- * 26 Crockford base32 characters). Crockford base32 excludes I, L, O, U to
- * avoid ambiguity with 1/0 and offensive substrings, so the regex rejects
- * those letters as well as the literal characters.
+ * 26 Crockford base32 characters). Crockford base32 excludes I, L, O, and U
+ * to avoid ambiguity with 1/0 and offensive substrings, so this regex does
+ * not allow those letters; because it uses the /i flag, that exclusion
+ * applies to both uppercase and lowercase input.
  *
  * Used by adapters to distinguish between new-style config_entry_id location
  * keys and legacy slug configs.

--- a/src/utils/silam.js
+++ b/src/utils/silam.js
@@ -1,5 +1,8 @@
 import silamAllergenMap from "../adapters/silam_allergen_map.json" assert { type: "json" };
-import { discoverEntitiesByDevice } from "./adapter-helpers.js";
+import { discoverEntitiesByDevice, isConfigEntryId } from "./adapter-helpers.js";
+
+// Re-export so editor and other callers can keep their silam.js import path.
+export { isConfigEntryId };
 
 // Skapa dynamisk reverse-map: masterAllergen => slug för rätt språk
 export function getSilamReverseMap(lang) {
@@ -10,11 +13,6 @@ export function getSilamReverseMap(lang) {
     reverse[master] = slug;
   }
   return reverse;
-}
-
-/** Test if a config.location value is a config_entry_id (ULID format). */
-export function isConfigEntryId(value) {
-  return typeof value === "string" && /^[0-9A-Z]{26}$/i.test(value);
 }
 
 /**

--- a/src/utils/silam.js
+++ b/src/utils/silam.js
@@ -53,6 +53,17 @@ function classifySilamEntity(eid, { entry }) {
  * entity_id starts with "weather.". They are excluded from the sensor map and
  * attached as weatherEntity per location instead.
  */
+/**
+ * Strip the generic "SILAM Pollen" prefix (with optional separators) from a
+ * device name so downstream consumers (editor dropdown, card title) get a
+ * clean location label like "Karis" rather than "SILAM Pollen - Karis".
+ */
+function stripSilamPrefix(name) {
+  if (typeof name !== "string") return name;
+  const stripped = name.replace(/^\s*silam\s*pollen\b[\s:\-–—]*/i, "").trim();
+  return stripped || name;
+}
+
 export function discoverSilamSensors(hass, debug = false) {
   const result = { locations: new Map() };
   if (!hass?.entities) return result;
@@ -63,6 +74,14 @@ export function discoverSilamSensors(hass, debug = false) {
     platform: "silam_pollen",
     classify: classifySilamEntity,
     classifyRelaxed: classifySilamEntity,
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      if (ctx.device?.name) return stripSilamPrefix(ctx.device.name);
+      if (ctx.state?.attributes?.friendly_name) {
+        return stripSilamPrefix(ctx.state.attributes.friendly_name);
+      }
+      return "Auto";
+    },
     fallbackRegex: null,
     debug,
     logTag: "SILAM",
@@ -85,7 +104,10 @@ export function discoverSilamSensors(hass, debug = false) {
         if (!deviceInfoMap.has(deviceId)) {
           const device = hass.devices?.[deviceId];
           const configEntryId = device?.config_entries?.[0] ?? "default";
-          const label = device?.name_by_user || device?.name || "Auto";
+          const label =
+            device?.name_by_user ||
+            (device?.name ? stripSilamPrefix(device.name) : null) ||
+            "Auto";
           deviceInfoMap.set(deviceId, { configEntryId, label });
         }
       }

--- a/src/utils/silam.js
+++ b/src/utils/silam.js
@@ -1,4 +1,5 @@
 import silamAllergenMap from "../adapters/silam_allergen_map.json" assert { type: "json" };
+import { discoverEntitiesByDevice } from "./adapter-helpers.js";
 
 // Skapa dynamisk reverse-map: masterAllergen => slug för rätt språk
 export function getSilamReverseMap(lang) {
@@ -17,75 +18,110 @@ export function isConfigEntryId(value) {
 }
 
 /**
+ * Classify a SILAM entity by its translation_key.
+ * Returns the canonical master allergen key, or null for non-allergen entities
+ * (weather/forecast entities return null so they are excluded from sensors).
+ */
+function classifySilamEntity(eid, { entry }) {
+  if (!entry) return null;
+  // Weather/forecast entities are handled as a separate postprocess step
+  if (eid.startsWith("weather.") || entry.translation_key === "forecast") return null;
+  const tk = entry.translation_key;
+  if (!tk) return null;
+  // Map through all language mappings to find the master allergen key
+  for (const mapping of Object.values(silamAllergenMap.mapping)) {
+    if (mapping[tk]) return mapping[tk];
+  }
+  // translation_key not found in any language mapping
+  return null;
+}
+
+/**
  * Discover all SILAM sensors using hass.entities (entity registry).
  *
  * Returns: { locations: Map<configEntryId, { label, weatherEntity, sensors: Map<allergenKey, entityId> }> }
  *
- * Primary path: hass.entities → filter platform === "silam_pollen", no entity_category
- * Groups entities by device → config_entry_id, identifies weather entities via
- * translation_key === "forecast" and allergen sensors via translation_key.
+ * Uses discoverEntitiesByDevice with tier 1 (device identifier scan) active.
+ * The SILAM integration uses platform "silam_pollen" in both entry.platform and
+ * device identifiers, enabling robust device-based grouping.
+ *
+ * Weather entities are resolved as a postprocess step after sensor discovery,
+ * by searching for entries with translation_key === "forecast" on the same device.
  *
  * Returns empty map if hass.entities is unavailable (older HA) — callers
- * should fall back to regex-based detection.
+ * should fall back to regex-based detection via findSilamWeatherEntity.
+ *
+ * Quirk: SILAM weather entities have translation_key === "forecast" and their
+ * entity_id starts with "weather.". They are excluded from the sensor map and
+ * attached as weatherEntity per location instead.
  */
 export function discoverSilamSensors(hass, debug = false) {
   const result = { locations: new Map() };
   if (!hass?.entities) return result;
 
-  // Collect candidate entity IDs from entity registry
-  const candidates = Object.entries(hass.entities).filter(
-    ([, entry]) => entry.platform === "silam_pollen" && !entry.entity_category,
-  );
+  // Run shared discovery for allergen sensors (weather entities classified as null → skipped).
+  // Tier 3 is disabled (fallbackRegex: null) — SILAM sensors always have entity registry entries.
+  const { locations: rawLocations } = discoverEntitiesByDevice(hass, {
+    platform: "silam_pollen",
+    classify: classifySilamEntity,
+    classifyRelaxed: classifySilamEntity,
+    fallbackRegex: null,
+    debug,
+    logTag: "SILAM",
+  });
 
-  if (!candidates.length) return result;
-  if (debug)
-    console.debug(
-      "[SILAM] Discovery: using hass.entities, found",
-      candidates.length,
-      "candidates",
-    );
-
-  // Group by config_entry_id (via device)
-  for (const [eid, entry] of candidates) {
-    // Resolve config_entry_id via device
-    let configEntryId = "default";
-    const deviceId = entry.device_id;
-    if (deviceId && hass.devices?.[deviceId]?.config_entries?.length) {
-      configEntryId = hass.devices[deviceId].config_entries[0];
-    }
-
-    // Get or create location entry
-    if (!result.locations.has(configEntryId)) {
-      let label = "Auto";
-      if (deviceId && hass.devices?.[deviceId]) {
-        const device = hass.devices[deviceId];
-        label = device.name_by_user || device.name || label;
-      }
-      result.locations.set(configEntryId, {
-        label,
-        weatherEntity: null,
-        sensors: new Map(),
-      });
-    }
-
-    const loc = result.locations.get(configEntryId);
-    const translationKey = entry.translation_key;
-
-    if (eid.startsWith("weather.") || translationKey === "forecast") {
-      // Weather entity
-      loc.weatherEntity = eid;
-    } else if (translationKey) {
-      // Allergen sensor — translation_key is the canonical allergen name
-      // Map through silamAllergenMap to get master key
-      let masterKey = translationKey;
-      for (const mapping of Object.values(silamAllergenMap.mapping)) {
-        if (mapping[translationKey]) {
-          masterKey = mapping[translationKey];
-          break;
+  // Build a lookup: deviceId -> weatherEntityId for the postprocess step.
+  // Also collect device metadata for locations that only have a weather entity
+  // (e.g. the user enabled no allergen sensors in the SILAM integration config).
+  //
+  // Identifies weather entities by eid starting with "weather." OR by
+  // translation_key === "forecast" (both are reliable in current HA versions).
+  const deviceWeatherMap = new Map(); // deviceId -> weatherEntityId
+  const deviceInfoMap = new Map();    // deviceId -> { configEntryId, label }
+  for (const [eid, entry] of Object.entries(hass.entities)) {
+    if (entry.platform !== "silam_pollen") continue;
+    if (eid.startsWith("weather.") || entry.translation_key === "forecast") {
+      const deviceId = entry.device_id;
+      if (deviceId) {
+        deviceWeatherMap.set(deviceId, eid);
+        if (!deviceInfoMap.has(deviceId)) {
+          const device = hass.devices?.[deviceId];
+          const configEntryId = device?.config_entries?.[0] ?? "default";
+          const label = device?.name_by_user || device?.name || "Auto";
+          deviceInfoMap.set(deviceId, { configEntryId, label });
         }
       }
-      loc.sensors.set(masterKey, eid);
     }
+  }
+
+  if (rawLocations.size === 0 && deviceWeatherMap.size === 0) return result;
+
+  // Convert discoverEntitiesByDevice result to SILAM's expected format:
+  //   { label, weatherEntity, sensors: Map<allergenKey, entityId> }
+  for (const [locKey, loc] of rawLocations) {
+    const weatherEntity = loc.deviceId
+      ? (deviceWeatherMap.get(loc.deviceId) || null)
+      : null;
+    result.locations.set(locKey, {
+      label: loc.label,
+      weatherEntity,
+      sensors: loc.entities,
+    });
+  }
+
+  // Add locations for devices that only have a weather entity (no allergen sensors).
+  // This ensures the card can still show the allergy_risk index for such setups.
+  for (const [deviceId, weatherEntityId] of deviceWeatherMap) {
+    const info = deviceInfoMap.get(deviceId);
+    if (!info) continue;
+    const { configEntryId, label } = info;
+    // Skip if already present from rawLocations
+    if (result.locations.has(configEntryId)) continue;
+    result.locations.set(configEntryId, {
+      label,
+      weatherEntity: weatherEntityId,
+      sensors: new Map(),
+    });
   }
 
   if (debug) {

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -316,10 +316,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
     const result = discoverDwdSensors(hass);
 
     const [, loc] = [...result.locations.entries()][0];
-    // Region 50 = "Brandenburg und Berlin" in DWD_REGIONS. Label is prefixed
-    // with the region ID so tier-3 labels remain unique for non-bijective
-    // entries (e.g. regions 11 and 12 share a name).
-    expect(loc.label).toBe("50 Brandenburg und Berlin");
+    expect(loc.label).toBe("Brandenburg und Berlin");
   });
 
   it("region label beats generic device name", () => {
@@ -351,7 +348,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
 
     const result = discoverDwdSensors(hass);
     const [, loc] = [...result.locations.entries()][0];
-    expect(loc.label).toBe("50 Brandenburg und Berlin");
+    expect(loc.label).toBe("Brandenburg und Berlin");
   });
 
   it("user-customized device name wins over region-derived label", () => {

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { fetchForecast, stubConfigDWD } from "../../src/adapters/dwd.js";
-import { createHass, createDWDSensor, assertSensorShape } from "../helpers.js";
+import { fetchForecast, stubConfigDWD, discoverDwdSensors, resolveEntityIds } from "../../src/adapters/dwd.js";
+import { createHass, createDWDSensor, assertSensorShape, assertDiscoveryShape, createHassWithRegistry } from "../helpers.js";
 
 function makeConfig(overrides = {}) {
   return { ...stubConfigDWD, ...overrides };
@@ -186,5 +186,137 @@ describe("DWD adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result[0].entity_id).toBe("sensor.pollenflug_erle_50");
+  });
+});
+
+describe("DWD adapter: discoverDwdSensors", () => {
+  it("returns empty discovery for null hass", () => {
+    const result = discoverDwdSensors(null);
+    assertDiscoveryShape(result);
+    expect(result.locations.size).toBe(0);
+    expect(result.tierUsed).toBe(0);
+  });
+
+  it("tier 3 (fallback): discovers sensors via regex when no registry is available", () => {
+    const hass = makeHass("50", {
+      erle: [1, 0, 0],
+      birke: [2, 1, 0],
+      graeser: [0, 1, 0],
+    });
+
+    const result = discoverDwdSensors(hass);
+
+    assertDiscoveryShape(result);
+    expect(result.tierUsed).toBe(3);
+    expect(result.locations.size).toBe(1);
+
+    // In tier 3, the location key is the region ID string
+    const [locKey, loc] = [...result.locations.entries()][0];
+    expect(locKey).toBe("50");
+    expect(loc.entities.has("erle")).toBe(true);
+    expect(loc.entities.has("birke")).toBe(true);
+    expect(loc.entities.has("graeser")).toBe(true);
+    expect(loc.entities.get("erle")).toBe("sensor.pollenflug_erle_50");
+  });
+
+  it("tier 2 (entity registry): discovers sensors when platform matches", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollenflug_erle_50",
+        state: "1",
+        attributes: {
+          state_tomorrow: "0",
+          state_in_2_days: "0",
+          state_today_desc: "",
+          state_tomorrow_desc: "",
+          state_in_2_days_desc: "",
+        },
+        deviceId: "dev_dwd_50",
+        platform: "dwd_pollenflug",
+        deviceMeta: {
+          identifiers: [],
+          configEntries: ["cfg_dwd_50"],
+          name: "DWD Region 50",
+        },
+      },
+      {
+        entityId: "sensor.pollenflug_birke_50",
+        state: "2",
+        attributes: {
+          state_tomorrow: "1",
+          state_in_2_days: "0",
+          state_today_desc: "",
+          state_tomorrow_desc: "",
+          state_in_2_days_desc: "",
+        },
+        deviceId: "dev_dwd_50",
+        platform: "dwd_pollenflug",
+      },
+    ]);
+
+    const result = discoverDwdSensors(hass);
+
+    assertDiscoveryShape(result);
+    expect(result.tierUsed).toBe(2);
+    expect(result.locations.size).toBe(1);
+
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.entities.has("erle")).toBe(true);
+    expect(loc.entities.has("birke")).toBe(true);
+    expect(loc.entities.get("erle")).toBe("sensor.pollenflug_erle_50");
+  });
+
+  it("tier 3: multi-region — two regions, resolveEntityIds picks correct one via region_id", () => {
+    // Simulate two DWD regions (50 and 91) in hass.states
+    const states = {
+      "sensor.pollenflug_erle_50": createDWDSensor(1, 0, 0),
+      "sensor.pollenflug_birke_50": createDWDSensor(2, 1, 0),
+      "sensor.pollenflug_erle_91": createDWDSensor(3, 2, 1),
+      "sensor.pollenflug_birke_91": createDWDSensor(0, 0, 0),
+    };
+    const hass = createHass(states, { language: "de" });
+
+    // Config selects region 91
+    const config = makeConfig({
+      region_id: "91",
+      allergens: ["erle", "birke"],
+      pollen_threshold: 0,
+    });
+
+    const entityMap = resolveEntityIds(config, hass);
+
+    // Should resolve to region 91 entities
+    expect(entityMap.get("erle")).toBe("sensor.pollenflug_erle_91");
+    expect(entityMap.get("birke")).toBe("sensor.pollenflug_birke_91");
+  });
+
+  it("tier 3: resolveEntityIds auto-selects single region when region_id is empty", () => {
+    const states = {
+      "sensor.pollenflug_erle_50": createDWDSensor(1, 0, 0),
+      "sensor.pollenflug_birke_50": createDWDSensor(2, 1, 0),
+    };
+    const hass = createHass(states, { language: "de" });
+
+    const config = makeConfig({
+      region_id: "",
+      allergens: ["erle", "birke"],
+      pollen_threshold: 0,
+    });
+
+    const entityMap = resolveEntityIds(config, hass);
+
+    // With a single region and empty region_id, resolveLocationByKey returns first location
+    expect(entityMap.get("erle")).toBe("sensor.pollenflug_erle_50");
+    expect(entityMap.get("birke")).toBe("sensor.pollenflug_birke_50");
+  });
+
+  it("region label falls back to DWD_REGIONS lookup (tier 3)", () => {
+    const hass = makeHass("50", { erle: [1, 0, 0] });
+
+    const result = discoverDwdSensors(hass);
+
+    const [, loc] = [...result.locations.entries()][0];
+    // Region 50 = "Brandenburg und Berlin" in DWD_REGIONS
+    expect(loc.label).toBe("Brandenburg und Berlin");
   });
 });

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -351,6 +351,55 @@ describe("DWD adapter: discoverDwdSensors", () => {
     expect(loc.label).toBe("Brandenburg und Berlin");
   });
 
+  it("duplicate region labels get disambiguated with region ID suffix", () => {
+    // Regions 121-124 all map to "Bayern" in DWD_REGIONS. When multiple
+    // appear in discovery, editor/card must be able to distinguish them.
+    const hass = {
+      states: {
+        "sensor.pollenflug_erle_121": { state: "1", attributes: {} },
+        "sensor.pollenflug_erle_122": { state: "0", attributes: {} },
+      },
+      entities: {
+        "sensor.pollenflug_erle_121": {
+          device_id: "dev_121",
+          platform: "dwd_pollenflug",
+          entity_category: null,
+        },
+        "sensor.pollenflug_erle_122": {
+          device_id: "dev_122",
+          platform: "dwd_pollenflug",
+          entity_category: null,
+        },
+      },
+      devices: {
+        dev_121: {
+          identifiers: [["dwd_pollenflug", "121"]],
+          config_entries: ["cfg_121"],
+          name: "Pollenflug Gefahrenindex",
+        },
+        dev_122: {
+          identifiers: [["dwd_pollenflug", "122"]],
+          config_entries: ["cfg_122"],
+          name: "Pollenflug Gefahrenindex",
+        },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const result = discoverDwdSensors(hass);
+    const labels = [...result.locations.values()].map((l) => l.label).sort();
+    expect(labels).toEqual(["Bayern (121)", "Bayern (122)"]);
+  });
+
+  it("unique region label stays clean (no disambiguation suffix)", () => {
+    const hass = makeHass("50", { erle: [1, 0, 0] });
+    const result = discoverDwdSensors(hass);
+    const [, loc] = [...result.locations.entries()][0];
+    // Only one region 50 present; label stays bare.
+    expect(loc.label).toBe("Brandenburg und Berlin");
+  });
+
   it("user-customized device name wins over region-derived label", () => {
     const hass = {
       states: {

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -321,4 +321,65 @@ describe("DWD adapter: discoverDwdSensors", () => {
     // entries (e.g. regions 11 and 12 share a name).
     expect(loc.label).toBe("50 Brandenburg und Berlin");
   });
+
+  it("region label beats generic device name", () => {
+    // The DWD integration sets device.name = "Pollenflug Gefahrenindex" for
+    // every region, which is useless as a card title. Region-derived label
+    // from entity_id must outrank the generic device name.
+    const hass = {
+      states: {
+        "sensor.pollenflug_erle_50": { state: "1", attributes: {} },
+      },
+      entities: {
+        "sensor.pollenflug_erle_50": {
+          device_id: "dev_dwd",
+          platform: "dwd_pollenflug",
+          entity_category: null,
+        },
+      },
+      devices: {
+        dev_dwd: {
+          identifiers: [["dwd_pollenflug", "50"]],
+          config_entries: ["cfg_dwd"],
+          name: "Pollenflug Gefahrenindex",
+          name_by_user: null,
+        },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const result = discoverDwdSensors(hass);
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.label).toBe("50 Brandenburg und Berlin");
+  });
+
+  it("user-customized device name wins over region-derived label", () => {
+    const hass = {
+      states: {
+        "sensor.pollenflug_erle_50": { state: "1", attributes: {} },
+      },
+      entities: {
+        "sensor.pollenflug_erle_50": {
+          device_id: "dev_dwd",
+          platform: "dwd_pollenflug",
+          entity_category: null,
+        },
+      },
+      devices: {
+        dev_dwd: {
+          identifiers: [["dwd_pollenflug", "50"]],
+          config_entries: ["cfg_dwd"],
+          name: "Pollenflug Gefahrenindex",
+          name_by_user: "My custom region",
+        },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const result = discoverDwdSensors(hass);
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.label).toBe("My custom region");
+  });
 });

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -316,7 +316,9 @@ describe("DWD adapter: discoverDwdSensors", () => {
     const result = discoverDwdSensors(hass);
 
     const [, loc] = [...result.locations.entries()][0];
-    // Region 50 = "Brandenburg und Berlin" in DWD_REGIONS
-    expect(loc.label).toBe("Brandenburg und Berlin");
+    // Region 50 = "Brandenburg und Berlin" in DWD_REGIONS. Label is prefixed
+    // with the region ID so tier-3 labels remain unique for non-bijective
+    // entries (e.g. regions 11 and 12 share a name).
+    expect(loc.label).toBe("50 Brandenburg und Berlin");
   });
 });

--- a/test/adapters/gpl.test.js
+++ b/test/adapters/gpl.test.js
@@ -266,6 +266,68 @@ describe("discoverGplSensors: primary path (hass.entities)", () => {
     expect(result.locations.get("entry-abc-123").label).toBe("My Location");
   });
 
+  it("strips ' - Pollentyper (lat, lon)' suffix from device name label", () => {
+    // The pollenlevels integration names devices
+    // "{user-name} - Pollentyper ({lat}, {lon})". Leaking the coordinate-
+    // laden suffix into the card header and editor dropdown is noise.
+    const statesMap = {
+      "sensor.pollenlevels_grass": makeTypeSensor("mdi:grass", 3),
+    };
+    const entitiesMap = {
+      "sensor.pollenlevels_grass": { device_id: "dev1" },
+    };
+    const devicesMap = {
+      dev1: {
+        name: "Hem - Pollentyper (50.450, 30.523)",
+        config_entries: ["entry-abc-123"],
+      },
+    };
+    const hass = makeHasPrimary(statesMap, entitiesMap, devicesMap);
+    const result = discoverGplSensors(hass);
+
+    expect(result.locations.get("entry-abc-123").label).toBe("Hem");
+  });
+
+  it("strips English 'Pollen types' and German 'Pollentypen' variants too", () => {
+    const cases = [
+      ["Garden - Pollen types (51.5, -0.1)", "Garden"],
+      ["Berlin - Pollentypen (52.5, 13.4)", "Berlin"],
+    ];
+    for (const [deviceName, expected] of cases) {
+      const statesMap = {
+        "sensor.pollenlevels_grass": makeTypeSensor("mdi:grass", 3),
+      };
+      const entitiesMap = {
+        "sensor.pollenlevels_grass": { device_id: "dev1" },
+      };
+      const devicesMap = {
+        dev1: { name: deviceName, config_entries: ["entry-xyz"] },
+      };
+      const hass = makeHasPrimary(statesMap, entitiesMap, devicesMap);
+      const result = discoverGplSensors(hass);
+      expect(result.locations.get("entry-xyz").label).toBe(expected);
+    }
+  });
+
+  it("name_by_user wins over device.name stripping", () => {
+    const statesMap = {
+      "sensor.pollenlevels_grass": makeTypeSensor("mdi:grass", 3),
+    };
+    const entitiesMap = {
+      "sensor.pollenlevels_grass": { device_id: "dev1" },
+    };
+    const devicesMap = {
+      dev1: {
+        name: "Hem - Pollentyper (50.450, 30.523)",
+        name_by_user: "Min plats",
+        config_entries: ["entry-abc-123"],
+      },
+    };
+    const hass = makeHasPrimary(statesMap, entitiesMap, devicesMap);
+    const result = discoverGplSensors(hass);
+    expect(result.locations.get("entry-abc-123").label).toBe("Min plats");
+  });
+
   it("excludes entities with entity_category set (diagnostic sensors)", () => {
     const statesMap = {
       "sensor.pollenlevels_grass": makeTypeSensor("mdi:grass", 3),

--- a/test/adapters/peu.test.js
+++ b/test/adapters/peu.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { fetchForecast, stubConfigPEU, PEU_ALLERGENS } from "../../src/adapters/peu.js";
-import { createHass, createPEUSensor, assertSensorShape } from "../helpers.js";
+import { fetchForecast, stubConfigPEU, PEU_ALLERGENS, discoverPeuSensors, resolveEntityIds } from "../../src/adapters/peu.js";
+import { createHass, createHassWithRegistry, createPEUSensor, assertSensorShape } from "../helpers.js";
 
 function makeConfig(overrides = {}) {
   return { ...stubConfigPEU, ...overrides };
@@ -877,6 +877,95 @@ describe("PEU adapter: fetchForecast", () => {
 
       expect(result.length).toBe(1);
       expect(result[0].entity_id).toBe("sensor.birch");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Device-based discovery
+  // -------------------------------------------------------------------------
+  describe("device-based discovery", () => {
+    it("tier 2 hit: entity-registry platform 'polleninformation' resolves allergens", () => {
+      // Simulate hass with entities registered under platform "polleninformation"
+      // but without device registry (tier 2 path).
+      const hass = createHassWithRegistry([
+        {
+          entityId: "sensor.polleninformation_wien_birch",
+          state: "2",
+          attributes: { forecast: [], data_stale: false },
+          deviceId: null,
+          platform: "polleninformation",
+        },
+        {
+          entityId: "sensor.polleninformation_wien_grasses",
+          state: "1",
+          attributes: { forecast: [], data_stale: false },
+          deviceId: null,
+          platform: "polleninformation",
+        },
+      ]);
+
+      const cfg = { ...stubConfigPEU, location: "wien", allergens: ["birch", "grasses"] };
+      const map = resolveEntityIds(cfg, hass);
+
+      expect(map.get("birch")).toBe("sensor.polleninformation_wien_birch");
+      expect(map.get("grasses")).toBe("sensor.polleninformation_wien_grasses");
+    });
+
+    it("tier 3 (state fallback) with slug config resolves allergens for cfg.location = 'wien'", () => {
+      // No entity/device registry - pure state fallback (tier 3).
+      const states = {
+        "sensor.polleninformation_wien_birch": makePEUSensor([2, 1, 0, 0]),
+        "sensor.polleninformation_wien_grasses": makePEUSensor([1, 0, 0, 0]),
+      };
+      const hass = createHass(states);
+
+      const cfg = { ...stubConfigPEU, location: "wien", allergens: ["birch", "grasses"] };
+      const map = resolveEntityIds(cfg, hass);
+
+      expect(map.get("birch")).toBe("sensor.polleninformation_wien_birch");
+      expect(map.get("grasses")).toBe("sensor.polleninformation_wien_grasses");
+    });
+
+    it("mode mapping: cfg.mode = 'hourly' + allergens = ['allergy_risk'] resolves to allergy_risk_hourly entity", () => {
+      const states = {
+        "sensor.polleninformation_wien_allergy_risk_hourly": {
+          state: "2",
+          attributes: { forecast: [], data_stale: false },
+        },
+      };
+      const hass = createHass(states);
+
+      const cfg = { ...stubConfigPEU, location: "wien", mode: "hourly", allergens: ["allergy_risk"] };
+      const map = resolveEntityIds(cfg, hass);
+
+      expect(map.get("allergy_risk")).toBe(
+        "sensor.polleninformation_wien_allergy_risk_hourly",
+      );
+    });
+
+    it("whitelist classifier: allergy_risk_hourly is not misclassified as allergy_risk", () => {
+      const states = {
+        "sensor.polleninformation_amsterdam_allergy_risk_hourly": makePEUSensor([3]),
+        "sensor.polleninformation_amsterdam_allergy_risk": makePEUSensor([2]),
+        "sensor.polleninformation_amsterdam_birch": makePEUSensor([1]),
+      };
+      const hass = createHass(states);
+
+      const discovery = discoverPeuSensors(hass);
+      const loc = discovery.locations.get("amsterdam");
+
+      expect(loc).toBeDefined();
+      // Both keys must be separately registered
+      expect(loc.entities.get("allergy_risk")).toBe(
+        "sensor.polleninformation_amsterdam_allergy_risk",
+      );
+      expect(loc.entities.get("allergy_risk_hourly")).toBe(
+        "sensor.polleninformation_amsterdam_allergy_risk_hourly",
+      );
+      // birch must not bleed into the allergy_risk key
+      expect(loc.entities.get("birch")).toBe(
+        "sensor.polleninformation_amsterdam_birch",
+      );
     });
   });
 

--- a/test/adapters/peu.test.js
+++ b/test/adapters/peu.test.js
@@ -943,6 +943,54 @@ describe("PEU adapter: fetchForecast", () => {
       );
     });
 
+    it("discovery label strips 'Polleninformation' prefix and unwraps parens", () => {
+      // The HA integration sets device.name = "Polleninformation (Hamburg)",
+      // which would produce a duplicated title in the card header.
+      const hass = createHassWithRegistry([
+        {
+          entityId: "sensor.polleninformation_hamburg_birch",
+          state: "2",
+          attributes: { forecast: [], data_stale: false },
+          platform: "polleninformation",
+          deviceId: "device_hamburg",
+          deviceMeta: {
+            name: "Polleninformation (Hamburg)",
+            configEntries: ["cfg_hamburg"],
+            identifiers: [["polleninformation", "hamburg"]],
+          },
+        },
+      ]);
+
+      const discovery = discoverPeuSensors(hass);
+      const [, loc] = [...discovery.locations.entries()][0];
+      expect(loc.label).toBe("Hamburg");
+    });
+
+    it("discovery label prefers state.attributes.location_title when present", () => {
+      const hass = createHassWithRegistry([
+        {
+          entityId: "sensor.polleninformation_hamburg_birch",
+          state: "2",
+          attributes: {
+            forecast: [],
+            data_stale: false,
+            location_title: "Hamburg",
+          },
+          platform: "polleninformation",
+          deviceId: "device_hamburg",
+          deviceMeta: {
+            name: "Polleninformation (Hamburg)",
+            configEntries: ["cfg_hamburg"],
+            identifiers: [["polleninformation", "hamburg"]],
+          },
+        },
+      ]);
+
+      const discovery = discoverPeuSensors(hass);
+      const [, loc] = [...discovery.locations.entries()][0];
+      expect(loc.label).toBe("Hamburg");
+    });
+
     it("whitelist classifier: allergy_risk_hourly is not misclassified as allergy_risk", () => {
       const states = {
         "sensor.polleninformation_amsterdam_allergy_risk_hourly": makePEUSensor([3]),

--- a/test/adapters/plu.test.js
+++ b/test/adapters/plu.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { fetchForecast, stubConfigPLU, PLU_SUPPORTED_ALLERGENS } from "../../src/adapters/plu.js";
-import { createHass, createPLUSensor, assertSensorShape } from "../helpers.js";
+import { fetchForecast, stubConfigPLU, PLU_SUPPORTED_ALLERGENS, discoverPluSensors, resolveEntityIds } from "../../src/adapters/plu.js";
+import { createHass, createPLUSensor, assertSensorShape, assertDiscoveryShape, createHassWithRegistry } from "../helpers.js";
 
 function makeConfig(overrides = {}) {
   return { ...stubConfigPLU, ...overrides };
@@ -197,5 +197,124 @@ describe("PLU adapter: fetchForecast", () => {
   it("PLU_SUPPORTED_ALLERGENS is alphabetically sorted", () => {
     const sorted = [...PLU_SUPPORTED_ALLERGENS].sort();
     expect(PLU_SUPPORTED_ALLERGENS).toEqual(sorted);
+  });
+});
+
+describe("PLU adapter: discoverPluSensors (tier 2 via entity registry)", () => {
+  it("returns valid discovery shape with entities from platform pollen_lu", () => {
+    const deviceId = "device_plu_001";
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_birch",
+        state: "25",
+        attributes: { unit_of_measurement: "grains/m\u00B3" },
+        deviceId,
+        platform: "pollen_lu",
+        deviceMeta: {
+          name: "Pollen.lu",
+          identifiers: [["pollen_lu", "pollen_lu_luxembourg"]],
+          configEntries: ["cfg_plu_001"],
+        },
+      },
+      {
+        entityId: "sensor.pollen_betula",
+        state: "30",
+        attributes: { unit_of_measurement: "grains/m\u00B3" },
+        deviceId,
+        platform: "pollen_lu",
+      },
+      {
+        entityId: "sensor.pollen_alder",
+        state: "5",
+        attributes: { unit_of_measurement: "grains/m\u00B3" },
+        deviceId,
+        platform: "pollen_lu",
+      },
+    ]);
+
+    const discovery = discoverPluSensors(hass);
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBeGreaterThanOrEqual(1);
+    expect(discovery.locations.size).toBe(1);
+
+    const [, location] = discovery.locations.entries().next().value;
+    // sensor.pollen_birch -> canonical "birch"
+    expect(location.entities.get("birch")).toBe("sensor.pollen_birch");
+    // sensor.pollen_betula -> also canonical "birch" (Latin alias)
+    // Note: collision: first entity wins, second is silently skipped
+    // The important guarantee is that at least one birch entity was classified
+    expect(["sensor.pollen_birch", "sensor.pollen_betula"]).toContain(location.entities.get("birch"));
+    // sensor.pollen_alder -> canonical "alder"
+    expect(location.entities.get("alder")).toBe("sensor.pollen_alder");
+  });
+
+  it("resolveEntityIds uses discovery when entity registry is available", () => {
+    const deviceId = "device_plu_002";
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_birch",
+        state: "25",
+        attributes: { unit_of_measurement: "grains/m\u00B3" },
+        deviceId,
+        platform: "pollen_lu",
+        deviceMeta: {
+          name: "Pollen Luxembourg",
+          identifiers: [["pollen_lu", "pollen_lu_main"]],
+          configEntries: ["cfg_plu_002"],
+        },
+      },
+      {
+        entityId: "sensor.pollen_alder",
+        state: "5",
+        attributes: { unit_of_measurement: "grains/m\u00B3" },
+        deviceId,
+        platform: "pollen_lu",
+      },
+    ]);
+
+    const cfg = { ...stubConfigPLU, allergens: ["birch", "alder", "hazel"] };
+    const result = resolveEntityIds(cfg, hass);
+
+    // birch and alder are in entity registry -> discovery path
+    expect(result.get("birch")).toBe("sensor.pollen_birch");
+    expect(result.get("alder")).toBe("sensor.pollen_alder");
+    // hazel has no entity in the registry -> not in result
+    expect(result.has("hazel")).toBe(false);
+  });
+});
+
+describe("PLU adapter: resolveEntityIds alias-probe fallback", () => {
+  it("falls back to alias-probe when no entity registry is present", () => {
+    // Plain hass mock without entities/devices -- simulates legacy HA setup
+    const states = {
+      "sensor.pollen_betula": createPLUSensor(30),
+      "sensor.pollen_alder": createPLUSensor(5),
+    };
+    const hass = createHass(states);
+    const cfg = { ...stubConfigPLU, allergens: ["birch", "alder"] };
+
+    const result = resolveEntityIds(cfg, hass);
+
+    // sensor.pollen_betula is a Latin alias for birch -> alias-probe finds it
+    expect(result.get("birch")).toBe("sensor.pollen_betula");
+    expect(result.get("alder")).toBe("sensor.pollen_alder");
+  });
+
+  it("alias-probe classifies both canonical English keys and Latin/French aliases", () => {
+    // Verify the reverse-alias map covers all alias forms
+    const states = {
+      "sensor.pollen_bouleau": createPLUSensor(20),  // French alias for birch
+      "sensor.pollen_corylus": createPLUSensor(8),   // Latin alias for hazel
+      "sensor.pollen_mugwort": createPLUSensor(3),   // English canonical
+    };
+    const hass = createHass(states);
+    const cfg = { ...stubConfigPLU, allergens: ["birch", "hazel", "mugwort"] };
+
+    const result = resolveEntityIds(cfg, hass);
+
+    expect(result.get("birch")).toBe("sensor.pollen_bouleau");
+    expect(result.get("hazel")).toBe("sensor.pollen_corylus");
+    expect(result.get("mugwort")).toBe("sensor.pollen_mugwort");
   });
 });

--- a/test/adapters/pp.test.js
+++ b/test/adapters/pp.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import * as PP from "../../src/adapters/pp.js";
-import { createHass, createPPSensor, assertSensorShape } from "../helpers.js";
+import { createHass, createPPSensor, assertSensorShape, createHassWithRegistry } from "../helpers.js";
 
 const { stubConfigPP } = PP;
 // Call fetchForecast as method on module to match production call pattern
@@ -251,5 +251,85 @@ describe("PP adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result[0].entity_id).toBe("sensor.pollen_stockholm_bjork");
+  });
+});
+
+describe("PP adapter: resolveEntityIds — device-based discovery", () => {
+  const { resolveEntityIds } = PP;
+
+  it("tier 2 hit: entity registry with platform pollenprognos returns correct entity IDs", () => {
+    // Simulates tier 2: hass.entities present, no hass.devices with PP identifiers
+    const levels = [3, 2, 1, 0];
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_stockholm_bjork",
+        attributes: { forecast: createPPSensor(levels).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_sthlm",
+        deviceMeta: {
+          name: "Stockholm",
+          configEntries: ["cfg_sthlm"],
+        },
+      },
+      {
+        entityId: "sensor.pollen_stockholm_al",
+        attributes: { forecast: createPPSensor(levels).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_sthlm",
+      },
+    ]);
+
+    const cfg = {
+      city: "Stockholm",
+      allergens: ["Björk", "Al"],
+    };
+    const result = resolveEntityIds(cfg, hass, false);
+
+    expect(result instanceof Map).toBe(true);
+    expect(result.get("bjork")).toBe("sensor.pollen_stockholm_bjork");
+    expect(result.get("al")).toBe("sensor.pollen_stockholm_al");
+  });
+
+  it("multi-city: two discovered locations, config selects the correct one", () => {
+    const levels = [2, 1, 0, 0];
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_goteborg_bjork",
+        attributes: { forecast: createPPSensor(levels).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_gbg",
+        deviceMeta: { name: "Goteborg", configEntries: ["cfg_gbg"] },
+      },
+      {
+        entityId: "sensor.pollen_stockholm_bjork",
+        attributes: { forecast: createPPSensor(levels).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_sthlm",
+        deviceMeta: { name: "Stockholm", configEntries: ["cfg_sthlm"] },
+      },
+    ]);
+
+    const cfgGbg = { city: "goteborg", allergens: ["Björk"] };
+    const resultGbg = resolveEntityIds(cfgGbg, hass, false);
+    expect(resultGbg.get("bjork")).toBe("sensor.pollen_goteborg_bjork");
+
+    const cfgSthlm = { city: "stockholm", allergens: ["Björk"] };
+    const resultSthlm = resolveEntityIds(cfgSthlm, hass, false);
+    expect(resultSthlm.get("bjork")).toBe("sensor.pollen_stockholm_bjork");
+  });
+
+  it("legacy slug config (city as slug) falls through to tier 3 regex fallback when no registry", () => {
+    // createHass does not provide hass.entities with platform info,
+    // so tiers 1 and 2 yield nothing; tier 3 (regex) must fire.
+    const hass = createHass({
+      "sensor.pollen_stockholm_bjork": createPPSensor([4, 3, 2, 1]),
+      "sensor.pollen_stockholm_al": createPPSensor([1, 0, 0, 0]),
+    });
+
+    const cfg = { city: "stockholm", allergens: ["Björk", "Al"] };
+    const result = resolveEntityIds(cfg, hass, false);
+
+    expect(result.get("bjork")).toBe("sensor.pollen_stockholm_bjork");
+    expect(result.get("al")).toBe("sensor.pollen_stockholm_al");
   });
 });

--- a/test/adapters/pp.test.js
+++ b/test/adapters/pp.test.js
@@ -332,4 +332,48 @@ describe("PP adapter: resolveEntityIds — device-based discovery", () => {
     expect(result.get("bjork")).toBe("sensor.pollen_stockholm_bjork");
     expect(result.get("al")).toBe("sensor.pollen_stockholm_al");
   });
+
+  it("discovery label strips 'Pollenprognos ' prefix from device name", () => {
+    // The HA integration sets device.name = "Pollenprognos Visby", which
+    // would render as a duplicated title ("Pollenprognos för Pollenprognos
+    // Visby") in the card header.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_visby_bjork",
+        attributes: { forecast: createPPSensor([1, 0, 0, 0]).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_visby",
+        deviceMeta: {
+          name: "Pollenprognos Visby",
+          configEntries: ["cfg_visby"],
+          identifiers: [["pollenprognos", "visby"]],
+        },
+      },
+    ]);
+
+    const discovery = PP.discoverPpSensors(hass);
+    const [, loc] = [...discovery.locations.entries()][0];
+    expect(loc.label).toBe("Visby");
+  });
+
+  it("user-customized device name wins over prefix stripping", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.pollen_visby_bjork",
+        attributes: { forecast: createPPSensor([1, 0, 0, 0]).attributes.forecast },
+        platform: "pollenprognos",
+        deviceId: "device_visby",
+        deviceMeta: {
+          name: "Pollenprognos Visby",
+          nameByUser: "My Visby card",
+          configEntries: ["cfg_visby"],
+          identifiers: [["pollenprognos", "visby"]],
+        },
+      },
+    ]);
+
+    const discovery = PP.discoverPpSensors(hass);
+    const [, loc] = [...discovery.locations.entries()][0];
+    expect(loc.label).toBe("My Visby card");
+  });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -106,6 +106,150 @@ export function createPEUSensor(level, forecastLevels = [], opts = {}) {
 }
 
 /**
+ * Create a minimal device registry entry.
+ *
+ * @param {object} opts
+ * @param {string}   [opts.deviceId]    - Device ID. Auto-generated if omitted.
+ * @param {Array[]}  opts.identifiers   - Array of [domain, unique_id] tuples.
+ * @param {string[]} [opts.configEntries] - Config entry IDs. Default: ["cfg_default"].
+ * @param {string}   [opts.name]        - Device name.
+ * @param {string}   [opts.nameByUser]  - User-assigned device name.
+ * @returns {object}
+ */
+export function makeDevice({ deviceId, identifiers, configEntries = ["cfg_default"], name, nameByUser } = {}) {
+  return {
+    device_id: deviceId || `device_${Math.random().toString(36).slice(2, 9)}`,
+    identifiers: identifiers || [],
+    config_entries: configEntries,
+    name: name || null,
+    name_by_user: nameByUser || null,
+  };
+}
+
+/**
+ * Create a minimal entity registry entry.
+ *
+ * @param {object} opts
+ * @param {string} [opts.deviceId]        - Device ID the entity belongs to.
+ * @param {string} [opts.platform]        - Integration platform name.
+ * @param {string} [opts.translationKey]  - Translation key.
+ * @param {string} [opts.uniqueId]        - Unique ID.
+ * @param {string|null} [opts.entityCategory] - Entity category (e.g. "diagnostic"). Default: null.
+ * @returns {object}
+ */
+export function makeEntityEntry({ deviceId, platform, translationKey, uniqueId, entityCategory = null } = {}) {
+  return {
+    device_id: deviceId || null,
+    platform: platform || null,
+    translation_key: translationKey || null,
+    unique_id: uniqueId || null,
+    entity_category: entityCategory,
+  };
+}
+
+/**
+ * Create a hass mock with wired states, entities, and devices registries.
+ *
+ * @param {Array} entries - Array of entity descriptors:
+ *   { entityId, state, attributes, deviceId, platform, translationKey, uniqueId, entityCategory, deviceMeta }
+ *   deviceMeta is passed to makeDevice() (keyed by deviceId, first occurrence wins).
+ * @param {object} [opts]
+ * @param {object} [opts.locale] - Default: { language: "en" }.
+ * @returns {object} hass mock
+ */
+export function createHassWithRegistry(entries, { locale = { language: "en" } } = {}) {
+  const states = {};
+  const entities = {};
+  const devices = {};
+  const seenDevices = new Set();
+
+  for (const entry of entries) {
+    const {
+      entityId,
+      state: stateVal = "0",
+      attributes = {},
+      deviceId = null,
+      platform = null,
+      translationKey = null,
+      uniqueId = null,
+      entityCategory = null,
+      deviceMeta = {},
+    } = entry;
+
+    // Build state
+    states[entityId] = {
+      state: String(stateVal),
+      attributes: { friendly_name: entityId, ...attributes },
+    };
+
+    // Build entity registry entry
+    entities[entityId] = makeEntityEntry({
+      deviceId,
+      platform,
+      translationKey,
+      uniqueId,
+      entityCategory,
+    });
+
+    // Build device registry entry (first occurrence wins)
+    if (deviceId && !seenDevices.has(deviceId)) {
+      seenDevices.add(deviceId);
+      const dev = makeDevice({ deviceId, ...deviceMeta });
+      devices[deviceId] = {
+        identifiers: dev.identifiers,
+        config_entries: dev.config_entries,
+        name: dev.name,
+        name_by_user: dev.name_by_user,
+      };
+    }
+  }
+
+  return {
+    states,
+    entities,
+    devices,
+    locale,
+    language: locale.language,
+  };
+}
+
+/**
+ * Assert the structural contract of a discoverEntitiesByDevice() result.
+ *
+ * @param {{ locations: Map, tierUsed: number }} discovery
+ */
+export function assertDiscoveryShape(discovery) {
+  if (!discovery || typeof discovery !== "object") {
+    throw new Error("discovery must be an object");
+  }
+  if (!(discovery.locations instanceof Map)) {
+    throw new Error("discovery.locations must be a Map");
+  }
+  if (typeof discovery.tierUsed !== "number" || discovery.tierUsed < 0 || discovery.tierUsed > 3) {
+    throw new Error(`discovery.tierUsed must be 0-3, got ${discovery.tierUsed}`);
+  }
+  for (const [key, loc] of discovery.locations) {
+    if (typeof key !== "string") {
+      throw new Error(`location key must be string, got ${typeof key}`);
+    }
+    if (typeof loc.label !== "string") {
+      throw new Error(`location.label must be string, got ${typeof loc.label}`);
+    }
+    if (!(loc.entities instanceof Map)) {
+      throw new Error("location.entities must be a Map");
+    }
+    for (const [allergenKey, entityId] of loc.entities) {
+      if (typeof allergenKey !== "string") {
+        throw new Error(`allergen key must be string, got ${typeof allergenKey}`);
+      }
+      if (typeof entityId !== "string") {
+        throw new Error(`entity ID must be string, got ${typeof entityId}`);
+      }
+    }
+  }
+}
+
+/**
  * Assert the contract shape of a sensor dict returned by any adapter's fetchForecast().
  * @param {Object} sensor - A single sensor dict from fetchForecast result
  * @param {Object} [opts] - Optional expectations

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -109,18 +109,19 @@ export function createPEUSensor(level, forecastLevels = [], opts = {}) {
  * Create a minimal device registry entry.
  *
  * @param {object} opts
- * @param {string}   [opts.deviceId]    - Device ID. Auto-generated if omitted.
+ * @param {string}   opts.deviceId      - Device ID (required, must be explicit).
  * @param {Array[]}  opts.identifiers   - Array of [domain, unique_id] tuples.
  * @param {string[]} [opts.configEntries] - Config entry IDs. Default: ["cfg_default"].
  * @param {string}   [opts.name]        - Device name.
  * @param {string}   [opts.nameByUser]  - User-assigned device name.
  * @returns {object}
  */
-let _makeDeviceCounter = 0;
-
 export function makeDevice({ deviceId, identifiers, configEntries = ["cfg_default"], name, nameByUser } = {}) {
+  if (!deviceId) {
+    throw new Error("makeDevice: deviceId is required");
+  }
   return {
-    device_id: deviceId || `device_auto_${++_makeDeviceCounter}`,
+    device_id: deviceId,
     identifiers: identifiers || [],
     config_entries: configEntries,
     name: name || null,
@@ -164,13 +165,17 @@ export function createHassWithRegistry(entries, { locale = { language: "en" } } 
   const entities = {};
   const devices = {};
   const seenDevices = new Set();
+  // Per-call counter so any auto-assigned device IDs are deterministic and
+  // independent of test execution order. Earlier versions used a module-level
+  // counter, which made test failures order-dependent.
+  let autoDeviceCounter = 0;
 
   for (const entry of entries) {
     const {
       entityId,
       state: stateVal = "0",
       attributes = {},
-      deviceId = null,
+      deviceId: rawDeviceId = null,
       platform = null,
       translationKey = null,
       uniqueId = null,
@@ -178,8 +183,16 @@ export function createHassWithRegistry(entries, { locale = { language: "en" } } 
       deviceMeta = {},
     } = entry;
 
-    // Build state
+    let deviceId = rawDeviceId;
+    if (deviceId === "auto") {
+      deviceId = `device_auto_${++autoDeviceCounter}`;
+    }
+
+    // Build state. Include entity_id so the mock matches real HA, where
+    // production code can iterate Object.values(hass.states) and read
+    // s.entity_id directly (e.g. editor/card slug-based fallbacks).
     states[entityId] = {
+      entity_id: entityId,
       state: String(stateVal),
       attributes: { friendly_name: entityId, ...attributes },
     };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -116,9 +116,11 @@ export function createPEUSensor(level, forecastLevels = [], opts = {}) {
  * @param {string}   [opts.nameByUser]  - User-assigned device name.
  * @returns {object}
  */
+let _makeDeviceCounter = 0;
+
 export function makeDevice({ deviceId, identifiers, configEntries = ["cfg_default"], name, nameByUser } = {}) {
   return {
-    device_id: deviceId || `device_${Math.random().toString(36).slice(2, 9)}`,
+    device_id: deviceId || `device_auto_${++_makeDeviceCounter}`,
     identifiers: identifiers || [],
     config_entries: configEntries,
     name: name || null,

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   discoverEntitiesByDevice,
   findLocationBySlug,

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -92,9 +92,9 @@ describe("discoverEntitiesByDevice", () => {
     expect(discovery.locations.get("cfg_loc1").label).toBe("MyCity");
   });
 
-  it("tier 1: entities filtered by isRelevant fall through to tier 2 if tier 2 matches", () => {
-    // Set up: device exists (tier 1 capable) but isRelevant filters all out.
-    // tier 2 entities have matching platform, so tier 2 should fire.
+  it("isRelevant blocking all entities yields tierUsed 0 in every tier", () => {
+    // isRelevant applied uniformly to tier 1/2/3 → when it blocks everything,
+    // no tier produces locations and tierUsed must be 0.
     const hass = createHassWithRegistry([
       {
         entityId: "sensor.testint_birch_loc1",
@@ -114,8 +114,6 @@ describe("discoverEntitiesByDevice", () => {
       isRelevant: () => false, // filter everything
     });
 
-    // Tier 1 and tier 2 both produce nothing (isRelevant blocks all).
-    // Result should be tierUsed 0.
     expect(discovery.tierUsed).toBe(0);
     expect(discovery.locations.size).toBe(0);
   });
@@ -504,6 +502,41 @@ describe("discoverEntitiesByDevice", () => {
 
     expect(discovery.tierUsed).toBe(2);
     expect(discovery.locations.size).toBe(1);
+  });
+
+  it("deviceId is backfilled when the first entity lacks it but a later one has it", () => {
+    // First entity has no device_id (tier 3 fallback match), second entity in
+    // the same location has a device_id. Earlier code only set deviceId on
+    // bucket creation, which silently lost it.
+    const hass = {
+      states: {
+        "sensor.abc_alder": { state: "0", attributes: {} },
+        "sensor.abc_birch": { state: "1", attributes: {} },
+      },
+      entities: {
+        // First entity in iteration order has no device_id.
+        "sensor.abc_alder": { device_id: null, platform: "abc", entity_category: null },
+        "sensor.abc_birch": { device_id: "dev_later", platform: "abc", entity_category: null },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => {
+        if (eid.includes("alder")) return "alder";
+        if (eid.includes("birch")) return "birch";
+        return null;
+      },
+      // Collapse both entities into the same location.
+      resolveLocationKey: () => "shared",
+    });
+
+    const loc = discovery.locations.get("shared");
+    expect(loc).toBeDefined();
+    expect(loc.deviceId).toBe("dev_later");
+    expect(loc.entities.size).toBe(2);
   });
 
   it("tier 2 without hass.devices still sets loc.deviceId when entry.device_id is present", () => {

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -506,6 +506,37 @@ describe("discoverEntitiesByDevice", () => {
     expect(discovery.locations.size).toBe(1);
   });
 
+  it("tier 2 without hass.devices still sets loc.deviceId when entry.device_id is present", () => {
+    // Regression: early versions only set loc.deviceId when ctx.device was
+    // non-null, which meant tier 2 without hass.devices lost deviceId even
+    // though entry.device_id was available. SILAM weather postprocess relies
+    // on this.
+    const hass = {
+      states: {
+        "sensor.abc_birch": { state: "1", attributes: {} },
+      },
+      entities: {
+        "sensor.abc_birch": {
+          device_id: "dev_known",
+          platform: "abc",
+          entity_category: null,
+        },
+      },
+      // No hass.devices — lookup of ctx.device will fail.
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => eid.includes("birch") ? "birch" : null,
+    });
+
+    expect(discovery.tierUsed).toBe(2);
+    const [, location] = discovery.locations.entries().next().value;
+    expect(location.deviceId).toBe("dev_known");
+  });
+
   // --- Multi-instance ---
 
   it("multi-instance: two devices produce two separate locations", () => {
@@ -578,6 +609,19 @@ describe("resolveLocationByKey", () => {
     const discovery = { locations: new Map(), tierUsed: 0 };
     const result = resolveLocationByKey(discovery, "");
     expect(result).toBeNull();
+  });
+
+  it("empty cfgLocation picks deterministically by sorted key, not insertion order", () => {
+    // Insert cfg_xyz first, cfg_abc second. Insertion-order "first" would be
+    // cfg_xyz, but sorted-key "first" must be cfg_abc.
+    const discovery = makeDiscovery([
+      ["cfg_xyz", "City X", { grass: "sensor.grass_x" }],
+      ["cfg_abc", "City A", { birch: "sensor.birch_a" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
   });
 
   it("exact key match", () => {

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -1,0 +1,714 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  discoverEntitiesByDevice,
+  findLocationBySlug,
+  resolveLocationByKey,
+} from "../../src/utils/adapter-helpers.js";
+import {
+  createHassWithRegistry,
+  assertDiscoveryShape,
+} from "../helpers.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures and helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a simple classify function that maps entity IDs to allergen keys
+ * based on a lookup map.
+ */
+function makeClassifier(mapping) {
+  return (eid) => {
+    for (const [pattern, key] of Object.entries(mapping)) {
+      if (eid.includes(pattern)) return key;
+    }
+    return null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// discoverEntitiesByDevice
+// ---------------------------------------------------------------------------
+
+describe("discoverEntitiesByDevice", () => {
+  // --- Tier 1 ---
+
+  it("tier 1 hit: device identifier matches platform, entities mapped correctly", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+          name: "Location One",
+        },
+      },
+      {
+        entityId: "sensor.testint_grass_loc1",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "testint",
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch", grass: "grass" }),
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.get("cfg_loc1");
+    expect(loc).toBeDefined();
+    expect(loc.entities.get("birch")).toBe("sensor.testint_birch_loc1");
+    expect(loc.entities.get("grass")).toBe("sensor.testint_grass_loc1");
+  });
+
+  it("tier 1 hit: two entities from same device, label from device.name", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+          name: "MyCity",
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch" }),
+    });
+
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.get("cfg_loc1").label).toBe("MyCity");
+  });
+
+  it("tier 1: entities filtered by isRelevant fall through to tier 2 if tier 2 matches", () => {
+    // Set up: device exists (tier 1 capable) but isRelevant filters all out.
+    // tier 2 entities have matching platform, so tier 2 should fire.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch" }),
+      isRelevant: () => false, // filter everything
+    });
+
+    // Tier 1 and tier 2 both produce nothing (isRelevant blocks all).
+    // Result should be tierUsed 0.
+    expect(discovery.tierUsed).toBe(0);
+    expect(discovery.locations.size).toBe(0);
+  });
+
+  it("tier 1: isRelevant blocks tier-1 entities but tier-2 entity without device matches", () => {
+    // One entity with device (tier 1 candidate), blocked by isRelevant.
+    // Another entity without device but with matching platform (tier 2 candidate).
+    // isRelevant applied in both tiers; first entity still blocked.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_grass_noloc",
+        state: "1",
+        deviceId: null,
+        platform: "testint",
+      },
+    ]);
+
+    // isRelevant only blocks entities containing "birch"
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch", grass: "grass" }),
+      isRelevant: (eid) => !eid.includes("birch"),
+    });
+
+    // Tier 1: device found, but birch is blocked -> no entities -> tier 1 produces 0 locations
+    // Tier 2: platform match, birch still blocked, grass passes -> tier 2 fires
+    expect(discovery.tierUsed).toBe(2);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.has("grass")).toBe(true);
+    expect(loc.entities.has("birch")).toBe(false);
+  });
+
+  // --- Tier 2 ---
+
+  it("tier 2 hit: no devices, entities with matching platform", () => {
+    const hass = {
+      states: {
+        "sensor.myint_birch": { state: "2", attributes: { friendly_name: "Birch" } },
+      },
+      entities: {
+        "sensor.myint_birch": { device_id: null, platform: "myint", entity_category: null },
+      },
+      // No hass.devices
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "myint",
+      classify: makeClassifier({ birch: "birch" }),
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(2);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.get("birch")).toBe("sensor.myint_birch");
+  });
+
+  it("tier 2: location key defaults to 'default' when no device config_entries", () => {
+    const hass = {
+      states: {
+        "sensor.myint_birch": { state: "2", attributes: {} },
+      },
+      entities: {
+        "sensor.myint_birch": { device_id: null, platform: "myint", entity_category: null },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "myint",
+      classify: () => "birch",
+    });
+
+    expect(discovery.tierUsed).toBe(2);
+    expect(discovery.locations.has("default")).toBe(true);
+  });
+
+  // --- Tier 3 ---
+
+  it("tier 3 regex hit: no entities registry, fallback regex matches states", () => {
+    const hass = {
+      states: {
+        "sensor.abc_birch_stadtx": { state: "1", attributes: {} },
+        "sensor.abc_grass_stadtx": { state: "2", attributes: {} },
+        "sensor.unrelated_sensor": { state: "0", attributes: {} },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: makeClassifier({ birch: "birch", grass: "grass" }),
+      fallbackRegex: /^sensor\.abc_/,
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(3);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.get("birch")).toBe("sensor.abc_birch_stadtx");
+    expect(loc.entities.get("grass")).toBe("sensor.abc_grass_stadtx");
+  });
+
+  it("tier 3 selector hit: fallbackSelector overrides regex", () => {
+    const hass = {
+      states: {
+        "sensor.selected_birch": { state: "3", attributes: {} },
+        "sensor.not_selected": { state: "1", attributes: {} },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => eid.includes("birch") ? "birch" : null,
+      fallbackRegex: /^sensor\.not_/, // would match "not_selected" — should be ignored
+      fallbackSelector: () => ["sensor.selected_birch"],
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(3);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.get("birch")).toBe("sensor.selected_birch");
+  });
+
+  // --- No match ---
+
+  it("no match in any tier: returns empty locations with tierUsed 0", () => {
+    const hass = {
+      states: {
+        "sensor.unrelated": { state: "0", attributes: {} },
+      },
+      entities: {
+        "sensor.unrelated": { device_id: null, platform: "other_platform", entity_category: null },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "myint",
+      classify: () => null,
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(0);
+    expect(discovery.locations.size).toBe(0);
+  });
+
+  // --- classifyRelaxed only used in tier 1 ---
+
+  it("classifyRelaxed used in tier 1, strict returns null in tier 2/3", () => {
+    // Tier 1: device found, classifyRelaxed returns "birch" (strict returns null)
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: () => null,          // strict: never classifies
+      classifyRelaxed: (eid) => eid.includes("birch") ? "birch" : null,
+    });
+
+    // Tier 1 uses relaxed -> succeeds
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(1);
+    expect(discovery.locations.values().next().value.entities.get("birch")).toBe("sensor.testint_birch_loc1");
+  });
+
+  it("classifyRelaxed irrelevant when no device: tier 2 uses strict (which returns null) -> no results", () => {
+    const hass = {
+      states: {
+        "sensor.testint_birch": { state: "2", attributes: {} },
+      },
+      entities: {
+        "sensor.testint_birch": { device_id: null, platform: "testint", entity_category: null },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: () => null,
+      classifyRelaxed: () => "birch", // relaxed would classify but should not be used in tier 2
+    });
+
+    expect(discovery.tierUsed).toBe(0);
+    expect(discovery.locations.size).toBe(0);
+  });
+
+  // --- excludeEntry ---
+
+  it("excludeEntry: entries with entity_category skipped by default", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_diagnostic",
+        state: "1",
+        deviceId: "dev_abc",
+        platform: "testint",
+        entityCategory: "diagnostic",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_birch",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "testint",
+        entityCategory: null,
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: (eid) => eid.includes("birch") ? "birch" : eid.includes("diagnostic") ? "diag" : null,
+    });
+
+    expect(discovery.tierUsed).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.has("diag")).toBe(false);
+    expect(loc.entities.has("birch")).toBe(true);
+  });
+
+  // --- onCollision ---
+
+  it("onCollision triggered when two entities map to the same key", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_a",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_birch_b",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "testint",
+      },
+    ]);
+
+    const collisionCtx = [];
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: () => "birch", // both map to "birch"
+      onCollision: (ctx, info) => {
+        collisionCtx.push({ ctx, info });
+        return "birch_alt";
+      },
+    });
+
+    expect(discovery.tierUsed).toBe(1);
+    expect(collisionCtx.length).toBe(1);
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.has("birch")).toBe(true);
+    expect(loc.entities.has("birch_alt")).toBe(true);
+  });
+
+  it("onCollision returning null skips the colliding entity", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_a",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_birch_b",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "testint",
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: () => "birch",
+      onCollision: () => null, // skip
+    });
+
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.size).toBe(1); // only the first one kept
+  });
+
+  // --- platform as array ---
+
+  it("platform array: tier 1 matches device identifier with alternative platform name", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.altname_birch",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "primary",
+        deviceMeta: {
+          identifiers: [["altname", "loc1"]],
+          configEntries: ["cfg_alt"],
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: ["primary", "altname"],
+      classify: (eid) => eid.includes("birch") ? "birch" : null,
+    });
+
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.has("cfg_alt")).toBe(true);
+  });
+
+  // --- Missing hass sub-objects ---
+
+  it("hass.entities missing: tier 1 and tier 2 skipped, tier 3 (regex) used", () => {
+    const hass = {
+      states: {
+        "sensor.abc_birch": { state: "1", attributes: {} },
+      },
+      // No hass.entities, no hass.devices
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => eid.includes("birch") ? "birch" : null,
+      fallbackRegex: /^sensor\.abc_/,
+    });
+
+    expect(discovery.tierUsed).toBe(3);
+    expect(discovery.locations.size).toBe(1);
+  });
+
+  it("hass.devices missing but hass.entities present: tier 1 skipped, tier 2 activated", () => {
+    const hass = {
+      states: {
+        "sensor.abc_birch": { state: "1", attributes: {} },
+      },
+      entities: {
+        "sensor.abc_birch": { device_id: null, platform: "abc", entity_category: null },
+      },
+      // No hass.devices
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => eid.includes("birch") ? "birch" : null,
+    });
+
+    expect(discovery.tierUsed).toBe(2);
+    expect(discovery.locations.size).toBe(1);
+  });
+
+  // --- Multi-instance ---
+
+  it("multi-instance: two devices produce two separate locations", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_loc1",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+          name: "Location One",
+        },
+      },
+      {
+        entityId: "sensor.testint_birch_loc2",
+        state: "1",
+        deviceId: "dev_loc2",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc2"]],
+          configEntries: ["cfg_loc2"],
+          name: "Location Two",
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch" }),
+    });
+
+    assertDiscoveryShape(discovery);
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(2);
+    expect(discovery.locations.has("cfg_loc1")).toBe(true);
+    expect(discovery.locations.has("cfg_loc2")).toBe(true);
+    expect(discovery.locations.get("cfg_loc1").entities.get("birch")).toBe("sensor.testint_birch_loc1");
+    expect(discovery.locations.get("cfg_loc2").entities.get("birch")).toBe("sensor.testint_birch_loc2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLocationByKey
+// ---------------------------------------------------------------------------
+
+describe("resolveLocationByKey", () => {
+  function makeDiscovery(entries) {
+    const locations = new Map();
+    for (const [key, label, entities] of entries) {
+      const entMap = new Map(Object.entries(entities));
+      locations.set(key, { label, entities: entMap });
+    }
+    return { locations, tierUsed: 2 };
+  }
+
+  it("empty cfgLocation returns first location", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "City A", { birch: "sensor.birch_a" }],
+      ["cfg_xyz", "City X", { grass: "sensor.grass_x" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("empty cfgLocation with empty map returns null", () => {
+    const discovery = { locations: new Map(), tierUsed: 0 };
+    const result = resolveLocationByKey(discovery, "");
+    expect(result).toBeNull();
+  });
+
+  it("exact key match", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "City A", { birch: "sensor.birch_a" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "cfg_abc");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("label substring match", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "City of Nice", { birch: "sensor.birch_nice" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "Nice");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("slug fallback via suffix matching", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "Auto", { birch: "sensor.niveau_bouleau_paris" }],
+    ]);
+
+    // "paris" matches because "sensor.niveau_bouleau_paris" ends with "_paris"
+    const result = resolveLocationByKey(discovery, "paris");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("no match returns null", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "City A", { birch: "sensor.birch_a" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "completely_unknown_xyz");
+    expect(result).toBeNull();
+  });
+
+  it("null discovery returns null", () => {
+    expect(resolveLocationByKey(null, "paris")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findLocationBySlug
+// ---------------------------------------------------------------------------
+
+describe("findLocationBySlug", () => {
+  function makeDiscovery(entries) {
+    const locations = new Map();
+    for (const [key, label, entities] of entries) {
+      const entMap = new Map(Object.entries(entities));
+      locations.set(key, { label, entities: entMap });
+    }
+    return { locations, tierUsed: 2 };
+  }
+
+  it("matches entity ending with _{slug}", () => {
+    const discovery = makeDiscovery([
+      ["cfg_paris", "Auto", { birch: "sensor.niveau_bouleau_paris" }],
+    ]);
+
+    const result = findLocationBySlug(discovery, "paris");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_paris");
+  });
+
+  it("matches entity ending with _{slug}_j_1 via default suffixExtras", () => {
+    const discovery = makeDiscovery([
+      ["cfg_paris", "Auto", { birch: "sensor.niveau_bouleau_paris_j_1" }],
+    ]);
+
+    const result = findLocationBySlug(discovery, "paris");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_paris");
+  });
+
+  it("custom suffixExtras: matches _{slug}_v2 if provided", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "Auto", { birch: "sensor.birch_cityname_v2" }],
+    ]);
+
+    const result = findLocationBySlug(discovery, "cityname", { suffixExtras: ["", "_v2"] });
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("does not match _{slug}_j_1 when suffixExtras is empty array", () => {
+    const discovery = makeDiscovery([
+      ["cfg_paris", "Auto", { birch: "sensor.niveau_bouleau_paris_j_1" }],
+    ]);
+
+    // Without "_j_1" in suffixExtras, only plain suffix matches
+    const result = findLocationBySlug(discovery, "paris", { suffixExtras: [] });
+    expect(result).toBeNull();
+  });
+
+  it("no match returns null", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "Auto", { birch: "sensor.niveau_bouleau_abc" }],
+    ]);
+
+    expect(findLocationBySlug(discovery, "xyz")).toBeNull();
+  });
+
+  it("null slug returns null", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "Auto", { birch: "sensor.birch_abc" }],
+    ]);
+
+    expect(findLocationBySlug(discovery, null)).toBeNull();
+    expect(findLocationBySlug(discovery, "")).toBeNull();
+  });
+
+  it("slugExtractor used for custom matching", () => {
+    const discovery = makeDiscovery([
+      ["cfg_abc", "Auto", { birch: "sensor.prefix_birch_NICE_extra" }],
+    ]);
+
+    // Extractor pulls out the city name from a known position
+    const slugExtractor = (eid) => {
+      const m = eid.match(/_([A-Z]+)_extra$/);
+      return m ? m[1].toLowerCase() : null;
+    };
+
+    const result = findLocationBySlug(discovery, "nice", { slugExtractor });
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_abc");
+  });
+});

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -742,6 +742,19 @@ describe("resolveLocationByKey", () => {
     expect(result[0]).toBe("cfg_abc");
   });
 
+  it("empty cfgLocation with all-numeric keys sorts numerically, not lexicographically", () => {
+    // "102" < "50" lexicographically but 50 < 102 numerically. DWD region IDs
+    // are numeric strings; the user expects region 50 to come first.
+    const discovery = makeDiscovery([
+      ["102", "102 Mittelgebirge", { birke: "sensor.pollenflug_birke_102" }],
+      ["50", "50 Brandenburg", { birke: "sensor.pollenflug_birke_50" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("50");
+  });
+
   it("exact key match", () => {
     const discovery = makeDiscovery([
       ["cfg_abc", "City A", { birch: "sensor.birch_a" }],
@@ -771,6 +784,36 @@ describe("resolveLocationByKey", () => {
     const result = resolveLocationByKey(discovery, "paris");
     expect(result).not.toBeNull();
     expect(result[0]).toBe("cfg_abc");
+  });
+
+  it("slug extractor takes precedence over fuzzy label substring", () => {
+    // Regression: cfg.region_id "50" must resolve to the region-50 entity
+    // via its slugExtractor match, not to a location whose label happens to
+    // include "50" as a substring (e.g. "150 Other Place").
+    const discovery = makeDiscovery([
+      ["cfg_wrong", "150 Other Place", { birke: "sensor.pollenflug_birke_150" }],
+      ["cfg_right", "50 Brandenburg", { birke: "sensor.pollenflug_birke_50" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "50", {
+      slugExtractor: (eid) => {
+        const m = eid.match(/_(\d+)$/);
+        return m ? m[1] : null;
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_right");
+  });
+
+  it("exact case-insensitive label equality beats fuzzy substring", () => {
+    const discovery = makeDiscovery([
+      ["cfg_substr", "Hamburger Meile", { birch: "sensor.x_birch" }],
+      ["cfg_exact",  "Hamburg",          { birch: "sensor.y_birch" }],
+    ]);
+
+    const result = resolveLocationByKey(discovery, "hamburg");
+    expect(result).not.toBeNull();
+    expect(result[0]).toBe("cfg_exact");
   });
 
   it("no match returns null", () => {

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -405,6 +405,52 @@ describe("discoverEntitiesByDevice", () => {
     expect(loc.entities.has("birch_alt")).toBe(true);
   });
 
+  it("onCollision returning a key that already exists is ignored (no overwrite)", () => {
+    // Regression: earlier code used locEntities.set(newKey, eid) unconditionally.
+    // If onCollision returned an already-occupied key (including existingKey),
+    // the original sensor mapping would be silently overwritten.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_grass_cat",
+        state: "3",
+        deviceId: "dev_abc",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_graminales",
+        state: "2",
+        deviceId: "dev_abc",
+        platform: "testint",
+      },
+      {
+        entityId: "sensor.testint_gras_2",
+        state: "1",
+        deviceId: "dev_abc",
+        platform: "testint",
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: (eid) => {
+        if (eid.includes("grass_cat") || eid.includes("gras_2")) return "grass_cat";
+        if (eid.includes("graminales")) return "graminales";
+        return null;
+      },
+      // Collision handler returns an already-used key → must be ignored.
+      onCollision: () => "graminales",
+    });
+
+    const loc = discovery.locations.values().next().value;
+    expect(loc.entities.get("grass_cat")).toBe("sensor.testint_grass_cat");
+    expect(loc.entities.get("graminales")).toBe("sensor.testint_graminales");
+    expect(loc.entities.size).toBe(2);
+  });
+
   it("onCollision returning null skips the colliding entity", () => {
     const hass = createHassWithRegistry([
       {
@@ -537,6 +583,45 @@ describe("discoverEntitiesByDevice", () => {
     expect(loc).toBeDefined();
     expect(loc.deviceId).toBe("dev_later");
     expect(loc.entities.size).toBe(2);
+  });
+
+  it("label is upgraded when device context first becomes available for a bucket", () => {
+    // First entity has no device → label falls back to friendly_name.
+    // Second entity provides a device with name_by_user → label must upgrade.
+    const hass = {
+      states: {
+        "sensor.abc_alder": { state: "0", attributes: { friendly_name: "Fallback name" } },
+        "sensor.abc_birch": { state: "1", attributes: {} },
+      },
+      entities: {
+        "sensor.abc_alder": { device_id: null, platform: "abc", entity_category: null },
+        "sensor.abc_birch": { device_id: "dev_rich", platform: "abc", entity_category: null },
+      },
+      devices: {
+        dev_rich: {
+          identifiers: [],
+          config_entries: ["cfg_rich"],
+          name: "Device Name",
+          name_by_user: "User Label",
+        },
+      },
+      locale: { language: "en" },
+      language: "en",
+    };
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "abc",
+      classify: (eid) => {
+        if (eid.includes("alder")) return "alder";
+        if (eid.includes("birch")) return "birch";
+        return null;
+      },
+      resolveLocationKey: () => "shared",
+    });
+
+    const loc = discovery.locations.get("shared");
+    expect(loc.label).toBe("User Label");
+    expect(loc.deviceId).toBe("dev_rich");
   });
 
   it("tier 2 without hass.devices still sets loc.deviceId when entry.device_id is present", () => {

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -143,7 +143,7 @@ describe("findAvailableSensors", () => {
       expect(result).toEqual(["sensor.pollenflug_birke_50"]);
     });
 
-    it("returns empty when multiple candidates exist without explicit region_id", () => {
+    it("auto-selects first region when multiple candidates exist without explicit region_id", () => {
       const hass = createHass({
         "sensor.pollenflug_birke_50": s(),
         "sensor.pollenflug_birke_91": s(),
@@ -156,8 +156,10 @@ describe("findAvailableSensors", () => {
 
       const result = findAvailableSensors(cfg, hass);
 
-      // Two candidates -> no unique match -> empty
-      expect(result).toEqual([]);
+      // Discovery groups by region; empty region_id picks the first location.
+      // The exact entity returned depends on Map insertion order (region 50 first).
+      expect(result.length).toBe(1);
+      expect(result[0]).toMatch(/^sensor\.pollenflug_birke_\d+$/);
     });
   });
 

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -156,10 +156,9 @@ describe("findAvailableSensors", () => {
 
       const result = findAvailableSensors(cfg, hass);
 
-      // Discovery groups by region; empty region_id picks the first location.
-      // The exact entity returned depends on Map insertion order (region 50 first).
-      expect(result.length).toBe(1);
-      expect(result[0]).toMatch(/^sensor\.pollenflug_birke_\d+$/);
+      // Discovery groups by region; when region_id is empty, location keys
+      // are sorted lexicographically and the first ("50") is selected.
+      expect(result).toEqual(["sensor.pollenflug_birke_50"]);
     });
   });
 

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -157,7 +157,8 @@ describe("findAvailableSensors", () => {
       const result = findAvailableSensors(cfg, hass);
 
       // Discovery groups by region; when region_id is empty, location keys
-      // are sorted lexicographically and the first ("50") is selected.
+      // are sorted deterministically (numerically for all-digit DWD region IDs)
+      // and the first ("50") is selected.
       expect(result).toEqual(["sensor.pollenflug_birke_50"]);
     });
   });

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -171,19 +171,19 @@ describe("findAvailableSensors", () => {
     it("returns sensors for a configured location and allergens", () => {
       const hass = createHass({
         "sensor.polleninformation_wien_birch": s(),
-        "sensor.polleninformation_wien_grass": s(),
+        "sensor.polleninformation_wien_grasses": s(),
       });
       const cfg = {
         integration: "peu",
         location: "Wien",
-        allergens: ["birch", "grass"],
+        allergens: ["birch", "grasses"],
       };
 
       const result = findAvailableSensors(cfg, hass);
 
       expect(result).toEqual([
         "sensor.polleninformation_wien_birch",
-        "sensor.polleninformation_wien_grass",
+        "sensor.polleninformation_wien_grasses",
       ]);
     });
 

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -239,7 +239,7 @@ describe("findAvailableSensors", () => {
     describe("discovery path (hass.entities available)", () => {
       it("returns sensors via entity registry discovery", () => {
         const deviceId = "device_1";
-        const configEntryId = "01ABCDEFGHIJKLMNOPQRSTUVWX";
+        const configEntryId = "01ABCDEFGHJKMNPQRSTVWXYZ12";
         const hass = createHass(
           {
             "sensor.silam_pollen_london_birch_pollen": s(),
@@ -284,7 +284,7 @@ describe("findAvailableSensors", () => {
 
       it("maps translation_key through silam allergen map to master key", () => {
         const deviceId = "device_1";
-        const configEntryId = "01ABCDEFGHIJKLMNOPQRSTUVWX";
+        const configEntryId = "01ABCDEFGHJKMNPQRSTVWXYZ12";
         // Dutch translation_key "berk" maps to master "birch"
         const hass = createHass(
           {


### PR DESCRIPTION
## Summary

Implements issue #202: extracts Atmo France's three-tier device-based entity discovery into a shared helper and migrates every adapter to use it. Adds tier-1 device identifier support where it was missing (SILAM, GPL, GP) and adds full device/platform discovery where it was absent (PP, DWD, PEU, PLU). Ready to ship with v3.2.0.

## Changes

- **New** `discoverEntitiesByDevice(hass, opts)` in `src/utils/adapter-helpers.js`. Three-tier cascade: `hass.devices` identifier scan → `hass.entities` platform filter → `hass.states` regex/selector fallback. Configurable classifier (strict + relaxed), relevance filter, label resolver, location-key resolver, collision callback, and tier-3 regex or custom selector. Tier-1/2 produce deterministic auto-select, deviceId backfill across bucket members, and label upgrade when richer device context arrives.
- **New** `findLocationBySlug` and `resolveLocationByKey` helpers generalized from Atmo's slug-matching logic. Resolution chain: empty cfg -> exact key -> case-insensitive label equality -> slug fallback -> fuzzy substring.
- **Ported** Atmo to the shared helper (~130 line reduction, identical behavior).
- **Upgraded** SILAM to include tier-1 device identifier scan while keeping weather-entity postprocess path.
- **Migrated** GPL to the shared helper with attribution-based tier-3 selector.
- **Migrated** GP to the shared helper with `onCollision` callback preserving the plant-vs-category reclassification for Swedish "Gräs". Collision handler guards against returning already-used keys so existing sensor mappings are never silently overwritten.
- **Added** device-based discovery to PP, DWD, PEU, PLU with template/alias fallback preserved for backwards compatibility.
  - PP: **whitelist classifier** over `PP_ALLERGEN_SLUGS` (longest-suffix-first) so multi-word allergens like `salg_och_viden` parse correctly. Tier-3 labels resolve back through `PP_POSSIBLE_CITIES` to preserve diacritics ("Göteborg", "Malmö").
  - DWD: regex classifier on `sensor.pollenflug_{allergen}_{region}`, region-ID as legacy key. Tier-3 labels prefixed with region ID since `DWD_REGIONS` is not a bijection (11 and 12 share a name).
  - PEU: **whitelist classifier** (longest-suffix-first, precomputed at module scope) avoids the previous greedy-regex fragility; `allergy_risk_hourly` mode-mapped correctly. Exports `extractPeuLocationSlugFromEntityId` for editor + card consumers.
  - PLU: reverse alias-map classifier, `resolveLocationKey: () => "default"` (no location dimension), alias-probe retained as fallback.
- **Card header** rendering uses cached PP/DWD/PEU/GPL discovery from `set hass()` instead of re-scanning the registry per HA update.
- **Editor** location dropdowns for PP, DWD, PEU now populated from shared discovery, with legacy slug/region_id entries preserved so saved configs continue to display the correct value. Sort is deterministic (numeric for all-digit keys, label otherwise).
- **Stale-config recovery**: DWD/GP/GPL `resolveEntityIds` retry with autodetect when a saved ULID location is no longer in discovered locations (post-reinstall, regrouped tier-3 buckets, etc.).
- **Docs**: CLAUDE.md now points new integrations at the shared helper.
- **Architecture**: `isConfigEntryId` lives in `utils/adapter-helpers.js` with a tightened Crockford-base32 regex (excludes I/L/O/U) to avoid a circular dependency with `utils/silam.js`.

## Test plan

- [x] Unit tests: **869/869 green** (includes new helper tests, per-adapter discovery-tier tests, collision/backfill/label regression cases)
- [x] `npm run build` succeeds (1010 kB raw, 240 kB gzip)
- [x] HACS validation passes (`validate-hacs` CI job green)
- [x] Deployed to hass-test environment
- [x] Manual QA in HA (Issue 202 dashboard view with entry_id vs slug comparison per adapter):
  - [x] Atmo tier 1: 5 devices → 4 locations (Nice, Toulouse, Chambray-lès-Tours, Plouha)
  - [x] SILAM tier 1: 3 devices → 3 locations (Trier, Karis, Stockholm)
  - [x] GP tier 1: 4 devices → 4 locations, `onCollision` verified reclassifying `grass_cat` → `graminales` for Swedish/Spanish/Ukrainian labels
  - [x] GPL tier 1: 6 devices → 2 locations (Hem, Testplats)
  - [x] PP tier 1: 3 devices → 3 locations (Forshaga, Visby, Malmö); multi-word allergen `salg_och_viden` resolves correctly
  - [x] DWD tier 1: 1 device → 1 location
  - [x] PEU tier 1: 1 device → 1 location (`allergy_risk_hourly` parsed correctly)
  - [x] PLU tier 2: platform-scan succeeds (pollen_lu integration does not set device identifiers)
  - [x] Legacy slug configs (PP `city: "Forshaga"`, DWD `region_id: "102"`, PEU `location: "hamburg"`, SILAM/Atmo slugs) continue to render identical data to their entry_id counterparts
  - [x] Zero new console errors across full dashboard

## Backwards compatibility

All legacy configs continue to work. Each adapter's `resolveEntityIds` tries (1) manual mode, (2) shared discovery with `resolveLocationByKey` (including slug fallback via `findLocationBySlug` and stale-ULID autodetect retry), (3) original template/regex path as safety net. No automatic config migration is written; users optionally re-select in the editor.

## Review status

9 rounds of Copilot Code Review across 14 commits today; all comments addressed or verified already-fixed. Final round (commit `df3b147`) returned `0 new comments`.

Cumulative review topics covered: PEU sort precomputation, deviceId backfill across buckets, deterministic auto-select, DWD unique labels, deterministic test helpers, circular dep break, collision-overwrite guard, label upgrade on backfill, case-insensitive label match, Crockford-strict ULID regex, mock `entity_id` field, header discovery cache (PP/DWD/PEU/GPL), JSDoc accuracy, second-block dropdown sorting, ULID-as-autodetect in PP/PEU template fallback, GPL cache reuse, PP diacritic restoration, **multi-word allergen suffix whitelist** (PP_ALLERGEN_SLUGS) across classifier/extractor/editor/card consumers, exported PEU location-slug helper, defensive `fallbackSelector` validation, stale-ULID recovery in DWD/GP/GPL.

## Open items before release

- Platform slugs for PP (`pollenprognos`), DWD (`dwd_pollenflug`, `pollenflug`), PEU (`polleninformation`), PLU (`pollen_lu`, `pollenlu`) are defensive guesses. PP/DWD/PEU confirmed working in hass-test. PLU falls through to tier 2 as expected (pollen_lu integration does not expose `identifiers`). If an upstream integration uses a different slug, tier 2 silently falls through and the existing template/alias path takes over -- no user-visible regression.

## Out of scope

- Issue #206 (Kleenex adapter improvements: clearer messaging when NA-region data lacks per-allergen detail; optional fallback to `KleenexDetailSensor` entities). Pre-existing behavior, not a regression from this PR.

Closes #202