### PR TITLE
(dwd) Handle device-name-prefixed entity IDs (closes #217)

### DIFF
--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -72,6 +72,13 @@ export const stubConfigDWD = {
  * instead of the legacy bare shape
  *   sensor.pollenflug_<allergen>_<region_id>.
  *
+ * Anchored to `^sensor\.` so callers can run the regex against
+ * `Object.keys(hass.states)` (which spans every HA domain) without
+ * misclassifying unrelated entities whose object_id happens to end with
+ * `_pollenflug_<token>_<digits>` (Copilot review on #218). Allows zero or
+ * more `\w+_` segments between `sensor.` and the integration's own
+ * `pollenflug_` marker so the device-name slug can be of any length.
+ *
  * The integration's allergen segment is always a single lowercase token
  * (erle / ambrosia / esche / birke / buche / hasel / graser / graeser /
  * beifuss / roggen), so anchoring the inner pattern to `[a-z]+` lets the
@@ -80,7 +87,7 @@ export const stubConfigDWD = {
  * "pollenflug" earlier in the string. (#217)
  */
 export const DWD_ENTITY_ID_RE =
-  /(?:^sensor\.|_)pollenflug_([a-z]+)_(\d+)$/;
+  /^sensor\.(?:\w+_)*pollenflug_([a-z]+)_(\d+)$/;
 
 /**
  * Extract the numeric region ID from a DWD entity ID, accepting both bare

--- a/src/adapters/dwd.js
+++ b/src/adapters/dwd.js
@@ -62,15 +62,50 @@ export const stubConfigDWD = {
 };
 
 /**
- * Extract the numeric region ID from a DWD entity ID.
- * "sensor.pollenflug_erle_50" -> "50"
- * Returns null if no trailing numeric segment is found.
+ * Match the integration's own naming segment in a DWD entity ID, allowing
+ * for an optional device-name prefix that Home Assistant prepends to the
+ * entity ID when the device has a friendly name. The DWD integration
+ * (hacs_dwd_pollenflug) has shipped a device-entity since around v1.0.4
+ * named "Pollenflug Gefahrenindex", so entity IDs created on those
+ * installs look like
+ *   sensor.pollenflug_gefahrenindex_pollenflug_<allergen>_<region_id>
+ * instead of the legacy bare shape
+ *   sensor.pollenflug_<allergen>_<region_id>.
+ *
+ * The integration's allergen segment is always a single lowercase token
+ * (erle / ambrosia / esche / birke / buche / hasel / graser / graeser /
+ * beifuss / roggen), so anchoring the inner pattern to `[a-z]+` lets the
+ * regex engine pick the correct rightmost `pollenflug_<allergen>_<id>`
+ * occurrence even when the device-name prefix happens to repeat
+ * "pollenflug" earlier in the string. (#217)
+ */
+export const DWD_ENTITY_ID_RE =
+  /(?:^sensor\.|_)pollenflug_([a-z]+)_(\d+)$/;
+
+/**
+ * Extract the numeric region ID from a DWD entity ID, accepting both bare
+ * and HA-device-prefixed shapes.
+ *   "sensor.pollenflug_erle_50" -> "50"
+ *   "sensor.pollenflug_gefahrenindex_pollenflug_erle_50" -> "50"
+ * Returns null if the integration's pattern is not found.
  *
  * @param {string} entityId
  * @returns {string|null}
  */
 function extractRegionIdFromEntityId(entityId) {
-  return entityId.match(/_(\d+)$/)?.[1] || null;
+  return entityId.match(DWD_ENTITY_ID_RE)?.[2] || null;
+}
+
+/**
+ * Extract the integration's allergen segment from a DWD entity ID, accepting
+ * both bare and HA-device-prefixed shapes. Returns null if the pattern is
+ * not found.
+ *
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function extractAllergenFromEntityId(entityId) {
+  return entityId.match(DWD_ENTITY_ID_RE)?.[1] || null;
 }
 
 /**
@@ -114,23 +149,28 @@ export function discoverDwdSensors(hass, debug = false) {
     platform: ["dwd_pollenflug", "pollenflug"],
     /**
      * Strict classifier: derive the normalized allergen key from the entity ID.
-     * DWD entity IDs follow the pattern sensor.pollenflug_{allergen}_{region_id}.
-     * The allergen segment may contain underscores; region_id is always numeric.
+     * Accepts both the bare shape (sensor.pollenflug_<allergen>_<region>)
+     * and the device-prefixed shape HA produces when a device-name slug
+     * is prepended (e.g. sensor.pollenflug_gefahrenindex_pollenflug_<allergen>_<region>).
+     * DWD allergens are single lowercase tokens, so the inner anchor in
+     * DWD_ENTITY_ID_RE prevents misclassification when the device-name
+     * happens to repeat "pollenflug". (#217)
      */
     classify: (eid) => {
-      const m = eid.match(/^sensor\.pollenflug_(.+)_(\d+)$/);
-      if (!m) return null;
-      return normalizeDWD(m[1]);
+      const allergen = extractAllergenFromEntityId(eid);
+      return allergen ? normalizeDWD(allergen) : null;
     },
     classifyRelaxed: (eid) => {
-      const m = eid.match(/^sensor\.pollenflug_(.+)_(\d+)$/);
-      if (!m) return null;
-      return normalizeDWD(m[1]);
+      const allergen = extractAllergenFromEntityId(eid);
+      return allergen ? normalizeDWD(allergen) : null;
     },
     /**
-     * isRelevant: quick pre-filter before classify runs.
+     * isRelevant: quick pre-filter before classify runs. The integration's
+     * own naming segment ("pollenflug_<allergen>_<region>") may sit anywhere
+     * in the entity ID after an optional device-name prefix, so check the
+     * full pattern rather than just the entity-ID start.
      */
-    isRelevant: (eid) => eid.startsWith("sensor.pollenflug_"),
+    isRelevant: (eid) => DWD_ENTITY_ID_RE.test(eid),
     /**
      * resolveLabel priority:
      *   1. device.name_by_user -- explicit user override always wins.
@@ -161,9 +201,10 @@ export function discoverDwdSensors(hass, debug = false) {
       return ctx.device?.config_entries?.[0] || "default";
     },
     /**
-     * fallbackRegex: matches the standard DWD entity ID pattern used in tier 3.
+     * fallbackRegex: matches the integration's own pollenflug_<allergen>_<id>
+     * segment whether or not HA has prepended a device-name slug.
      */
-    fallbackRegex: /^sensor\.pollenflug_.+_\d+$/,
+    fallbackRegex: DWD_ENTITY_ID_RE,
     debug,
     logTag: "DWD",
   });
@@ -246,18 +287,32 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   }
 
   // --- Path 3: Template fallback (legacy / when discovery yields nothing) ---
+  // Rebuilt around DWD_ENTITY_ID_RE so it accepts the device-name-prefixed
+  // shape HA emits when the integration's device has a friendly name (#217).
+  // The bare-shape direct lookup is tried first as a fast path; the regex
+  // scan handles both shapes when that misses.
   for (const allergen of cfg.allergens || []) {
     const rawKey = normalizeDWD(allergen);
-    let sensorId = cfg.region_id
-      ? `sensor.pollenflug_${rawKey}_${cfg.region_id}`
-      : null;
-    if (!sensorId || !hass.states[sensorId]) {
-      const candidates = Object.keys(hass.states).filter((id) =>
-        id.startsWith(`sensor.pollenflug_${rawKey}_`),
-      );
-      if (candidates.length === 1) sensorId = candidates[0];
-      else continue;
+    let sensorId = null;
+    if (cfg.region_id) {
+      const direct = `sensor.pollenflug_${rawKey}_${cfg.region_id}`;
+      if (hass.states[direct]) sensorId = direct;
     }
+    if (!sensorId) {
+      const candidates = Object.keys(hass.states).filter((id) => {
+        const m = id.match(DWD_ENTITY_ID_RE);
+        if (!m) return false;
+        if (m[1] !== rawKey) return false;
+        return cfg.region_id ? m[2] === String(cfg.region_id) : true;
+      });
+      if (candidates.length === 1) sensorId = candidates[0];
+      else if (candidates.length > 1 && debug) {
+        console.debug(
+          `[DWD:resolveEntityIds] template fallback ambiguous for '${allergen}' (${candidates.length} candidates); skipping`,
+        );
+      }
+    }
+    if (!sensorId) continue;
     if (debug) {
       console.debug(
         `[DWD:resolveEntityIds] template fallback allergen: '${allergen}', rawKey: '${rawKey}', sensorId: '${sensorId}'`,

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -18,7 +18,7 @@ import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
 import { discoverGpSensors } from "./adapters/gp/index.js";
 import { discoverMswSensors } from "./adapters/msw.js";
 import { discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
-import { discoverDwdSensors } from "./adapters/dwd.js";
+import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
 import { discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import {
@@ -987,8 +987,10 @@ class PollenPrognosCard extends LitElement {
         return true;
       },
     );
+    // DWD: match the integration's pollenflug_<allergen>_<region> segment
+    // whether or not HA has prepended a device-name slug (#217).
     const dwdStates = Object.keys(hass.states).filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+      (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
     );
     const peuStates = Object.keys(hass.states).filter(
       (id) =>

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -13,7 +13,7 @@ import { COSMETIC_FIELDS } from "./constants.js";
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getAllAdapterIds, getStubConfig } from "./adapter-registry.js";
 import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
-import { stubConfigDWD, discoverDwdSensors } from "./adapters/dwd.js";
+import { stubConfigDWD, discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
 import { PEU_ALLERGENS, discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { SILAM_ALLERGENS } from "./adapters/silam.js";
 import { stubConfigKleenex } from "./adapters/kleenex/index.js";
@@ -494,8 +494,7 @@ class PollenPrognosCardEditor extends LitElement {
           integration = "peu";
         } else if (
           all.some(
-            (id) =>
-              typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+            (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
           )
         ) {
           integration = "dwd";
@@ -701,14 +700,20 @@ class PollenPrognosCardEditor extends LitElement {
           this.installedRegionIds = this.installedDwdLocations.map(([key]) => key);
         } else {
           const all = Object.keys(this._hass.states);
+          // Pull the trailing region ID from any DWD entity, accepting both
+          // bare and HA-device-prefixed shapes (#217). The regex's second
+          // capture group is always the numeric region ID, so use it
+          // directly instead of splitting on underscores (which would pick
+          // up a stray ID from a device-name slug like "_92" mid-string).
           this.installedRegionIds = Array.from(
             new Set(
               all
-                .filter(
-                  (id) =>
-                    typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+                .map((id) =>
+                  typeof id === "string"
+                    ? id.match(DWD_ENTITY_ID_RE)?.[2]
+                    : null,
                 )
-                .map((id) => id.split("_").pop()),
+                .filter(Boolean),
             ),
           ).sort((a, b) => Number(a) - Number(b));
           this.installedDwdLocations = this.installedRegionIds.map((id) => [
@@ -878,8 +883,9 @@ class PollenPrognosCardEditor extends LitElement {
       },
     );
 
+    // DWD: lenient regex catches device-prefixed entity_ids too (#217).
     const dwdStates = stateIds.filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.pollenflug_"),
+      (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
     );
 
     const peuStates = stateIds.filter(

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -563,4 +563,23 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
       "sensor.pollenflug_pollenflug_erle_121",
     );
   });
+
+  it("does not match entities outside the sensor.* domain (Copilot review on #218)", () => {
+    // Regression: an earlier draft of DWD_ENTITY_ID_RE used
+    // (?:^sensor\\.|_) and would falsely match e.g. an automation whose
+    // object_id ended in _pollenflug_<token>_<digits>. The anchor is now
+    // ^sensor\\. so non-sensor domains never enter discovery / autodetect.
+    const hass = createHass({
+      "automation.house_alarm_pollenflug_test_42": { state: "on", attributes: {} },
+      "input_select.thing_pollenflug_birke_50": { state: "Med", attributes: {} },
+      // A real DWD sensor in the same hass to confirm sensors still match.
+      "sensor.pollenflug_erle_50": createDWDSensor(1, 0, 0),
+    });
+    const result = discoverDwdSensors(hass);
+    expect(result.locations.size).toBe(1);
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.entities.get("erle")).toBe("sensor.pollenflug_erle_50");
+    // No other entities should have leaked into the location's entity map.
+    expect(loc.entities.size).toBe(1);
+  });
 });

--- a/test/adapters/dwd.test.js
+++ b/test/adapters/dwd.test.js
@@ -429,3 +429,138 @@ describe("DWD adapter: discoverDwdSensors", () => {
     expect(loc.label).toBe("My custom region");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Device-prefixed entity IDs (#217)
+//
+// hacs_dwd_pollenflug v1.0.4 ships a device named "Pollenflug Gefahrenindex",
+// so HA prepends the device-name slug to every entity ID:
+//   sensor.pollenflug_gefahrenindex_pollenflug_<allergen>_<region_id>
+// instead of the legacy bare shape sensor.pollenflug_<allergen>_<region_id>.
+// User-renamed devices produce arbitrary prefixes
+// (sensor.<custom-slug>_pollenflug_<allergen>_<region_id>). Both shapes have
+// to classify and resolve to the configured allergen.
+// ---------------------------------------------------------------------------
+
+const PREFIXED_ZONE = "92"; // Hessen, the region in the bug report
+
+describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
+  function makePrefixedHass(prefix, regionId, allergenMap) {
+    const states = {};
+    for (const [allergen, [today, tomorrow, twoDays]] of Object.entries(allergenMap)) {
+      states[`sensor.${prefix}_pollenflug_${allergen}_${regionId}`] =
+        createDWDSensor(today, tomorrow, twoDays);
+    }
+    return createHass(states, { language: "de" });
+  }
+
+  it("regex fallback discovers default 'Pollenflug Gefahrenindex' prefix", () => {
+    const hass = makePrefixedHass(
+      "pollenflug_gefahrenindex",
+      PREFIXED_ZONE,
+      { ambrosia: [3, 2, 1], birke: [2, 1, 0] },
+    );
+    const result = discoverDwdSensors(hass);
+    expect(result.locations.size).toBe(1);
+    const [, loc] = [...result.locations.entries()][0];
+    // Entities are keyed by the normalizeDWD() output (German allergen
+    // segment from the entity ID), matching the existing bare-shape tests
+    // above.
+    expect(loc.entities.get("ambrosia")).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_ambrosia_${PREFIXED_ZONE}`,
+    );
+    expect(loc.entities.get("birke")).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_birke_${PREFIXED_ZONE}`,
+    );
+  });
+
+  it("regex fallback discovers user-renamed device prefix", () => {
+    const hass = makePrefixedHass(
+      "mystation",
+      "50",
+      { erle: [1, 2, 0], graeser: [4, 3, 2] },
+    );
+    const result = discoverDwdSensors(hass);
+    expect(result.locations.size).toBe(1);
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.entities.get("erle")).toBe("sensor.mystation_pollenflug_erle_50");
+    expect(loc.entities.get("graeser")).toBe(
+      "sensor.mystation_pollenflug_graeser_50",
+    );
+  });
+
+  it("resolveEntityIds maps configured allergens through device-prefixed shape", () => {
+    const hass = makePrefixedHass(
+      "pollenflug_gefahrenindex",
+      PREFIXED_ZONE,
+      { ambrosia: [3, 0, 0], graeser: [2, 1, 0], birke: [1, 0, 0] },
+    );
+    const config = makeConfig({
+      region_id: PREFIXED_ZONE,
+      allergens: ["ambrosia", "graeser", "birke"],
+    });
+    const map = resolveEntityIds(config, hass);
+    expect(map.get("ambrosia")).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_ambrosia_${PREFIXED_ZONE}`,
+    );
+    expect(map.get("graeser")).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_graeser_${PREFIXED_ZONE}`,
+    );
+    expect(map.get("birke")).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_birke_${PREFIXED_ZONE}`,
+    );
+  });
+
+  it("fetchForecast produces sensors when entities are device-prefixed", async () => {
+    const hass = makePrefixedHass(
+      "pollenflug_gefahrenindex",
+      PREFIXED_ZONE,
+      { ambrosia: [3, 2, 1] },
+    );
+    const config = makeConfig({
+      region_id: PREFIXED_ZONE,
+      allergens: ["ambrosia"],
+      pollen_threshold: 0,
+    });
+    const result = await fetchForecast(hass, config);
+    expect(result.length).toBe(1);
+    expect(result[0].entity_id).toBe(
+      `sensor.pollenflug_gefahrenindex_pollenflug_ambrosia_${PREFIXED_ZONE}`,
+    );
+    assertSensorShape(result[0], { minDays: 1 });
+  });
+
+  it("template fallback handles device-prefixed shape when discovery yields nothing", () => {
+    // hass without devices/entities forces tier-3 (regex fallback) inside
+    // discovery, and if discovery somehow misses, resolveEntityIds falls
+    // through to its own template scan -- both must accept the prefix.
+    const hass = makePrefixedHass(
+      "foo_bar_baz",
+      "50",
+      { erle: [1, 0, 0] },
+    );
+    const config = makeConfig({
+      region_id: "50",
+      allergens: ["erle"],
+    });
+    const map = resolveEntityIds(config, hass);
+    expect(map.get("erle")).toBe("sensor.foo_bar_baz_pollenflug_erle_50");
+  });
+
+  it("regex anchors to the rightmost pollenflug_<allergen>_<id> segment", () => {
+    // Edge case: device name happens to be just "pollenflug" -- the
+    // entity_id then contains "pollenflug_pollenflug_" before the allergen.
+    // The regex should still anchor the allergen to the rightmost
+    // pollenflug_<allergen>_<region> match.
+    const hass = makePrefixedHass(
+      "pollenflug",
+      "121",
+      { erle: [2, 1, 0] },
+    );
+    const result = discoverDwdSensors(hass);
+    const [, loc] = [...result.locations.entries()][0];
+    expect(loc.entities.get("erle")).toBe(
+      "sensor.pollenflug_pollenflug_erle_121",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #217.

`hacs_dwd_pollenflug` v1.0.4 ships a device named *Pollenflug Gefahrenindex*. Home Assistant prepends the device-name slug to every entity ID, so on those installs the integration's own naming segment sits **inside** the entity ID rather than at the start:

```
sensor.pollenflug_gefahrenindex_pollenflug_<allergen>_<region_id>
```

instead of the legacy bare shape

```
sensor.pollenflug_<allergen>_<region_id>
```

User-renamed devices produce arbitrary prefixes (`sensor.<custom-slug>_pollenflug_<allergen>_<region_id>`). Both have to classify and resolve to the configured allergen.

Reporter @LightMaster001 saw the card render "No sensors found" with a populated `DWD: [ ... ]` autodetect array; `fetchForecast` returned 0 sensors because the classifier captured `gefahrenindex_pollenflug_ambrosia` as the allergen segment via the greedy `(.+)`, and the template fallback's `startsWith('sensor.pollenflug_<allergen>_')` missed entirely.

Same pattern as MSW (#214); the fix mirrors it.

## Changes

**`src/adapters/dwd.js`**
- New `DWD_ENTITY_ID_RE = /^sensor\.(?:\w+_)*pollenflug_([a-z]+)_(\d+)$/`, exported. Anchored to `^sensor\.` so callers running it against `Object.keys(hass.states)` never misclassify entities from other domains; the `(?:\w+_)*` segment lets HA's device-name slug be of any length. The inner `[a-z]+` exploits the fact that DWD allergens are single-word lowercase tokens (erle / ambrosia / esche / birke / buche / hasel / graser / graeser / beifuss / roggen) so the regex picks the rightmost `pollenflug_<allergen>_<region>` even when the device-name itself happens to repeat "pollenflug".
- `classify`, `classifyRelaxed`, `isRelevant` and `fallbackRegex` use the new regex. `extractRegionIdFromEntityId` is rebuilt around it; new `extractAllergenFromEntityId` mirrors it.
- `resolveEntityIds` template fallback: scan all states with the regex and require both the allergen and `region_id` capture groups to match. Bare-shape direct lookup retained as a fast path.

**`src/pollenprognos-card.js`** and **`src/pollenprognos-editor.js`**
- Import `DWD_ENTITY_ID_RE`.
- `dwdStates` filters and the editor's `installedRegionIds` derivation switch from `startsWith('sensor.pollenflug_')` to the regex, so DWD with arbitrary device-name prefix is autodetected and listed in editor dropdowns.

## Test plan

- [x] `npm run test` -- 965 tests pass (was 958; +7 contract tests for #217 and the regex tighten).
- [x] `npm run build` -- clean.
- New tests cover: upstream-default `pollenflug_gefahrenindex` prefix, user-renamed device prefix, multi-allergen `resolveEntityIds`, `fetchForecast` end-to-end, standalone template fallback, the edge case where the device-name itself is `pollenflug`, plus a regression test that ensures non-`sensor.*` entities (automation, input_select) with `_pollenflug_<token>_<digits>` suffixes never enter DWD discovery.
- [ ] Verify on a v1.0.4 install (reporter or hass-test).

## Backwards compatibility

- Bare-shape entity IDs (`sensor.pollenflug_<allergen>_<region>`) covered by existing tests; behavior unchanged.
- Auto-detection no longer requires the device-name slug to start with "pollenflug"; arbitrary device-rename prefixes work too.

## Review history

- Initial regex `(?:^sensor\.|_)pollenflug_([a-z]+)_(\d+)$` flagged by Copilot for matching outside the `sensor.*` domain via the underscore alternation. Tightened to `^sensor\.(?:\w+_)*pollenflug_...` and a regression test added (commit baffe6a).

If this lands in time, it ships with v3.2.0 (currently in beta3); otherwise we cut a beta4 from this branch.