### PR TITLE
(gpl,gp) Locale-agnostic location-label normalization (closes #208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - (kleenex) Add per-allergen DetailSensor fallback and a clearer warning for US zones where the API only returns category totals (issue #206).
 
+### Fixed
+- (gpl, gp) Strip integration-appended " - <category> (<lat>,<lng>)" suffix from location labels (issue #208). Previously the editor dropdown and card title leaked text like "Hem - Pollentyper (50.45, 30.52)". Now uses a locale-agnostic util that handles any HA language, applied at both discovery and the card's title resolver for defense-in-depth.
+
 ## [3.1.0] - 2026-04-19
 
 ### Added

--- a/src/adapters/gp/discovery.js
+++ b/src/adapters/gp/discovery.js
@@ -1,5 +1,6 @@
 // src/adapters/gp/discovery.js
 import { normalizeManualPrefix, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
+import { cleanDeviceLabel } from "../../utils/device-label.js";
 import { GP_DOMAIN, GP_DISPLAY_NAME_MAP, GP_COLLISION_PLANTS, GP_BASE_ALLERGENS } from "./constants.js";
 
 // Regex to extract pollen code from unique_id.
@@ -119,6 +120,22 @@ export function discoverGpSensors(hass, debug = false) {
     fallbackSelector: (h) => Object.keys(h.states).filter((eid) =>
       eid.startsWith("sensor.google_pollen_")
     ),
+
+    /**
+     * resolveLabel for GP — same shape as GPL: user override wins,
+     * otherwise device.name is normalized via the locale-agnostic
+     * cleanDeviceLabel util to strip integration-appended " - <category>
+     * (<lat>,<lng>)" suffixes.
+     */
+    resolveLabel: (ctx) => {
+      if (ctx.device?.name_by_user) return ctx.device.name_by_user;
+      const cleaned = cleanDeviceLabel(ctx.device?.name);
+      if (typeof cleaned === "string" && cleaned.trim()) return cleaned;
+      if (ctx.state?.attributes?.friendly_name) {
+        return cleanDeviceLabel(ctx.state.attributes.friendly_name);
+      }
+      return "Auto";
+    },
 
     debug,
     logTag: "GP",

--- a/src/adapters/gpl/discovery.js
+++ b/src/adapters/gpl/discovery.js
@@ -1,6 +1,7 @@
 // src/adapters/gpl/discovery.js
 import { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS } from "./constants.js";
 import { discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
+import { cleanDeviceLabel } from "../../utils/device-label.js";
 
 /**
  * Classify a GPL sensor by its attributes.
@@ -66,29 +67,20 @@ export function discoverGplSensors(hass, debug = false) {
 
     /**
      * resolveLabel priority for GPL:
-     *   1. device.name_by_user -- explicit user override.
-     *   2. device.name with the "- Pollentyper (lat, lon)" suffix stripped,
-     *      since the HA integration names devices "{user-name} - Pollentyper
-     *      ({lat}, {lon})". Without stripping, the label becomes a useless
-     *      coordinate-laden title in both editor dropdown and card header.
-     *   3. device.name as-is (defensive).
-     *   4. friendly_name from state.attributes.
-     *   5. "Auto" fallback.
+     *   1. device.name_by_user -- explicit user override, kept verbatim.
+     *   2. device.name run through cleanDeviceLabel to strip the
+     *      "{location} - {category-localized} ({lat},{lng})" suffix that
+     *      the pollenlevels integration appends. cleanDeviceLabel uses a
+     *      locale-agnostic regex so new HA languages don't regress this.
+     *   3. friendly_name from state.attributes.
+     *   4. "Auto" fallback.
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
-      const raw = ctx.device?.name;
-      if (typeof raw === "string" && raw.trim()) {
-        // Strip " - Pollentyper (...)" / " - Pollen types (...)" /
-        // " - Pollentypen (...)" suffixes the upstream integration appends.
-        const cleaned = raw
-          .replace(/\s*[-–—]\s*pollen\s*(?:typer|typen|types)\s*\([^)]*\)\s*$/i, "")
-          .trim();
-        if (cleaned) return cleaned;
-        return raw.trim();
-      }
+      const cleaned = cleanDeviceLabel(ctx.device?.name);
+      if (typeof cleaned === "string" && cleaned.trim()) return cleaned;
       if (ctx.state?.attributes?.friendly_name) {
-        return ctx.state.attributes.friendly_name;
+        return cleanDeviceLabel(ctx.state.attributes.friendly_name);
       }
       return "Auto";
     },

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -6,6 +6,7 @@ import { svgs, getSvgContent } from "./pollenprognos-svgs.js";
 import { t, detectLang } from "./i18n.js";
 import { getAdapter, getStubConfig } from "./adapter-registry.js";
 import { findAvailableSensors } from "./utils/sensors.js";
+import { cleanDeviceLabel } from "./utils/device-label.js";
 import {
   filterSensorsPostFetch,
   resolveLocationByKey,
@@ -1650,18 +1651,11 @@ class PollenPrognosCard extends LitElement {
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const gplMatch = resolveLocationByKey(gplDiscovery, wantedLocation);
-        let title = gplMatch ? gplMatch[1].label : "";
-
-        // Clean up device name if it looks like a friendly_name with type suffix
-        if (title) {
-          title = title
-            .replace(/\s*(grass|tree|weed)\s*$/i, "")
-            .replace(/\s*type\s*$/i, "")
-            .trim();
-          if (title) {
-            title = title.charAt(0).toUpperCase() + title.slice(1);
-          }
-        }
+        // Defensive: discovery already calls cleanDeviceLabel, but apply again
+        // here so a future discovery refactor that drops the call doesn't leak
+        // the integration's "- <category> (<coords>)" suffix into the title.
+        let title = gplMatch ? cleanDeviceLabel(gplMatch[1].label) : "";
+        if (title) title = title.charAt(0).toUpperCase() + title.slice(1);
 
         loc = title || cfg.location || "";
       } else if (integration === "gp") {
@@ -1671,7 +1665,8 @@ class PollenPrognosCard extends LitElement {
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const gpMatch = resolveLocationByKey(gpDiscovery, wantedLocation);
-        const title = gpMatch ? gpMatch[1].label : "";
+        // Defensive: same rationale as the GPL branch above.
+        const title = gpMatch ? cleanDeviceLabel(gpMatch[1].label) : "";
 
         loc = title || cfg.location || "";
       } else if (integration === "plu") {

--- a/src/utils/device-label.js
+++ b/src/utils/device-label.js
@@ -1,0 +1,49 @@
+// src/utils/device-label.js
+
+/**
+ * Normalize an HA-derived device name for display as a location label.
+ *
+ * Several pollen integrations (pollenlevels for sure, others suspected)
+ * name devices as:
+ *
+ *   "<user-given-name> - <category-localized> (<lat>,<lng>)"
+ *
+ * The category word varies by HA language: Swedish "Pollentyper", German
+ * "Pollentypen", English "Pollen types", French "Niveaux de pollen", etc.
+ * The coordinate-laden suffix is unhelpful in editor dropdowns and card
+ * titles. The user just wants their location name back.
+ *
+ * Strategy (locale-agnostic):
+ *   1. Strip a trailing parenthesized segment whose contents look like
+ *      decimal coordinates (digits, dot, comma, sign, whitespace only).
+ *      This avoids matching parens that contain real text.
+ *   2. If (1) matched, drop a trailing " - <something>" too. Use the LAST
+ *      occurrence so hyphenated locations like "Saint-Cloud" survive.
+ *   3. If (1) did NOT match, leave the string unchanged. Without a
+ *      coordinate signal we can't tell integration noise from a real name.
+ *
+ * Returns the cleaned string. Empty cleanup result falls back to the
+ * trimmed input. Non-string inputs are returned as-is.
+ *
+ * History note: this util exists to stop a recurring regression where
+ * inline cleanup logic in adapter discovery code keeps getting refactored
+ * away. See issue #208 for the latest occurrence.
+ */
+export function cleanDeviceLabel(raw) {
+  if (typeof raw !== "string") return raw;
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  const COORD_PAREN = /\s*\([\s\d.,+\-]+\)\s*$/;
+  const stripped = trimmed.replace(COORD_PAREN, "").trim();
+  if (stripped === trimmed) return trimmed;
+
+  // Match the LAST " - " / " – " / " — " separator so hyphenated locations
+  // like "Saint-Cloud" survive while a trailing " - <category>" is removed.
+  const SEP = /\s+[-–—]\s+(?=[^-–—]*$)/;
+  const sepMatch = stripped.match(SEP);
+  const final = sepMatch
+    ? stripped.slice(0, sepMatch.index).trim()
+    : stripped;
+  return final || trimmed;
+}

--- a/src/utils/device-label.js
+++ b/src/utils/device-label.js
@@ -34,16 +34,24 @@ export function cleanDeviceLabel(raw) {
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
 
-  const COORD_PAREN = /\s*\([\s\d.,+\-]+\)\s*$/;
+  // Require two numeric values separated by a comma (i.e. lat/lng shape) so
+  // legitimate names like "Office (123)" or "Paris (2024)" aren't stripped.
+  // Each value: optional sign, digits, optional decimal part. Whitespace
+  // tolerated around values and the comma.
+  const COORD_PAREN = /\s*\(\s*[+\-]?\d+(?:\.\d+)?\s*,\s*[+\-]?\d+(?:\.\d+)?\s*\)\s*$/;
   const stripped = trimmed.replace(COORD_PAREN, "").trim();
   if (stripped === trimmed) return trimmed;
 
-  // Match the LAST " - " / " – " / " — " separator so hyphenated locations
-  // like "Saint-Cloud" survive while a trailing " - <category>" is removed.
-  const SEP = /\s+[-–—]\s+(?=[^-–—]*$)/;
-  const sepMatch = stripped.match(SEP);
-  const final = sepMatch
-    ? stripped.slice(0, sepMatch.index).trim()
-    : stripped;
+  // Drop a trailing " - <suffix>" / " – <suffix>" / " — <suffix>" using the
+  // LAST occurrence of any of the separator variants. Hyphenated location
+  // names like "Saint-Cloud" survive because their internal hyphen has no
+  // surrounding spaces. Suffixes that contain hyphens (e.g. "Pollen-types")
+  // are still removed because we match on the separator's whitespace context,
+  // not on what follows.
+  const lastHyphen = stripped.lastIndexOf(" - ");
+  const lastEnDash = stripped.lastIndexOf(" – ");
+  const lastEmDash = stripped.lastIndexOf(" — ");
+  const sepIdx = Math.max(lastHyphen, lastEnDash, lastEmDash);
+  const final = sepIdx >= 0 ? stripped.slice(0, sepIdx).trim() : stripped;
   return final || trimmed;
 }

--- a/test/adapters/gp.test.js
+++ b/test/adapters/gp.test.js
@@ -249,6 +249,49 @@ describe("discoverGpSensors: primary path (hass.entities)", () => {
     expect(loc.entities.size).toBe(1);
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
+
+  it("strips integration-appended ' - <category> (<coords>)' suffix from device label", () => {
+    // Locale-agnostic via cleanDeviceLabel — Swedish, French, Italian all
+    // covered by the same regex (no enumerated category list).
+    const cases = [
+      ["Hem - Pollentyper (50.45, 30.52)", "Hem"],
+      ["Paris - Niveaux de pollen (48.85, 2.35)", "Paris"],
+      ["Saint-Cloud - Pollentyper (48.84, 2.21)", "Saint-Cloud"],
+    ];
+    for (const [deviceName, expected] of cases) {
+      const statesMap = {
+        "sensor.google_pollen_grass": makeSensor("Grass", 3),
+      };
+      const entitiesMap = {
+        "sensor.google_pollen_grass": { device_id: "dev1" },
+      };
+      const devicesMap = {
+        dev1: { name: deviceName, config_entries: ["entry-gp-xyz"] },
+      };
+      const hass = makeHassPrimary(statesMap, entitiesMap, devicesMap);
+      const result = discoverGpSensors(hass);
+      expect(result.locations.get("entry-gp-xyz").label).toBe(expected);
+    }
+  });
+
+  it("name_by_user wins over device.name cleanup", () => {
+    const statesMap = {
+      "sensor.google_pollen_grass": makeSensor("Grass", 3),
+    };
+    const entitiesMap = {
+      "sensor.google_pollen_grass": { device_id: "dev1" },
+    };
+    const devicesMap = {
+      dev1: {
+        name: "Hem - Pollentyper (50.45, 30.52)",
+        name_by_user: "Min trädgård",
+        config_entries: ["entry-gp-user"],
+      },
+    };
+    const hass = makeHassPrimary(statesMap, entitiesMap, devicesMap);
+    const result = discoverGpSensors(hass);
+    expect(result.locations.get("entry-gp-user").label).toBe("Min trädgård");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/adapters/gpl.test.js
+++ b/test/adapters/gpl.test.js
@@ -288,10 +288,16 @@ describe("discoverGplSensors: primary path (hass.entities)", () => {
     expect(result.locations.get("entry-abc-123").label).toBe("Hem");
   });
 
-  it("strips English 'Pollen types' and German 'Pollentypen' variants too", () => {
+  it("strips device-name suffix in a locale-agnostic way (English/German/French/Italian/Japanese)", () => {
+    // The cleanDeviceLabel util uses a coordinate-shaped paren regex, not
+    // an enumerated list of category words. New HA languages should not
+    // regress this behavior.
     const cases = [
       ["Garden - Pollen types (51.5, -0.1)", "Garden"],
       ["Berlin - Pollentypen (52.5, 13.4)", "Berlin"],
+      ["Paris - Niveaux de pollen (48.8566, 2.3522)", "Paris"],
+      ["Roma - Tipi di polline (41.9028, 12.4964)", "Roma"],
+      ["Tokyo - 花粉タイプ (35.6762, 139.6503)", "Tokyo"],
     ];
     for (const [deviceName, expected] of cases) {
       const statesMap = {
@@ -307,6 +313,24 @@ describe("discoverGplSensors: primary path (hass.entities)", () => {
       const result = discoverGplSensors(hass);
       expect(result.locations.get("entry-xyz").label).toBe(expected);
     }
+  });
+
+  it("preserves hyphenated location names like 'Saint-Cloud'", () => {
+    const statesMap = {
+      "sensor.pollenlevels_grass": makeTypeSensor("mdi:grass", 3),
+    };
+    const entitiesMap = {
+      "sensor.pollenlevels_grass": { device_id: "dev1" },
+    };
+    const devicesMap = {
+      dev1: {
+        name: "Saint-Cloud - Pollentyper (48.84, 2.21)",
+        config_entries: ["entry-sc"],
+      },
+    };
+    const hass = makeHasPrimary(statesMap, entitiesMap, devicesMap);
+    const result = discoverGplSensors(hass);
+    expect(result.locations.get("entry-sc").label).toBe("Saint-Cloud");
   });
 
   it("name_by_user wins over device.name stripping", () => {

--- a/test/utils/device-label.test.js
+++ b/test/utils/device-label.test.js
@@ -56,6 +56,14 @@ describe("cleanDeviceLabel: no-op cases", () => {
     expect(cleanDeviceLabel("Hem - Office (Building B)")).toBe("Hem - Office (Building B)");
   });
 
+  it("does not strip a single-number parenthesized suffix (not coordinate-shaped)", () => {
+    // Legitimate names with sequence numbers, year suffixes, etc.
+    expect(cleanDeviceLabel("Home (2)")).toBe("Home (2)");
+    expect(cleanDeviceLabel("Paris (2024)")).toBe("Paris (2024)");
+    expect(cleanDeviceLabel("Office (123)")).toBe("Office (123)");
+    expect(cleanDeviceLabel("Sensor (3.14)")).toBe("Sensor (3.14)");
+  });
+
   it("does not strip ' - <suffix>' when no coord-paren is present", () => {
     // Without the coord signal, we can't tell integration noise from a
     // legitimate dashed name like a venue suffix. Leave it alone.
@@ -85,6 +93,13 @@ describe("cleanDeviceLabel: coordinate-paren variants", () => {
   it("strips coord-paren even without ' - <suffix>' before it", () => {
     // Edge case: device named only "<location> (<coords>)" without separator.
     expect(cleanDeviceLabel("Hem (50.45,30.52)")).toBe("Hem");
+  });
+
+  it("strips suffix even when the suffix itself contains a hyphen", () => {
+    // The separator regex uses lastIndexOf on whitespace-padded separators,
+    // so dashes inside the suffix don't block matching.
+    expect(cleanDeviceLabel("Hem - Pollen-types (50.45,30.52)")).toBe("Hem");
+    expect(cleanDeviceLabel("Hem - co2-monitor data (50.45,30.52)")).toBe("Hem");
   });
 });
 

--- a/test/utils/device-label.test.js
+++ b/test/utils/device-label.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { cleanDeviceLabel } from "../../src/utils/device-label.js";
+
+describe("cleanDeviceLabel: locale matrix", () => {
+  it("strips Swedish 'Pollentyper (lat,lng)' suffix", () => {
+    expect(cleanDeviceLabel("Hem - Pollentyper (50.450034,30.524136)")).toBe("Hem");
+  });
+
+  it("strips German 'Pollentypen (lat,lng)' suffix", () => {
+    expect(cleanDeviceLabel("Stockholm - Pollentypen (59.3293,18.0686)")).toBe("Stockholm");
+  });
+
+  it("strips English 'Pollen types (lat,lng)' suffix", () => {
+    expect(cleanDeviceLabel("Lyon - Pollen types (45.764,4.8357)")).toBe("Lyon");
+  });
+
+  it("strips multi-word French 'Niveaux de pollen' suffix", () => {
+    expect(cleanDeviceLabel("Paris - Niveaux de pollen (48.8566,2.3522)")).toBe("Paris");
+  });
+
+  it("strips Italian-style suffix", () => {
+    expect(cleanDeviceLabel("Roma - Tipi di polline (41.9028,12.4964)")).toBe("Roma");
+  });
+
+  it("works for an unknown future locale (locale-agnostic)", () => {
+    // Whatever the integration appends, as long as the (<coords>) trailer
+    // looks numeric, the strip kicks in.
+    expect(cleanDeviceLabel("Tokyo - 花粉タイプ (35.6762,139.6503)")).toBe("Tokyo");
+  });
+});
+
+describe("cleanDeviceLabel: hyphenated location names", () => {
+  it("preserves internal hyphens when the suffix is stripped", () => {
+    expect(cleanDeviceLabel("Saint-Cloud - Pollentyper (48.84,2.21)")).toBe("Saint-Cloud");
+  });
+
+  it("preserves a fully hyphenated name when no suffix is present", () => {
+    expect(cleanDeviceLabel("Saint-Cloud")).toBe("Saint-Cloud");
+  });
+
+  it("handles em-dash and en-dash in the separator (defensive)", () => {
+    expect(cleanDeviceLabel("Hem – Pollentyper (50.45,30.52)")).toBe("Hem");
+    expect(cleanDeviceLabel("Hem — Pollentyper (50.45,30.52)")).toBe("Hem");
+  });
+});
+
+describe("cleanDeviceLabel: no-op cases", () => {
+  it("leaves an already-clean name untouched", () => {
+    expect(cleanDeviceLabel("Hem")).toBe("Hem");
+    expect(cleanDeviceLabel("My Custom Location")).toBe("My Custom Location");
+  });
+
+  it("does not strip parenthesized text that is not coordinate-shaped", () => {
+    expect(cleanDeviceLabel("My Lab (Test)")).toBe("My Lab (Test)");
+    expect(cleanDeviceLabel("Office (Building B)")).toBe("Office (Building B)");
+    expect(cleanDeviceLabel("Hem - Office (Building B)")).toBe("Hem - Office (Building B)");
+  });
+
+  it("does not strip ' - <suffix>' when no coord-paren is present", () => {
+    // Without the coord signal, we can't tell integration noise from a
+    // legitimate dashed name like a venue suffix. Leave it alone.
+    expect(cleanDeviceLabel("Branch Office - Annex")).toBe("Branch Office - Annex");
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(cleanDeviceLabel("  Hem  ")).toBe("Hem");
+  });
+});
+
+describe("cleanDeviceLabel: coordinate-paren variants", () => {
+  it("handles coord-paren with internal whitespace", () => {
+    expect(cleanDeviceLabel("Hem - Pollentyper (50.45, 30.52)")).toBe("Hem");
+    expect(cleanDeviceLabel("Hem - Pollentyper ( 50.45 , 30.52 )")).toBe("Hem");
+  });
+
+  it("handles negative coordinates", () => {
+    expect(cleanDeviceLabel("Quito - Pollen types (-0.18,-78.47)")).toBe("Quito");
+    expect(cleanDeviceLabel("New York - Pollen types (40.71,-74.01)")).toBe("New York");
+  });
+
+  it("handles coordinates with explicit + sign", () => {
+    expect(cleanDeviceLabel("Place - Type (+50.45,+30.52)")).toBe("Place");
+  });
+
+  it("strips coord-paren even without ' - <suffix>' before it", () => {
+    // Edge case: device named only "<location> (<coords>)" without separator.
+    expect(cleanDeviceLabel("Hem (50.45,30.52)")).toBe("Hem");
+  });
+});
+
+describe("cleanDeviceLabel: defensive input handling", () => {
+  it("returns the input as-is when not a string", () => {
+    expect(cleanDeviceLabel(null)).toBe(null);
+    expect(cleanDeviceLabel(undefined)).toBe(undefined);
+    expect(cleanDeviceLabel(42)).toBe(42);
+    expect(cleanDeviceLabel({})).toEqual({});
+  });
+
+  it("returns empty string for empty/whitespace-only input", () => {
+    expect(cleanDeviceLabel("")).toBe("");
+    expect(cleanDeviceLabel("   ")).toBe("");
+  });
+
+  it("falls back to trimmed input when cleaning would leave empty string", () => {
+    // Pathological case: name is only the coord-paren. The strip would
+    // result in empty string; we return the trimmed original instead.
+    expect(cleanDeviceLabel("(50.45,30.52)")).toBe("(50.45,30.52)");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #208 — recurring bug where the GPL (and GP) location label leaks the integration's localized category and coordinate suffix into the editor dropdown and card title.

Previously labels surfaced as e.g. `Hem - Pollentyper (50.450034,30.524136)`. Now: just `Hem`.

## Why this fix won't regress (the goal)

This bug has been fixed before (commit `5571326` on `feature/device-discovery`) but kept reappearing after refactors. The previous fix was a locale-enumerating inline regex (`typer|typen|types`), so any new HA language silently slipped through. Plus the cleanup logic was scattered across multiple places.

This PR addresses the regression pattern:

1. **Centralized util** at `src/utils/device-label.js` (`cleanDeviceLabel`). One source of truth.
2. **Locale-agnostic regex** — strips any trailing parenthesized segment whose contents look like decimal coordinates (digits, dot, comma, sign, whitespace). No enumerated category words. Adding new HA languages can't break it.
3. **Defense in depth** — applied at GPL discovery, GP discovery, AND the card's auto-title resolver. Two layers must regress simultaneously to expose the raw string again.
4. **Test coverage at two layers** — `test/utils/device-label.test.js` (locale matrix + edge cases) plus discovery-level tests in `test/adapters/gpl.test.js` and `test/adapters/gp.test.js`.

## What changed

- New: `src/utils/device-label.js` — locale-agnostic `cleanDeviceLabel(raw)` util.
- `src/adapters/gpl/discovery.js` — `resolveLabel` callback now uses `cleanDeviceLabel` (drops the inline regex enumerating Swedish/German/English).
- `src/adapters/gp/discovery.js` — adds a `resolveLabel` callback (was previously absent — GP had no cleanup at all).
- `src/pollenprognos-card.js` — replaces the partial `grass|tree|weed|type` cleanup with `cleanDeviceLabel` for both GPL and GP header titles.
- `CHANGELOG.md` — Unreleased entry under "Fixed".

## Test plan

- [x] `npm run test` — full suite passes (913/913 locally)
- [x] `npm run build` — succeeds
- [ ] Manual verification in `hass-test`: editor location dropdown for GPL shows just the user-given name (e.g. `Hem`, `Testplats`), not the localized-category-with-coords. Card title shows `Pollenprognos för Hem`.
- [ ] Manual: a device renamed via HA UI (`name_by_user`) is shown verbatim, NOT munged by the cleanup.
- [ ] No regression in PP/DWD/PEU/SILAM/Kleenex/Atmo/Pollen.lu location dropdowns.

## Out of scope

The pollenlevels HA integration's choice to encode the coordinates in the device name is upstream; we just don't surface that detail to the user.