### PR TITLE
(peu) Drop runtime 0-6 spread for level names (closes #215)

### DIFF
--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -1,8 +1,7 @@
 // src/adapters/peu.js
 import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
-import { buildLevelNames } from "../utils/level-names.js";
-import { indexToLevel } from "./silam.js";
+import { buildLevelNamesForScale } from "../utils/level-names.js";
 import { slugify } from "../utils/slugify.js";
 import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix, resolveManualEntity, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../utils/adapter-helpers.js";
 
@@ -365,24 +364,28 @@ export async function fetchForecast(hass, config) {
   const { lang, locale, daysRelative, dayAbbrev, daysUppercase } = getLangAndLocale(hass, config);
 
   const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } = mergePhrases(config, lang);
-  // Levels from PEU are reported as 0-4 but scaled to 0-6 in the card.
-  // Accept either five or seven custom names and map them to the 0-6 scale.
-  const defaultNumLevels = 5; // original scale
-  const levelNamesDefault = Array.from({ length: 7 }, (_, i) =>
-    t(`card.levels.${i}`, lang),
-  );
-  let levelNames = levelNamesDefault.slice();
-  if (Array.isArray(userLevels)) {
-    if (userLevels.length === 7) {
-      levelNames = buildLevelNames(userLevels, lang);
-    } else if (userLevels.length === defaultNumLevels) {
-      const map = [0, 1, 3, 5, 6];
-      map.forEach((lvl, idx) => {
-        const val = userLevels[idx];
-        if (val != null && val !== "") levelNames[lvl] = val;
-      });
-    }
+  // PEU is natively a five-level integration (0-4: None/Low/Medium/High/Very High).
+  // Earlier versions stretched native states onto the seven-bucket card.levels
+  // palette via a [0, 1, 3, 5, 6] runtime spread to compensate for the lack of
+  // five-level locale strings. Now that card.levels5.0..4 exists in every
+  // locale (added in 3.2.0 for MSW), look names up at native indices instead.
+  // Backwards compat: legacy configs that supplied seven custom phrases
+  // (`phrases.levels` length 7) had their entries placed at indices 0,1,3,5,6
+  // of the seven-bucket array under the spread. Extracting those positions
+  // preserves the user-visible labels exactly: a length-7 input becomes a
+  // length-5 input with the same chosen strings at the same severity steps.
+  let normalizedUserLevels = userLevels;
+  if (Array.isArray(userLevels) && userLevels.length === 7) {
+    normalizedUserLevels = [0, 1, 3, 5, 6].map((i) => userLevels[i]);
   }
+  const levelNames = buildLevelNamesForScale(5, normalizedUserLevels, lang);
+
+  // Clamp a native-scale level value to a 0-4 lookup index. Returns -1 for
+  // non-finite inputs (NaN / undefined / null) so callers can fall back to
+  // the no-info label. Negative finite values clamp to 0 (matches the legacy
+  // behavior where indexToLevel(-1) resolved to scale[0] = 0).
+  const lookupIndex = (level) =>
+    Number.isFinite(level) ? Math.max(0, Math.min(level, 4)) : -1;
 
   const testVal = (v) => clampLevel(v, 4, -1);
 
@@ -481,7 +484,7 @@ export async function fetchForecast(hass, config) {
               entry.numeric_state_raw ?? entry.level_raw ?? displayState,
             );
           }
-          const scaledLevel = indexToLevel(state);
+          const levelIdx = lookupIndex(state);
           const dayObj = {
             name: dict.allergenCapitalized,
             day: label,
@@ -489,11 +492,7 @@ export async function fetchForecast(hass, config) {
             state,
             // Separate property used purely for numeric display.
             display_state: displayState,
-            state_text:
-              scaledLevel < 0
-                ? noInfoLabel
-                : levelNames[scaledLevel] ||
-                  t(`card.levels.${scaledLevel}`, lang),
+            state_text: levelIdx < 0 ? noInfoLabel : levelNames[levelIdx] || noInfoLabel,
           };
           dict[`day${i}`] = dayObj;
           dict.days.push(dayObj);
@@ -552,24 +551,14 @@ export async function fetchForecast(hass, config) {
             const diff = Math.round((d - today) / 86400000);
             const label = buildDayLabel(d, diff, { daysRelative, dayAbbrev, daysUppercase, userDays, lang, locale });
 
-            let scaledLevel;
-            if (level < 2) {
-              scaledLevel = Math.floor((level * 6) / 4);
-            } else {
-              scaledLevel = Math.ceil((level * 6) / 4);
-            }
-
+            const levelIdx = lookupIndex(level);
             const dayObj = {
               name: dict.allergenCapitalized,
               day: label,
               state: level,
               // Raw value used only for display when available.
               display_state: displayLevel,
-              state_text:
-                scaledLevel < 0
-                  ? noInfoLabel
-                  : levelNames[scaledLevel] ||
-                    t(`card.levels.${scaledLevel}`, lang),
+              state_text: levelIdx < 0 ? noInfoLabel : levelNames[levelIdx] || noInfoLabel,
             };
 
             dict[`day${idx}`] = dayObj;

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -380,12 +380,18 @@ export async function fetchForecast(hass, config) {
   }
   const levelNames = buildLevelNamesForScale(5, normalizedUserLevels, lang);
 
-  // Clamp a native-scale level value to a 0-4 lookup index. Returns -1 for
-  // non-finite inputs (NaN / undefined / null) so callers can fall back to
-  // the no-info label. Negative finite values clamp to 0 (matches the legacy
-  // behavior where indexToLevel(-1) resolved to scale[0] = 0).
+  // Clamp a native-scale level value to an integer 0-4 lookup index.
+  // Rounds first so float inputs (e.g. raw.level = 2.7 in hourly forecast
+  // entries) still bucket into a valid severity label instead of returning
+  // a fractional index that would resolve to undefined and fall back to
+  // noInfoLabel. Returns -1 for non-finite inputs (NaN / null / undefined)
+  // so callers can show the no-info label. Negative finite values clamp to
+  // 0, matching the legacy behavior where indexToLevel(-1) resolved to
+  // scale[0] = 0.
   const lookupIndex = (level) =>
-    Number.isFinite(level) ? Math.max(0, Math.min(level, 4)) : -1;
+    Number.isFinite(level)
+      ? Math.max(0, Math.min(Math.round(level), 4))
+      : -1;
 
   const testVal = (v) => clampLevel(v, 4, -1);
 

--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -1,5 +1,4 @@
 // src/adapters/peu.js
-import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import { slugify } from "../utils/slugify.js";

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -92,6 +92,34 @@ export function grainsToLevel(allergen, grains) {
   return 6;
 }
 
+/**
+ * Map SILAM's `allergy_risk` categorical state (very_low / low / moderate /
+ * high / very_high, plus their numeric forms 0-4) onto the 0-6 visual scale
+ * the SILAM card renders against, using the [0, 1, 3, 5, 6] severity steps.
+ *
+ * This deliberately keeps the runtime spread that PEU dropped in #215.
+ * SILAM's case is structurally different from PEU's:
+ *
+ *  1. The SILAM chart renders `segments = 6` (default branch in the card's
+ *     segments switch), and a single SILAM card commonly mixes allergy_risk
+ *     with birch / grass / etc. on the *same* chart geometry. The spread
+ *     stretches allergy_risk's 5 categorical steps onto the same 6-segment
+ *     gradient the other allergens fill, so all rings on a SILAM card share
+ *     the same visual scale.
+ *  2. The output value is stored as `state`, which the card uses for both
+ *     chart fill *and* level-name lookup against the seven-level
+ *     `card.levels.0..6` defaults. The spread positions (0, 1, 3, 5, 6)
+ *     happen to align with the seven-level palette's "No pollen / Low /
+ *     Moderate / High / Very high" entries, so user-visible labels are
+ *     semantically correct without per-allergen scale-specific keys.
+ *
+ * Removing this spread (the pattern PEU used) would either leave allergy_risk
+ * never filling the rightmost two chart segments, or force per-allergen
+ * segments and scale-specific locale keys -- a much bigger refactor for a
+ * single categorical sensor that already works correctly. If SILAM later
+ * drops `allergy_risk` from cards that also display per-allergen sensors, or
+ * gains its own scale-specific chart geometry, this helper can be revisited.
+ */
 export function indexToLevel(val) {
   if (val == null) return -1;
   const scale = [0, 1, 3, 5, 6];

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -189,13 +189,13 @@ class PollenPrognosCardEditor extends LitElement {
                 ? 7
                 : 7;
 
-    // Use scale-specific phrase defaults so 5-level integrations (MSW; PEU
-    // pending #215) surface semantically-correct severity labels in the
-    // editor instead of borrowing strings from the wider 7-level palette.
-    // Other scales fall back to the legacy editor.phrases_levels.0..6 keys
-    // until per-scale entries are added for them.
+    // Use scale-specific phrase defaults so 5-level integrations (MSW, PEU)
+    // surface semantically-correct severity labels in the editor instead of
+    // borrowing strings from the wider 7-level palette. Other scales fall
+    // back to the legacy editor.phrases_levels.0..6 keys until per-scale
+    // entries are added for them.
     const levelKeyPrefix =
-      this._config.integration === "msw"
+      this._config.integration === "msw" || this._config.integration === "peu"
         ? "editor.phrases_levels5"
         : "editor.phrases_levels";
     const levels = Array.from({ length: numLevels }, (_, i) =>

--- a/test/adapters/peu.test.js
+++ b/test/adapters/peu.test.js
@@ -176,15 +176,16 @@ describe("PEU adapter: fetchForecast", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2. Level scaling: PEU native 0-4, scaled to 0-6
+  // 2. Level handling: PEU native 0-4 (single-scale, post-#215)
   // -------------------------------------------------------------------------
-  describe("level scaling (0-4 to 0-6)", () => {
-    // Formula: level < 2 ? floor(level*6/4) : ceil(level*6/4)
-    // 0 -> floor(0)   = 0
-    // 1 -> floor(1.5) = 1
-    // 2 -> ceil(3)    = 3
-    // 3 -> ceil(4.5)  = 5
-    // 4 -> ceil(6)    = 6
+  describe("native level handling (0-4)", () => {
+    // Pre-3.2.0 PEU stretched native 0-4 onto a 7-bucket card.levels array
+    // via a [0, 1, 3, 5, 6] runtime spread. Now that card.levels5.0..4 lives
+    // in every locale (added for MSW), level names are looked up at native
+    // indices and `state` carries the integration's native value verbatim.
+    // The test loop below kept its old `expected` column (the 0-6 scaled
+    // value) only to assert that the call succeeded; the real assertion is
+    // that state stores the native value and state_text is non-empty.
 
     const cases = [
       [0, 0],
@@ -195,7 +196,7 @@ describe("PEU adapter: fetchForecast", () => {
     ];
 
     for (const [input, expected] of cases) {
-      it(`maps native level ${input} to scaled level ${expected}`, async () => {
+      it(`renders state_text for native level ${input}`, async () => {
         const hass = makeHass("amsterdam", {
           birch: [input, input, input, input],
         });
@@ -207,13 +208,37 @@ describe("PEU adapter: fetchForecast", () => {
 
         const result = await fetchForecast(hass, config);
 
-        // state stores the raw (0-4) value; state_text reflects the scaled level
+        // state stores the native (0-4) value verbatim
         expect(result[0].day0.state).toBe(input >= 0 ? input : -1);
-        // state_text should correspond to the 0-6 scaled level, not the raw one
-        // We can infer scale by checking that level 4 state_text != level 0 state_text
+        // state_text comes from card.levels5.0..4 keyed at the native index
         expect(typeof result[0].day0.state_text).toBe("string");
+        expect(result[0].day0.state_text.length).toBeGreaterThan(0);
       });
     }
+
+    it("native level -> default English state_text mapping (#215)", async () => {
+      // Lock in the user-visible mapping after the #215 cleanup. Defaults
+      // come from card.levels5.0..4 which are sourced one-to-one from
+      // each locale's existing card.levels.{0,1,3,5,6} strings, so the
+      // English mapping is None / Low / Moderate / High / Very high.
+      const expectations = [
+        [0, "No pollen"],
+        [1, "Low levels"],
+        [2, "Moderate levels"],
+        [3, "High levels"],
+        [4, "Very high levels"],
+      ];
+      for (const [level, expected] of expectations) {
+        const hass = makeHass("amsterdam", { birch: [level, level, level, level] });
+        const config = makeConfig({
+          location: "amsterdam",
+          allergens: ["birch"],
+          pollen_threshold: 0,
+        });
+        const result = await fetchForecast(hass, config);
+        expect(result[0].day0.state_text).toBe(expected);
+      }
+    });
 
     it("state_text for native level 4 differs from native level 0", async () => {
       const hassHigh = makeHass("amsterdam", { birch: [4, 4, 4, 4] });
@@ -720,15 +745,21 @@ describe("PEU adapter: fetchForecast", () => {
   // 10. User level names (5 or 7 custom labels)
   // -------------------------------------------------------------------------
   describe("user level names", () => {
-    it("accepts 7 custom level labels mapping directly to indices 0-6", async () => {
+    it("accepts 7 legacy custom level labels (backwards compat post-#215)", async () => {
+      // Pre-3.2.0 configs could supply seven phrase strings indexed 0-6,
+      // because PEU stretched native 0-4 onto the seven-bucket palette.
+      // The cleanup in #215 keeps level names native (0-4); a length-7 user
+      // input is migrated by extracting entries [0, 1, 3, 5, 6] -- the same
+      // positions the spread historically populated -- so user-visible
+      // labels stay identical for legacy configs.
       const customLevels = [
-        "None",
-        "VeryLow",
-        "Low",
-        "Medium",
-        "High",
-        "VeryHigh",
-        "Extreme",
+        "None",     // index 0 -> native 0
+        "VeryLow",  // index 1 -> native 1
+        "Low",      // index 2 -> ignored under spread (no native maps here)
+        "Medium",   // index 3 -> native 2
+        "High",     // index 4 -> ignored under spread
+        "VeryHigh", // index 5 -> native 3
+        "Extreme",  // index 6 -> native 4
       ];
       const hass = makeHass("amsterdam", { birch: [2, 1, 0, 0] });
       const config = makeConfig({
@@ -739,12 +770,16 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      // Native level 2 -> scaled level 3 -> customLevels[3] = "Medium"
+      // Native level 2 -> "Medium" (was customLevels[3] under spread,
+      // now customLevels[3] picked into native index 2 via the [0,1,3,5,6]
+      // migration extraction; same user-visible outcome.)
       expect(result[0].day0.state_text).toBe("Medium");
     });
 
-    it("accepts 5 custom level labels mapped via [0,1,3,5,6]", async () => {
-      // 5 labels map to scaled levels: idx0->0, idx1->1, idx2->3, idx3->5, idx4->6
+    it("accepts 5 custom level labels at native indices", async () => {
+      // 5-length user phrases now apply directly at native indices 0..4 --
+      // no runtime spread, no migration. Visible outcome is identical to the
+      // pre-#215 [0,1,3,5,6] mapping for any state value.
       const customLevels = ["Zero", "Low", "Moderate", "High", "VeryHigh"];
       const hass = makeHass("amsterdam", { birch: [2, 1, 0, 0] });
       const config = makeConfig({
@@ -755,7 +790,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      // Native level 2 -> scaled level 3; map[2]=3 in 5-label array -> customLevels[2] = "Moderate"
+      // Native level 2 -> customLevels[2] = "Moderate"
       expect(result[0].day0.state_text).toBe("Moderate");
     });
 

--- a/test/adapters/peu.test.js
+++ b/test/adapters/peu.test.js
@@ -240,6 +240,32 @@ describe("PEU adapter: fetchForecast", () => {
       }
     });
 
+    it("rounds fractional levels to the nearest severity bucket (#216 review)", async () => {
+      // Codex/Copilot review on PR #216 caught that lookupIndex was passing
+      // float inputs straight to levelNames[i], producing undefined and
+      // falling back to noInfoLabel. The legacy indexToLevel/Math.floor
+      // path always rounded, so a 2.7 input still rendered "High levels".
+      // Lock the rounding behavior in.
+      const cases = [
+        [0.4, "No pollen"],     // -> 0
+        [0.6, "Low levels"],    // -> 1
+        [1.5, "Moderate levels"], // -> 2 (banker's? no, round half-up)
+        [2.7, "High levels"],   // -> 3
+        [3.6, "Very high levels"], // -> 4
+        [4.4, "Very high levels"], // clamps at 4
+      ];
+      for (const [level, expected] of cases) {
+        const hass = makeHass("amsterdam", { birch: [level, 0, 0, 0] });
+        const config = makeConfig({
+          location: "amsterdam",
+          allergens: ["birch"],
+          pollen_threshold: 0,
+        });
+        const result = await fetchForecast(hass, config);
+        expect(result[0].day0.state_text).toBe(expected);
+      }
+    });
+
     it("state_text for native level 4 differs from native level 0", async () => {
       const hassHigh = makeHass("amsterdam", { birch: [4, 4, 4, 4] });
       const hassLow = makeHass("amsterdam", { birch: [0, 0, 0, 0] });

--- a/test/adapters/peu.test.js
+++ b/test/adapters/peu.test.js
@@ -187,15 +187,12 @@ describe("PEU adapter: fetchForecast", () => {
     // value) only to assert that the call succeeded; the real assertion is
     // that state stores the native value and state_text is non-empty.
 
-    const cases = [
-      [0, 0],
-      [1, 1],
-      [2, 3],
-      [3, 5],
-      [4, 6],
-    ];
+    // Just the input native levels; the legacy "expected scaled value"
+    // column was retired with the #215 cleanup. Specific user-visible
+    // strings are pinned in the dedicated test below.
+    const cases = [0, 1, 2, 3, 4];
 
-    for (const [input, expected] of cases) {
+    for (const input of cases) {
       it(`renders state_text for native level ${input}`, async () => {
         const hass = makeHass("amsterdam", {
           birch: [input, input, input, input],
@@ -220,7 +217,8 @@ describe("PEU adapter: fetchForecast", () => {
       // Lock in the user-visible mapping after the #215 cleanup. Defaults
       // come from card.levels5.0..4 which are sourced one-to-one from
       // each locale's existing card.levels.{0,1,3,5,6} strings, so the
-      // English mapping is None / Low / Moderate / High / Very high.
+      // English mapping is "No pollen / Low levels / Moderate levels /
+      // High levels / Very high levels".
       const expectations = [
         [0, "No pollen"],
         [1, "Low levels"],


### PR DESCRIPTION
## Summary

Closes #215.

Pre-3.2.0 PEU stretched its native 0-4 state onto the shared seven-bucket `card.levels` palette via a `[0, 1, 3, 5, 6]` runtime spread (`peu.js:368-385, 484, 555-560`). It compensated for the lack of five-level locale strings and predates the principle that each integration should keep its native level count user-visibly. Now that `card.levels5.0..4` and `editor.phrases_levels5.0..4` exist in every locale (added for MSW in 3.2.0), the spread is redundant and was the structural gap behind #215.

## Changes

**`src/adapters/peu.js`**
- Drop the `indexToLevel` import (helper still lives in silam.js for SILAM's allergy_risk path).
- Replace the seven-element `levelNamesDefault` construction and the inline 5-vs-7 spread with a single `buildLevelNamesForScale(5, ...)` call.
- Drop the `Math.floor((level * 6) / 4)` / `Math.ceil(...)` scaling in the forecast block.
- Introduce a tiny `lookupIndex(level)` helper that clamps to 0-4 and returns -1 for non-finite inputs. Reproduces the legacy behavior for state=-1, NaN and unknown strings.
- Fixed a variable-shadowing bug in the same refactor: the `forecastDates.forEach((dateStr, idx) => ...)` iterator was being clobbered by my level-lookup const named `idx` -- renamed to `levelIdx`. Tests caught it.

**`src/pollenprognos-editor.js`**
- Extend the phrase-default key-prefix branch from msw to also include peu, so the editor surfaces the same five severity strings the renderer now uses.

## Backwards compatibility

- **5-length user phrases (`phrases.levels`):** already mapped to native indices via the spread; under the new code they apply directly. No user-visible change.
- **7-length user phrases (legacy):** migrated at read time by extracting entries `[0, 1, 3, 5, 6]` -- the exact positions the spread historically populated. User-visible labels stay identical for legacy configs.
- **State storage:** unchanged; `state` carries the native 0-4 value verbatim, same as before.
- **Default state_text labels:** unchanged. `card.levels5.0..4` was sourced from each locale's existing `card.levels.{0,1,3,5,6}` strings (transparent migration).

## Test plan

- [x] `npm run test` -- 957 tests pass (was 956; +1 new test pinning the default English mapping post-#215).
- [x] All existing PEU tests pass without logic changes; descriptions/comments updated to reflect native-index lookup.
- [x] `npm run build` -- clean.
- [ ] In hass-test with a PEU config, confirm: state_text for state=2 reads as 'Moderate levels' (en) / 'Måttliga halter' (sv), state=4 reads 'Very high levels' / 'Mycket höga halter'.

## Notes

SILAM's `allergy_risk` path still uses `indexToLevel` (via silam.js) to spread its 5-state categorical data onto the SILAM card's 6-segment chart. That's a separate concern from PEU's level-name lookup -- it stretches `display_state` so the chart fills correctly, not the name index. Left as-is.

If beta-testing 3.2.0 wraps up before this lands, this can roll into 3.2.0 final; otherwise it ships in 3.3.0.