### PR TITLE
(sensors) Keep state='unknown' entities in findAvailableSensors

### DIFF
--- a/src/utils/sensors.js
+++ b/src/utils/sensors.js
@@ -14,9 +14,11 @@ export function findAvailableSensors(cfg, hass, debug = false) {
   const sensors = [...map.values()].filter((eid) => {
     if (!eid) return false;
     const entity = hass?.states?.[eid];
-    // Exclude non-existent, unavailable, or unknown entities
     if (!entity) return false;
-    return entity.state !== "unavailable" && entity.state !== "unknown";
+    // Keep `unknown`: the entity exists but its value is currently None
+    // (e.g. API returned null). Only `unavailable` signals a disabled/down
+    // integration, where "no sensors found" is the right message.
+    return entity.state !== "unavailable";
   });
 
   if (debug) {

--- a/test/utils/sensors.test.js
+++ b/test/utils/sensors.test.js
@@ -1430,4 +1430,136 @@ describe("findAvailableSensors", () => {
       expect(withDebug).toEqual(withoutDebug);
     });
   });
+
+  // ===========================================================================
+  // State filtering (#224)
+  // ===========================================================================
+  // `unavailable` means the integration coordinator is down or the entity is
+  // disabled -- treat as "no sensors". `unknown` means the entity is alive but
+  // its value is currently None (e.g. API returned null for this location);
+  // it must still be reported as a discovered sensor.
+
+  describe("State filtering", () => {
+    it("includes entities with state='unknown'", () => {
+      const hass = createHass({
+        "sensor.pollen_stockholm_birch": s("unknown"),
+      });
+      const cfg = {
+        integration: "pp",
+        city: "Stockholm",
+        allergens: ["birch"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual(["sensor.pollen_stockholm_birch"]);
+    });
+
+    it("excludes entities with state='unavailable'", () => {
+      const hass = createHass({
+        "sensor.pollen_stockholm_birch": s("unavailable"),
+      });
+      const cfg = {
+        integration: "pp",
+        city: "Stockholm",
+        allergens: ["birch"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual([]);
+    });
+
+    it("excludes entities missing from hass.states (resolved but not present)", () => {
+      // Resolution may yield a candidate id that never made it into states.
+      // Filter must drop it instead of returning a dangling reference.
+      const hass = createHass({});
+      const cfg = {
+        integration: "pp",
+        city: "Stockholm",
+        allergens: ["birch"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual([]);
+    });
+
+    it("mixes states: keeps unknown, drops unavailable, keeps a normal value", () => {
+      const hass = createHass({
+        "sensor.pollen_stockholm_birch": s("unknown"),
+        "sensor.pollen_stockholm_grass": s("unavailable"),
+        "sensor.pollen_stockholm_alder": s("3"),
+      });
+      const cfg = {
+        integration: "pp",
+        city: "Stockholm",
+        allergens: ["birch", "grass", "alder"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual([
+        "sensor.pollen_stockholm_birch",
+        "sensor.pollen_stockholm_alder",
+      ]);
+    });
+
+    it("includes entities with null or empty state (treated like unknown)", () => {
+      const hass = createHass({
+        "sensor.pollen_stockholm_birch": s(null),
+        "sensor.pollen_stockholm_grass": s(""),
+      });
+      const cfg = {
+        integration: "pp",
+        city: "Stockholm",
+        allergens: ["birch", "grass"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual([
+        "sensor.pollen_stockholm_birch",
+        "sensor.pollen_stockholm_grass",
+      ]);
+    });
+
+    it("includes SILAM entity in state='unknown' (regex fallback path)", () => {
+      // SILAM's resolveEntityIds matches against hass.states[candidate]; an
+      // unknown-state entity passes its own filter and reaches sensors.js.
+      const hass = createHass(
+        {
+          "sensor.silam_pollen_london_birch": s("unknown"),
+        },
+        { entities: {} },
+      );
+      const cfg = {
+        integration: "silam",
+        location: "London",
+        allergens: ["birch"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual(["sensor.silam_pollen_london_birch"]);
+    });
+
+    it("includes MSW entity in state='unknown' (entity returned, value None upstream)", () => {
+      // MSW's level map can't translate 'unknown' to a level later in
+      // fetchForecast, but resolveEntityIds still returns it -- which is
+      // what sensors.js sees. Mirrors the #223 scenario for swissweather.
+      const hass = createHass({
+        "sensor.pollen_birch_level_at_8000_za": { state: "unknown", attributes: {} },
+      });
+      const cfg = {
+        integration: "msw",
+        location: "",
+        allergens: ["birch"],
+      };
+
+      const result = findAvailableSensors(cfg, hass);
+
+      expect(result).toEqual(["sensor.pollen_birch_level_at_8000_za"]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #224.

## Problem

`src/utils/sensors.js:19` filtered out both `state === "unavailable"` and `state === "unknown"`. The card then reported "no pollen sensors found" even when sensor entities existed -- the only thing missing was their current value.

This conflates two distinct HA semantics:

| state | meaning | desired report |
|---|---|---|
| `unavailable` | coordinator down / entity disabled | "no sensors found" |
| `unknown` | entity alive, value currently `None` | fall through to "no allergens above threshold" |

Surfaced by #223 (Google Pollen API returns null values for some coordinates -- both pollenlevels and the other Google Pollen HACS integration behave the same; verified upstream).

## Fix

Narrow the filter to `state !== "unavailable"`.

## Tests

`test/utils/sensors.test.js` gains a `State filtering` describe block with 7 cases:

- `state=unknown` included; `state=unavailable` excluded
- entity missing from `hass.states` still excluded
- mixed states resolve correctly
- `null` and empty string states behave like unknown
- SILAM and MSW entities in `state=unknown` are kept (their `resolveEntityIds` passes them through to `sensors.js`, which is where the filter lives)

Full suite: 975 passing.

## Test plan

- [x] `npm test` -- 975 passing
- [ ] Manual: load card in HA test env with an entity stuck at `unknown` and verify the card now shows "no allergens above threshold" instead of "no pollen sensors found"