### PR TITLE
(discovery) Cooperate tier 1 + tier 2 in mixed-registry scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - (kleenex) Per-allergen DetailSensor fallback and a clearer warning for US/CA zones where the upstream API only returns category totals (issue #206). The NA-zone warning is de-duplicated per session and per location.
 
 ### Changed
-- Discovery helper extracted to `src/utils/adapter-helpers.js` (`discoverEntitiesByDevice`, `resolveLocationByKey`, `findLocationBySlug`). PP, DWD, PEU, SILAM, Atmo, GPL, GP and MSW now share the same three-tier cascade, eliminating bespoke regex-based discovery in those adapters.
+- Discovery helper extracted to `src/utils/adapter-helpers.js` (`discoverEntitiesByDevice`, `resolveLocationByKey`, `findLocationBySlug`). PP, DWD, PEU, SILAM, Atmo, GPL, GP and MSW now share the same three-tier discovery. Tier 1 (device-identifier match) and tier 2 (entity-registry platform match) cooperate rather than strictly cascade: tier 2 tops up tier 1 with entities from integration devices that lack `identifiers` metadata, so mixed-registry scenarios do not silently drop entities. Tier 3 (regex/selector fallback) runs when neither registry produces a location. Replaces the bespoke regex-based discovery these adapters used previously.
 - (editor) PP and DWD location dropdowns now sorted consistently when populated via the secondary discovery path.
 - (card) Header location label now resolved through the shared discovery helper for PP, DWD, PEU, GPL, GP, MSW. Discovery results are cached per-render to avoid redundant entity scans.
 - (dwd) Region-ID prefix stripped from auto-derived region labels; ID suffix only appended when needed to disambiguate duplicate region names.

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -315,10 +315,21 @@ export function filterSensorsPostFetch(sensors, cfg, availableSensors, hassState
  * Tier 1 (device-based): Scan hass.devices for devices whose identifiers match
  *   the given platform. Then collect entities from hass.entities whose device_id
  *   belongs to one of those devices.
- * Tier 2 (entity-registry): Scan hass.entities filtered by entry.platform.
- *   Used when hass.devices is unavailable or tier 1 yields no results.
+ * Tier 2 (entity-registry): Scan hass.entities filtered by entry.platform. Runs
+ *   alongside tier 1 to top up entities whose device lacks identifiers metadata
+ *   (mixed-registry scenarios where one config entry's devices are tagged and
+ *   another's are not). Entities whose device was already considered by tier 1
+ *   are skipped so the strict classifier does not second-guess the relaxed
+ *   tier-1 result. Falls back to walking all platform-matching entities when
+ *   tier 1 found no devices at all (matchingDeviceIds empty), preserving the
+ *   pre-existing tier 2 behavior for adapters that never use device-based
+ *   discovery.
  * Tier 3 (fallback): Scan hass.states using fallbackSelector or fallbackRegex.
- *   Used when both tier 1 and tier 2 yield no results.
+ *   Used when neither tier 1 nor tier 2 produced any locations.
+ *
+ * `tierUsed` in the returned object reports the primary mechanism: 1 if tier 1
+ * contributed any entity, 2 if only tier 2 contributed, 3 if only tier 3
+ * contributed, 0 if no tier produced locations.
  *
  * @param {object} hass - Home Assistant state object.
  * @param {object} opts
@@ -469,9 +480,12 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
   };
 
   // --- Tier 1: Device-based discovery ---
+  // Find devices whose identifiers contain a matching platform as first element.
+  // Kept across both tier 1 and tier 2 so tier 2 can skip entities whose device
+  // was already considered by tier 1 (avoid double-classification with strict
+  // when relaxed already had a chance).
+  const matchingDeviceIds = new Set();
   if (hass !== null && hass !== undefined && hass.devices !== null && hass.devices !== undefined && hass.entities !== null && hass.entities !== undefined) {
-    // Find devices whose identifiers contain a matching platform as first element
-    const matchingDeviceIds = new Set();
     for (const [devId, dev] of Object.entries(hass.devices)) {
       if (dev === null || dev === undefined) continue;
       const identifiers = dev.identifiers;
@@ -505,23 +519,31 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
         addEntity(eid, allergenKey, ctx);
       }
 
-      if (locations.size > 0) {
-        if (debug) {
-          console.debug(`[${logTag}] Discovery tier 1 result:`, locations.size, "locations");
-          for (const [locId, loc] of locations) {
-            console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-          }
+      if (debug && locations.size > 0) {
+        console.debug(`[${logTag}] Discovery tier 1 result:`, locations.size, "locations");
+        for (const [locId, loc] of locations) {
+          console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
         }
-        return { locations, tierUsed: 1 };
       }
     }
   }
 
+  // Snapshot whether tier 1 contributed anything; needed for tierUsed below.
+  // Locations created by tier 1 cannot disappear, so the post-tier-2 check is a
+  // monotone superset of this.
+  const tier1ContributedLocations = locations.size > 0;
+
   // --- Tier 2: Entity-registry scan ---
+  // Always runs to top up entities from integration devices that lacked
+  // `identifiers` metadata (tier 1 invisible). Entities whose device was already
+  // walked by tier 1 are skipped so classifyStrict does not run on top of the
+  // relaxed tier-1 result.
   if (hass !== null && hass !== undefined && hass.entities !== null && hass.entities !== undefined) {
+    let tier2Walked = false;
     for (const [eid, entry] of Object.entries(hass.entities)) {
       if (entry === null || entry === undefined) continue;
       if (!platforms.includes(entry.platform)) continue;
+      if (matchingDeviceIds.has(entry.device_id)) continue;
       if (shouldExclude(entry)) continue;
 
       const state = hass.states !== null && hass.states !== undefined ? hass.states[eid] : undefined;
@@ -537,16 +559,22 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
 
       const allergenKey = classifyStrict(eid, ctx);
       addEntity(eid, allergenKey, ctx);
+      tier2Walked = true;
     }
 
     if (locations.size > 0) {
+      const tierUsed = tier1ContributedLocations ? 1 : 2;
       if (debug) {
-        console.debug(`[${logTag}] Discovery tier 2 result:`, locations.size, "locations");
+        if (tier1ContributedLocations && tier2Walked) {
+          console.debug(`[${logTag}] Discovery tier 1+2 result:`, locations.size, "locations (tier 1 + tier 2 top-up)");
+        } else if (!tier1ContributedLocations) {
+          console.debug(`[${logTag}] Discovery tier 2 result:`, locations.size, "locations");
+        }
         for (const [locId, loc] of locations) {
           console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
         }
       }
-      return { locations, tierUsed: 2 };
+      return { locations, tierUsed };
     }
   }
 

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -315,15 +315,18 @@ export function filterSensorsPostFetch(sensors, cfg, availableSensors, hassState
  * Tier 1 (device-based): Scan hass.devices for devices whose identifiers match
  *   the given platform. Then collect entities from hass.entities whose device_id
  *   belongs to one of those devices.
- * Tier 2 (entity-registry): Scan hass.entities filtered by entry.platform. Runs
- *   alongside tier 1 to top up entities whose device lacks identifiers metadata
- *   (mixed-registry scenarios where one config entry's devices are tagged and
- *   another's are not). Entities whose device was already considered by tier 1
- *   are skipped so the strict classifier does not second-guess the relaxed
- *   tier-1 result. Falls back to walking all platform-matching entities when
- *   tier 1 found no devices at all (matchingDeviceIds empty), preserving the
- *   pre-existing tier 2 behavior for adapters that never use device-based
- *   discovery.
+ * Tier 2 (entity-registry): For entities filtered by entry.platform whose
+ *   device was NOT in the tier-1 set. Tops up tier 1 with entities whose
+ *   device lacks identifiers metadata (mixed-registry scenarios where one
+ *   config entry's devices are tagged and another's are not). Entities whose
+ *   device tier 1 already matched stay on the tier-1 path (relaxed classifier)
+ *   and are not also offered to the strict classifier, so the two classifiers
+ *   never run on the same entity. When tier 1 found no devices at all
+ *   (matchingDeviceIds empty), tier 2 covers all platform-matching entities,
+ *   preserving the pre-existing tier 2 behavior for adapters that do not use
+ *   device-based discovery. Implementation: a single pass over hass.entities
+ *   routes each entity to the tier-1 or tier-2 path based on its device's
+ *   identifier match.
  * Tier 3 (fallback): Scan hass.states using fallbackSelector or fallbackRegex.
  *   Used when neither tier 1 nor tier 2 produced any locations.
  *

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -479,13 +479,11 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
     }
   };
 
-  // --- Tier 1: Device-based discovery ---
+  // --- Tier 1 + Tier 2: Single-pass entity discovery ---
   // Find devices whose identifiers contain a matching platform as first element.
-  // Kept across both tier 1 and tier 2 so tier 2 can skip entities whose device
-  // was already considered by tier 1 (avoid double-classification with strict
-  // when relaxed already had a chance).
+  // Used to decide tier-1 precedence per entity below.
   const matchingDeviceIds = new Set();
-  if (hass !== null && hass !== undefined && hass.devices !== null && hass.devices !== undefined && hass.entities !== null && hass.entities !== undefined) {
+  if (hass !== null && hass !== undefined && hass.devices !== null && hass.devices !== undefined) {
     for (const [devId, dev] of Object.entries(hass.devices)) {
       if (dev === null || dev === undefined) continue;
       const identifiers = dev.identifiers;
@@ -497,53 +495,24 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
         }
       }
     }
-
-    if (matchingDeviceIds.size > 0) {
-      if (debug) console.debug(`[${logTag}] Discovery tier 1 (device-based): found`, matchingDeviceIds.size, "devices");
-
-      for (const [eid, entry] of Object.entries(hass.entities)) {
-        if (entry === null || entry === undefined) continue;
-        if (!matchingDeviceIds.has(entry.device_id)) continue;
-        if (shouldExclude(entry)) continue;
-
-        const state = hass.states !== null && hass.states !== undefined ? hass.states[eid] : undefined;
-        if (state === null || state === undefined) continue;
-
-        const deviceId = entry.device_id;
-        const device = hass.devices[deviceId];
-        const ctx = { state, entry, device, deviceId, entityId: eid, tier: 1 };
-
-        if (!checkRelevant(eid, ctx)) continue;
-
-        const allergenKey = classifyTier1(eid, ctx);
-        addEntity(eid, allergenKey, ctx);
-      }
-
-      if (debug && locations.size > 0) {
-        console.debug(`[${logTag}] Discovery tier 1 result:`, locations.size, "locations");
-        for (const [locId, loc] of locations) {
-          console.debug(`  [${locId}] "${loc.label}":`, [...loc.entities.keys()]);
-        }
-      }
-    }
+  }
+  if (debug && matchingDeviceIds.size > 0) {
+    console.debug(`[${logTag}] Discovery tier 1 (device-based): found`, matchingDeviceIds.size, "devices");
   }
 
-  // Snapshot whether tier 1 contributed anything; needed for tierUsed below.
-  // Locations created by tier 1 cannot disappear, so the post-tier-2 check is a
-  // monotone superset of this.
-  const tier1ContributedLocations = locations.size > 0;
-
-  // --- Tier 2: Entity-registry scan ---
-  // Always runs to top up entities from integration devices that lacked
-  // `identifiers` metadata (tier 1 invisible). Entities whose device was already
-  // walked by tier 1 are skipped so classifyStrict does not run on top of the
-  // relaxed tier-1 result.
+  // Single walk over hass.entities. Tier 1 path handles entities whose device
+  // has matching identifiers (with the relaxed classifier); tier 2 path handles
+  // remaining entities whose entry.platform matches (with the strict classifier).
+  // Entities considered by tier 1 are NOT also offered to tier 2, so the strict
+  // classifier never second-guesses the relaxed result on the same entity.
+  let tier1Contributed = false;
+  let tier2Contributed = false;
   if (hass !== null && hass !== undefined && hass.entities !== null && hass.entities !== undefined) {
-    let tier2Walked = false;
     for (const [eid, entry] of Object.entries(hass.entities)) {
       if (entry === null || entry === undefined) continue;
-      if (!platforms.includes(entry.platform)) continue;
-      if (matchingDeviceIds.has(entry.device_id)) continue;
+      const inTier1 = matchingDeviceIds.has(entry.device_id);
+      const platformMatch = platforms.includes(entry.platform);
+      if (!inTier1 && !platformMatch) continue;
       if (shouldExclude(entry)) continue;
 
       const state = hass.states !== null && hass.states !== undefined ? hass.states[eid] : undefined;
@@ -553,21 +522,27 @@ export function discoverEntitiesByDevice(hass, opts = {}) {
       const device = (deviceId !== null && deviceId !== undefined && hass.devices !== null && hass.devices !== undefined)
         ? hass.devices[deviceId]
         : undefined;
-      const ctx = { state, entry, device, deviceId, entityId: eid, tier: 2 };
+      const tier = inTier1 ? 1 : 2;
+      const ctx = { state, entry, device, deviceId, entityId: eid, tier };
 
       if (!checkRelevant(eid, ctx)) continue;
 
-      const allergenKey = classifyStrict(eid, ctx);
+      const allergenKey = inTier1 ? classifyTier1(eid, ctx) : classifyStrict(eid, ctx);
+      if (allergenKey === null || allergenKey === undefined) continue;
+
       addEntity(eid, allergenKey, ctx);
-      tier2Walked = true;
+      if (inTier1) tier1Contributed = true;
+      else tier2Contributed = true;
     }
 
     if (locations.size > 0) {
-      const tierUsed = tier1ContributedLocations ? 1 : 2;
+      const tierUsed = tier1Contributed ? 1 : 2;
       if (debug) {
-        if (tier1ContributedLocations && tier2Walked) {
+        if (tier1Contributed && tier2Contributed) {
           console.debug(`[${logTag}] Discovery tier 1+2 result:`, locations.size, "locations (tier 1 + tier 2 top-up)");
-        } else if (!tier1ContributedLocations) {
+        } else if (tier1Contributed) {
+          console.debug(`[${logTag}] Discovery tier 1 result:`, locations.size, "locations");
+        } else {
           console.debug(`[${logTag}] Discovery tier 2 result:`, locations.size, "locations");
         }
         for (const [locId, loc] of locations) {

--- a/test/utils/adapter-helpers.test.js
+++ b/test/utils/adapter-helpers.test.js
@@ -696,6 +696,142 @@ describe("discoverEntitiesByDevice", () => {
     expect(discovery.locations.get("cfg_loc1").entities.get("birch")).toBe("sensor.testint_birch_loc1");
     expect(discovery.locations.get("cfg_loc2").entities.get("birch")).toBe("sensor.testint_birch_loc2");
   });
+
+  // --- Tier 1 + Tier 2 cooperation (mixed-registry top-up) ---
+
+  it("mixed registry: tier 2 tops up entities from devices without identifiers", () => {
+    // Two devices in the same integration. One has proper `identifiers`
+    // metadata (tier 1 sees it), the other has empty identifiers but its
+    // entities still carry `entry.platform` (tier 2 should catch it).
+    // The fix is that tier 1 must not short-circuit and hide the second
+    // device's entities.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_with_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+          name: "Location One",
+        },
+      },
+      {
+        entityId: "sensor.testint_birch_loc2",
+        state: "1",
+        deviceId: "dev_no_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [],
+          configEntries: ["cfg_loc2"],
+          name: "Location Two",
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch" }),
+    });
+
+    // tierUsed reflects tier 1 since tier 1 contributed; tier 2 topped up.
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(2);
+    expect(discovery.locations.get("cfg_loc1").entities.get("birch")).toBe("sensor.testint_birch_loc1");
+    expect(discovery.locations.get("cfg_loc2").entities.get("birch")).toBe("sensor.testint_birch_loc2");
+  });
+
+  it("mixed registry: tier 2 top-up does not reclassify tier-1 entities", () => {
+    // classifyRelaxed and strict differ for the SAME entity-id pattern.
+    // Tier-1-handled entity (dev_with_id) must keep the relaxed classification
+    // even though strict would also match it; the skip prevents double work
+    // and silent overwrites.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_loc1",
+        state: "3",
+        deviceId: "dev_with_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "loc1"]],
+          configEntries: ["cfg_loc1"],
+        },
+      },
+      {
+        entityId: "sensor.testint_grass_loc2",
+        state: "2",
+        deviceId: "dev_no_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [],
+          configEntries: ["cfg_loc2"],
+        },
+      },
+    ]);
+
+    let strictCallsForBirch = 0;
+    let relaxedCallsForBirch = 0;
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: (eid) => {
+        if (eid.includes("birch")) strictCallsForBirch++;
+        return eid.includes("grass") ? "grass" : null;
+      },
+      classifyRelaxed: (eid) => {
+        if (eid.includes("birch")) relaxedCallsForBirch++;
+        return eid.includes("birch") ? "birch" : eid.includes("grass") ? "grass" : null;
+      },
+    });
+
+    expect(relaxedCallsForBirch).toBe(1);
+    expect(strictCallsForBirch).toBe(0); // tier 2 skipped the tier-1 device
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(2);
+    expect(discovery.locations.get("cfg_loc1").entities.get("birch")).toBe("sensor.testint_birch_loc1");
+    expect(discovery.locations.get("cfg_loc2").entities.get("grass")).toBe("sensor.testint_grass_loc2");
+  });
+
+  it("mixed registry: tier 2 top-up merges into same location when config_entry_id matches", () => {
+    // Same config_entry_id but split across two devices, only one tagged with
+    // identifiers. Discovery should merge both entities into one location.
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.testint_birch_shared",
+        state: "3",
+        deviceId: "dev_with_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [["testint", "shared"]],
+          configEntries: ["cfg_shared"],
+          name: "Shared",
+        },
+      },
+      {
+        entityId: "sensor.testint_grass_shared",
+        state: "2",
+        deviceId: "dev_no_id",
+        platform: "testint",
+        deviceMeta: {
+          identifiers: [],
+          configEntries: ["cfg_shared"],
+          name: "Shared",
+        },
+      },
+    ]);
+
+    const discovery = discoverEntitiesByDevice(hass, {
+      platform: "testint",
+      classify: makeClassifier({ birch: "birch", grass: "grass" }),
+    });
+
+    expect(discovery.tierUsed).toBe(1);
+    expect(discovery.locations.size).toBe(1);
+    const loc = discovery.locations.get("cfg_shared");
+    expect(loc).toBeDefined();
+    expect(loc.entities.get("birch")).toBe("sensor.testint_birch_shared");
+    expect(loc.entities.get("grass")).toBe("sensor.testint_grass_shared");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Codex P2 review on #219 flagged that `discoverEntitiesByDevice` short-circuits as soon as tier 1 (device-identifier match) finds any device. In mixed-registry scenarios -- where some integration devices have proper `identifiers` metadata but others do not -- entities from the un-tagged devices were silently dropped, even though their `entry.platform` would let tier 2 see them.

## Fix

Tier 1 and tier 2 now cooperate rather than strictly cascade:

1. Tier 1 collects entities from devices with matching `identifiers` (unchanged loop logic).
2. Tier 2 always runs (when `hass.entities` is available) and walks all platform-matching entities, skipping any whose `device_id` was already in `matchingDeviceIds`. Skipping prevents `classifyStrict` from second-guessing the relaxed tier-1 classification on the same entity.
3. After both: if locations exist, return with `tierUsed = 1` when tier 1 contributed, else `tierUsed = 2`. If still empty, fall through to tier 3.

This preserves the existing test that exercises "tier 1 isRelevant-blocked, tier 2 picks up a no-device entity" (the blocked entity's device is in `matchingDeviceIds`, gets skipped; the no-device entity is processed; `tierUsed=2`).

## Tests

3 new contract tests in `test/utils/adapter-helpers.test.js`:

- Mixed registry top-up across two devices and two `config_entry_id`s.
- No re-classification of tier-1 entities (verified by call counters on the strict/relaxed classifiers).
- Same-`config_entry_id` merge: tier-1 and tier-2 entities go into the same location bucket.

All 968 tests pass (965 + 3 new).

## CHANGELOG

The existing `[3.2.0]` Changed entry for the discovery helper is expanded to document the cooperation semantics, so the final 3.2.0 release notes describe the as-shipped behavior rather than the intermediate cascade-only design.

## Release plan

This PR merges into `dev`, then `dev` is tagged `v3.2.0-beta5` for community testing alongside the existing #219 release-PR head update. Once beta5 is validated, #219 continues to merge into `master` for v3.2.0 final.