### PR TITLE
(card) Visually distinguish no-data (level=-1) from real zero with fuzzy rendering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ In this file:
 | `link_to_sensors` | `boolean` | `true` | Link allergen icons and circles to their sensor entities. |
 | `numeric_state_raw_risk` | `boolean` | `false` | Show the raw allergy risk value in numeric displays (PEU only). |
 | `show_empty_days` | `boolean` | `true` | Always render `days_to_show` columns even when there is no data. |
+| `show_no_data_distinct` | `boolean` | `true` | Render entries where the sensor exists but has no current value (e.g. `state: unknown`, upstream API returned `null`) with a distinct fuzzy texture instead of a plain empty circle. Disable to fall back to the old appearance, where no-data and a real `0` look identical. |
 | `pollen_threshold` | `integer` | `1` | Minimum value required to show an allergen. Use `0` to always show all. |
 | `sort` | `string` | `name_ascending` (PP) / `value_descending` (DWD) | Row sorting mode. Available options: `value_ascending`, `value_descending`, `name_ascending`, `name_descending`, `none`. |
 | `sort_category_allergens_first` *(Kleenex, GPL)* | `boolean` | `true` | Display category allergens (trees, grass, weeds) above individual allergens in the editor. |

--- a/src/constants.js
+++ b/src/constants.js
@@ -645,6 +645,7 @@ export const COSMETIC_FIELDS = [
   "text_size_ratio",
   "minimal_gap",
   "show_block_separator",
+  "show_no_data_distinct",
   "title",
   "card_mod",
 ];

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Vybrat kvalitu ovzduší",
   "editor.show_block_separator": "Zobrazit oddělovač mezi bloky",
   "editor.show_empty_days": "Zobrazit prázdné dny",
+  "editor.show_no_data_distinct": "Zobrazit \"žádná data\" s výrazným (rozmazaným) stylem",
   "editor.show_text_allergen": "Zobrazit text, alergen",
   "editor.show_value_numeric": "Zobrazit číselnou hodnotu",
   "editor.show_value_numeric_in_circle": "Zobrazit číslo v kruhu",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Vælg luftkvalitet",
   "editor.show_block_separator": "Vis separator mellem blokke",
   "editor.show_empty_days": "Vis tomme dage",
+  "editor.show_no_data_distinct": "Vis \"ingen data\" med tydelig (uklar) stil",
   "editor.show_text_allergen": "Vis tekst, allergen",
   "editor.show_value_numeric": "Vis talværdi",
   "editor.show_value_numeric_in_circle": "Vis talværdi i cirkler",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Luftqualität auswählen",
   "editor.show_block_separator": "Trennlinie zwischen Blöcken anzeigen",
   "editor.show_empty_days": "Leere Tage anzeigen",
+  "editor.show_no_data_distinct": "\"Keine Daten\" mit markiertem (verrauschtem) Stil anzeigen",
   "editor.show_text_allergen": "Allergentext anzeigen",
   "editor.show_value_numeric": "Wert als Zahl anzeigen",
   "editor.show_value_numeric_in_circle": "Numerischen Wert im Kreis anzeigen",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Επιλογή ποιότητας αέρα",
   "editor.show_block_separator": "Εμφάνιση διαχωριστικού μεταξύ μπλοκ",
   "editor.show_empty_days": "Εμφάνιση κενών ημερών",
+  "editor.show_no_data_distinct": "Εμφάνιση \"χωρίς δεδομένα\" με ξεχωριστό (θολό) στυλ",
   "editor.show_text_allergen": "Εμφάνιση κειμένου, αλλεργιογόνο",
   "editor.show_value_numeric": "Εμφάνιση τιμής, αριθμητικά",
   "editor.show_value_numeric_in_circle": "Εμφάνιση αριθμητικής τιμής στους κύκλους",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -290,6 +290,7 @@
   "editor.select_all_pollution": "Select air quality",
   "editor.show_block_separator": "Show separator between blocks",
   "editor.show_empty_days": "Show empty days",
+  "editor.show_no_data_distinct": "Show \"no data\" with distinct (fuzzy) styling",
   "editor.show_text_allergen": "Show text, allergen",
   "editor.show_value_numeric": "Show value, numeric",
   "editor.show_value_numeric_in_circle": "Show numeric value in the circles",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Seleccionar calidad del aire",
   "editor.show_block_separator": "Mostrar separador entre bloques",
   "editor.show_empty_days": "Mostrar días vacíos",
+  "editor.show_no_data_distinct": "Mostrar \"sin datos\" con estilo distintivo (difuso)",
   "editor.show_text_allergen": "Mostrar texto, alérgeno",
   "editor.show_value_numeric": "Mostrar valor numérico",
   "editor.show_value_numeric_in_circle": "Mostrar valor numérico en los círculos",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Valitse ilmanlaatu",
   "editor.show_block_separator": "Näytä erotin lohkojen välillä",
   "editor.show_empty_days": "Näytä tyhjät päivät",
+  "editor.show_no_data_distinct": "Näytä \"ei dataa\" erottuvalla (sumea) tyylillä",
   "editor.show_text_allergen": "Näytä allergeenin nimi",
   "editor.show_value_numeric": "Näytä numeerinen arvo",
   "editor.show_value_numeric_in_circle": "Näytä numeerinen arvo ympyröissä",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Sélectionner qualité de l'air",
   "editor.show_block_separator": "Afficher un séparateur entre les blocs",
   "editor.show_empty_days": "Afficher les jours vides",
+  "editor.show_no_data_distinct": "Afficher \"aucune donnée\" avec un style distinct (flou)",
   "editor.show_text_allergen": "Afficher le texte, allergène",
   "editor.show_value_numeric": "Afficher la valeur, numérique",
   "editor.show_value_numeric_in_circle": "Afficher la valeur numérique dans les cercles",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Seleziona qualità dell'aria",
   "editor.show_block_separator": "Mostra separatore tra i blocchi",
   "editor.show_empty_days": "Mostra giorni vuoti",
+  "editor.show_no_data_distinct": "Mostra \"nessun dato\" con stile distinto (sfocato)",
   "editor.show_text_allergen": "Mostra testo, allergene",
   "editor.show_value_numeric": "Mostra valore numerico",
   "editor.show_value_numeric_in_circle": "Mostra valore numerico nei cerchi",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Luchtkwaliteit selecteren",
   "editor.show_block_separator": "Scheidingslijn tussen blokken tonen",
   "editor.show_empty_days": "Toon lege dagen",
+  "editor.show_no_data_distinct": "Toon \"geen data\" met opvallende (wazige) stijl",
   "editor.show_text_allergen": "Toon tekst, allergeen",
   "editor.show_value_numeric": "Toon numerieke waarde",
   "editor.show_value_numeric_in_circle": "Toon numerieke waarde in de cirkels",

--- a/src/locales/no.json
+++ b/src/locales/no.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Velg luftkvalitet",
   "editor.show_block_separator": "Vis separator mellom blokker",
   "editor.show_empty_days": "Vis tomme dager",
+  "editor.show_no_data_distinct": "Vis \"ingen data\" med tydelig (uklar) stil",
   "editor.show_text_allergen": "Vis tekst, allergen",
   "editor.show_value_numeric": "Vis tallverdi",
   "editor.show_value_numeric_in_circle": "Vis tallverdi i sirkel",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Wybierz jakość powietrza",
   "editor.show_block_separator": "Pokaż separator między blokami",
   "editor.show_empty_days": "Pokaż puste dni",
+  "editor.show_no_data_distinct": "Pokaż \"brak danych\" z wyraźnym (rozmytym) stylem",
   "editor.show_text_allergen": "Pokaż tekst i alergen",
   "editor.show_value_numeric": "Pokaż wartość numeryczną",
   "editor.show_value_numeric_in_circle": "Pokaż wartość numeryczną w okręgu",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Выбрать качество воздуха",
   "editor.show_block_separator": "Показать разделитель между блоками",
   "editor.show_empty_days": "Показывать пустые дни",
+  "editor.show_no_data_distinct": "Показывать \"нет данных\" с выраженным (размытым) стилем",
   "editor.show_text_allergen": "Показывать название аллергена",
   "editor.show_value_numeric": "Показывать числовое значение",
   "editor.show_value_numeric_in_circle": "Показывать число в круге",

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Vybrať kvalitu ovzdušia",
   "editor.show_block_separator": "Zobraziť oddeľovač medzi blokmi",
   "editor.show_empty_days": "Zobraziť prázdne dni",
+  "editor.show_no_data_distinct": "Zobraziť \"žiadne údaje\" s výrazným (rozmazaným) štýlom",
   "editor.show_text_allergen": "Zobraziť text, alergén",
   "editor.show_value_numeric": "Zobraziť číselnú hodnotu",
   "editor.show_value_numeric_in_circle": "Zobraziť číslo v kruhu",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -289,6 +289,7 @@
   "editor.select_all_pollution": "Välj luftkvalitet",
   "editor.show_block_separator": "Visa separator mellan block",
   "editor.show_empty_days": "Visa tomma dagar",
+  "editor.show_no_data_distinct": "Visa \"inga data\" med distinkt (luddig) stil",
   "editor.show_text_allergen": "Visa text, allergen",
   "editor.show_value_numeric": "Visa värde, numeriskt",
   "editor.show_value_numeric_in_circle": "Visa numeriskt värde inuti cirklarna",

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -22,6 +22,11 @@ import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
 import { discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import {
+  buildNoiseSvgUri,
+  buildNoiseCanvasPattern,
+  hashStringSeed,
+} from "./utils/no-data-pattern.js";
+import {
   findSilamWeatherEntity,
   discoverSilamSensors,
   resolveDiscoveredLocation,
@@ -55,6 +60,27 @@ class PollenPrognosCard extends LitElement {
   _skipIntegrations = new Set(); // Integrations that failed during autodetect
 
 
+  /**
+   * Dot color for the "no data" noise pattern. Reads the card's resolved
+   * `--primary-text-color` so the texture follows the active HA theme, with
+   * a neutral grey fallback when the variable is not available (offscreen
+   * canvases, headless test runs, etc.).
+   */
+  _noDataDotColor() {
+    if (typeof window !== "undefined" && window.getComputedStyle) {
+      try {
+        const v = window
+          .getComputedStyle(this)
+          .getPropertyValue("--primary-text-color")
+          .trim();
+        if (v) return v;
+      } catch (_) {
+        // ignore and fall through
+      }
+    }
+    return "#888888";
+  }
+
   _renderLevelCircle(
     level,
     {
@@ -75,6 +101,8 @@ class PollenPrognosCard extends LitElement {
     const chartId = `chart-${allergen}-${dayIndex}-${level}`;
 
     // Use attributes instead of properties so values persist if DOM is cloned
+    const noDataDistinct = this.config?.show_no_data_distinct !== false;
+    const stateAttr = noDataDistinct && level === -1 ? "no_data" : "ok";
     return html`
       <div
         id="${chartId}"
@@ -85,6 +113,7 @@ class PollenPrognosCard extends LitElement {
           : ""}"
         data-level="${level}"
         data-display-level="${displayLevel}"
+        data-state="${stateAttr}"
         data-colors="${JSON.stringify(colors)}"
         data-empty-color="${emptyColor}"
         data-gap-color="${gapColor}"
@@ -140,6 +169,7 @@ class PollenPrognosCard extends LitElement {
       const gap = Number(container.dataset.gap);
       const size = Number(container.dataset.size);
       const showValue = container.dataset.showValue === "true";
+      const isNoData = container.dataset.state === "no_data";
 
       // Get custom styling from data attributes
       const fontWeight = container.dataset.fontWeight || "normal";
@@ -159,13 +189,29 @@ class PollenPrognosCard extends LitElement {
         canvas.height = size;
         container.appendChild(canvas);
 
+        const canvasCtx = canvas.getContext("2d");
+        // No-data: fill every segment with the noise tile pattern so the
+        // ring looks visibly distinct from a real "level 0" (which is just
+        // the empty color repeated). Each chart gets its own seed derived
+        // from the container id (allergen+dayIndex+level) so adjacent
+        // no-data circles don't display identical clumps. Falls back to
+        // emptyColor if pattern creation fails (e.g. headless ctx with no
+        // createPattern).
+        const noisePattern = isNoData
+          ? buildNoiseCanvasPattern(canvasCtx, this._noDataDotColor(), {
+              seed: hashStringSeed(container.id),
+            })
+          : null;
+        const fill = noisePattern ?? emptyColor;
         const data = Array(numSegments).fill(1);
-        const bg = Array(numSegments)
-          .fill(emptyColor)
-          .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
+        const bg = isNoData
+          ? Array(numSegments).fill(fill)
+          : Array(numSegments)
+              .fill(emptyColor)
+              .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
         const bc = Array(numSegments).fill(gapColor);
 
-        chart = new Chart(canvas.getContext("2d"), {
+        chart = new Chart(canvasCtx, {
           type: "doughnut",
           data: {
             labels: Array(numSegments).fill(""),
@@ -223,11 +269,31 @@ class PollenPrognosCard extends LitElement {
         // Update existing chart only if colors actually changed
         const datasets = chart.data.datasets;
         if (datasets && datasets[0]) {
-          const bg = Array(datasets[0].backgroundColor.length)
-            .fill(emptyColor)
-            .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
-
           const oldBg = datasets[0].backgroundColor;
+          let bg;
+          if (isNoData) {
+            // Reuse the cached pattern if the chart already has one in oldBg
+            // (CanvasPattern objects compare identity-safely here), otherwise
+            // build a fresh one for this canvas context — same per-container
+            // seed as the initial create branch.
+            const existingPattern = oldBg.find(
+              (c) => typeof c === "object" && c !== null,
+            );
+            const pattern =
+              existingPattern ??
+              buildNoiseCanvasPattern(
+                chart.canvas.getContext("2d"),
+                this._noDataDotColor(),
+                { seed: hashStringSeed(container.id) },
+              ) ??
+              emptyColor;
+            bg = Array(oldBg.length).fill(pattern);
+          } else {
+            bg = Array(oldBg.length)
+              .fill(emptyColor)
+              .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
+          }
+
           const colorsChanged =
             bg.length !== oldBg.length || bg.some((c, i) => c !== oldBg[i]);
           if (colorsChanged) {
@@ -802,6 +868,31 @@ class PollenPrognosCard extends LitElement {
       effectiveKey = `allergy_risk_${Math.min(level, 6)}`;
     }
     const svgContent = getSvgContent(effectiveKey);
+
+    // No-data branch: render the icon as a CSS mask filled with the noise
+    // pattern instead of inline SVG. The shape is preserved (you still see
+    // the allergen silhouette) but the fill is fuzzy, signalling "we have
+    // no data for this entry" without screaming red.
+    const noDataDistinct = this.config?.show_no_data_distinct !== false;
+    if (!stale && noDataDistinct && level === -1 && svgContent) {
+      const clickHandler = clickable && onClick ? onClick : null;
+      const iconUri = `data:image/svg+xml;utf8,${encodeURIComponent(svgContent)}`;
+      const noiseUri = buildNoiseSvgUri(this._noDataDotColor());
+      const style =
+        `--pp-icon-no-data-mask: url("${iconUri}"); ` +
+        `--pp-icon-no-data-noise: url("${noiseUri}"); ` +
+        `--pp-icon-stroke-width: ${strokeWidth};` +
+        (clickable ? " cursor: pointer;" : "");
+      return html`
+        <div
+          class="pp-icon pp-icon-no-data"
+          data-state="no_data"
+          style="${style}"
+          aria-hidden="true"
+          @click=${clickHandler}
+        ></div>
+      `;
+    }
 
     // Determine stroke color based on sync setting
     let actualStrokeColor;
@@ -2490,6 +2581,33 @@ class PollenPrognosCard extends LitElement {
       .pp-icon svg g {
         stroke: var(--pp-icon-stroke, none);
         stroke-width: var(--pp-icon-stroke-width, 1);
+      }
+
+      /* No-data icon: silhouette filled with a faint solid color (anchors
+         the shape so it stays readable against a heavily textured ring)
+         plus a noise pattern on top (carries the "no data" cue). The icon
+         SVG acts as the mask; mask-mode: alpha is set explicitly so SVG
+         paths filled with black act as the opaque part of the mask in
+         Chrome (its default for SVG-via-url is luminance, which would
+         invert the result). */
+      .pp-icon-no-data {
+        -webkit-mask-image: var(--pp-icon-no-data-mask);
+        mask-image: var(--pp-icon-no-data-mask);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+        -webkit-mask-mode: alpha;
+        mask-mode: alpha;
+        background-image: var(--pp-icon-no-data-noise);
+        background-repeat: repeat;
+        background-color: color-mix(
+          in srgb,
+          var(--primary-text-color, #888888) 15%,
+          transparent
+        );
       }
 
       .pp-icon-placeholder {

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -154,6 +154,13 @@ class PollenPrognosCard extends LitElement {
     const containers = this.renderRoot?.querySelectorAll(".level-circle") || [];
     const activeIds = new Set();
 
+    // Resolve the no-data dot color once per rebuild. _noDataDotColor() reads
+    // getComputedStyle which is non-trivial; caching here both saves work
+    // when many circles are no-data AND lets the update branch detect a
+    // theme-color change (chart._noDataColor !== noDataColor) so stale
+    // patterns get rebuilt instead of reused indefinitely.
+    const noDataColor = this._noDataDotColor();
+
     containers.forEach((container) => {
       activeIds.add(container.id);
 
@@ -198,7 +205,7 @@ class PollenPrognosCard extends LitElement {
         // emptyColor if pattern creation fails (e.g. headless ctx with no
         // createPattern).
         const noisePattern = isNoData
-          ? buildNoiseCanvasPattern(canvasCtx, this._noDataDotColor(), {
+          ? buildNoiseCanvasPattern(canvasCtx, noDataColor, {
               seed: hashStringSeed(container.id),
             })
           : null;
@@ -264,6 +271,10 @@ class PollenPrognosCard extends LitElement {
           },
         });
 
+        // Tag the chart with the dot color used to build this pattern so
+        // a later theme-color change can invalidate the cached pattern.
+        if (isNoData) chart._noDataColor = noDataColor;
+
         this._chartCache.set(container.id, chart);
       } else {
         // Update existing chart only if colors actually changed
@@ -273,20 +284,24 @@ class PollenPrognosCard extends LitElement {
           let bg;
           if (isNoData) {
             // Reuse the cached pattern if the chart already has one in oldBg
-            // (CanvasPattern objects compare identity-safely here), otherwise
-            // build a fresh one for this canvas context — same per-container
-            // seed as the initial create branch.
+            // AND the theme dot color hasn't changed since it was built.
+            // Otherwise rebuild so a theme switch propagates through.
             const existingPattern = oldBg.find(
               (c) => typeof c === "object" && c !== null,
             );
-            const pattern =
-              existingPattern ??
-              buildNoiseCanvasPattern(
-                chart.canvas.getContext("2d"),
-                this._noDataDotColor(),
-                { seed: hashStringSeed(container.id) },
-              ) ??
-              emptyColor;
+            const colorChanged = chart._noDataColor !== noDataColor;
+            let pattern;
+            if (existingPattern && !colorChanged) {
+              pattern = existingPattern;
+            } else {
+              pattern =
+                buildNoiseCanvasPattern(
+                  chart.canvas.getContext("2d"),
+                  noDataColor,
+                  { seed: hashStringSeed(container.id) },
+                ) ?? emptyColor;
+              chart._noDataColor = noDataColor;
+            }
             bg = Array(oldBg.length).fill(pattern);
           } else {
             bg = Array(oldBg.length)

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -898,10 +898,12 @@ class PollenPrognosCard extends LitElement {
       const clickHandler = clickable && onClick ? onClick : null;
       const iconUri = `data:image/svg+xml;utf8,${encodeURIComponent(svgContent)}`;
       const noiseUri = buildNoiseSvgUri(this._noDataDotColor());
+      // No --pp-icon-stroke-width here: the no-data branch renders a masked
+      // div with no inline SVG, so the stroke-width var (read by
+      // `.pp-icon svg g`) has no effect in this branch.
       const style =
         `--pp-icon-no-data-mask: url("${iconUri}"); ` +
-        `--pp-icon-no-data-noise: url("${noiseUri}"); ` +
-        `--pp-icon-stroke-width: ${strokeWidth};` +
+        `--pp-icon-no-data-noise: url("${noiseUri}");` +
         (clickable ? " cursor: pointer;" : "");
       return html`
         <div

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -2623,6 +2623,12 @@ class PollenPrognosCard extends LitElement {
         mask-mode: alpha;
         background-image: var(--pp-icon-no-data-noise);
         background-repeat: repeat;
+        /* Plain rgba fallback first so the icon still gets a translucent
+           anchor on browsers without color-mix() support (older WebKit /
+           legacy Chromium builds shipped via plugin-legacy). The
+           color-mix() declaration overrides it on modern browsers and
+           tracks --primary-text-color through theme switches. */
+        background-color: rgba(136, 136, 136, 0.15);
         background-color: color-mix(
           in srgb,
           var(--primary-text-color, #888888) 15%,

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -102,7 +102,10 @@ class PollenPrognosCard extends LitElement {
 
     // Use attributes instead of properties so values persist if DOM is cloned
     const noDataDistinct = this.config?.show_no_data_distinct !== false;
-    const stateAttr = noDataDistinct && level === -1 ? "no_data" : "ok";
+    // `level < 0` rather than `=== -1` so per-integration scaling doesn't
+    // hide the no-data sentinel. E.g. DWD scales raw state by 2 in the
+    // daily-row path, so an adapter-emitted -1 reaches here as -2.
+    const stateAttr = noDataDistinct && level < 0 ? "no_data" : "ok";
     return html`
       <div
         id="${chartId}"
@@ -888,8 +891,10 @@ class PollenPrognosCard extends LitElement {
     // pattern instead of inline SVG. The shape is preserved (you still see
     // the allergen silhouette) but the fill is fuzzy, signalling "we have
     // no data for this entry" without screaming red.
+    // `level < 0` rather than `=== -1`: DWD scales the level by 2 in the
+    // chart path, so adapter-emitted -1 can arrive here as -2.
     const noDataDistinct = this.config?.show_no_data_distinct !== false;
-    if (!stale && noDataDistinct && level === -1 && svgContent) {
+    if (!stale && noDataDistinct && level < 0 && svgContent) {
       const clickHandler = clickable && onClick ? onClick : null;
       const iconUri = `data:image/svg+xml;utf8,${encodeURIComponent(svgContent)}`;
       const noiseUri = buildNoiseSvgUri(this._noDataDotColor());

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -933,10 +933,14 @@ class PollenPrognosCard extends LitElement {
     const style = `--pp-icon-color: ${color}; --pp-icon-stroke: ${actualStrokeColor}; --pp-icon-stroke-width: ${strokeWidth}; ${clickable ? 'cursor: pointer;' : ''}`;
 
     if (svgContent) {
-      // Render inline SVG with color styling
+      // Render inline SVG with color styling.
+      // data-state="ok" mirrors the attribute the no-data icon branch sets,
+      // and matches the same attribute on .level-circle, so theme / card-mod
+      // overrides can target both states symmetrically.
       return html`
-        <div 
-          class="pp-icon" 
+        <div
+          class="pp-icon"
+          data-state="ok"
           style="${style}"
           aria-hidden="true"
           @click=${clickHandler}

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -3183,6 +3183,13 @@ class PollenPrognosCardEditor extends LitElement {
                   this._updateConfig("show_empty_days", e.target.checked)}
               ></ha-switch>
             </ha-formfield>
+            <ha-formfield label="${this._t("show_no_data_distinct")}">
+              <ha-switch
+                .checked=${c.show_no_data_distinct !== false}
+                @change=${(e) =>
+                  this._updateConfig("show_no_data_distinct", e.target.checked)}
+              ></ha-switch>
+            </ha-formfield>
           </details>
 
           <!-- Day Settings -->

--- a/src/utils/levels-defaults.js
+++ b/src/utils/levels-defaults.js
@@ -40,6 +40,12 @@ export const LEVELS_DEFAULTS = {
   
   // Default color for no allergens icon
   no_allergens_color: "#a9cfe0",
+
+  // Render the "no data" state (adapter-emitted level=-1) with a distinct
+  // fuzzy texture so it doesn't visually collapse into a real level=0.
+  // Spread into every adapter's stub config so the editor / YAML can opt
+  // out per card.
+  show_no_data_distinct: true,
 };
 
 // Conversion factor for stroke width to gap conversion

--- a/src/utils/no-data-pattern.js
+++ b/src/utils/no-data-pattern.js
@@ -1,0 +1,148 @@
+// src/utils/no-data-pattern.js
+//
+// Noise-pattern generator for the "no data" visual treatment (level === -1).
+// Two output forms are provided so distinct textures can be applied to the
+// allergen icon (CSS mask + background) and the level circle ring
+// (Chart.js doughnut via CanvasPattern):
+//
+//   - Icon background: tile of small round dots. The CSS rule layers this on
+//     top of a solid translucent fill so the icon silhouette stays readable
+//     even when the doughnut ring behind it is heavily textured.
+//   - Ring (doughnut): mixed 1-2px pixels with a sparse short-stroke
+//     "scratches" pass. Per-circle seed lets adjacent circles look different,
+//     avoiding visible identical clumps.
+
+const ICON_DOT_DENSITY = 0.5;
+const ICON_DOT_TILE = 12;
+
+const RING_TILE = 32;
+const RING_PIX_DENSITY = 0.10;
+const RING_SCRATCH_DENSITY_FACTOR = 0.25;
+const RING_MAX_PIX_SIZE = 2;
+
+const DEFAULT_SEED = 13;
+
+/**
+ * Seedable PRNG. Stable output for a given seed so headless screenshots and
+ * unit tests don't flake across runs.
+ */
+function mulberry32(seed) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Build a tiling SVG `data:` URI of small round dots. Used as
+ * `background-image` for the no-data icon (under a CSS mask of the allergen
+ * SVG). Density defaults to 50% so the silhouette reads even against a
+ * heavily-textured ring.
+ */
+export function buildNoiseSvgUri(color = "#888888", opts = {}) {
+  const density = opts.density ?? ICON_DOT_DENSITY;
+  const tile = opts.tile ?? ICON_DOT_TILE;
+  const seed = opts.seed ?? DEFAULT_SEED;
+  const rng = mulberry32(seed);
+  const dotR = 1.4;
+  const area = tile * tile;
+  const count = Math.round((area * density) / (Math.PI * dotR * dotR));
+  let body = "";
+  for (let i = 0; i < count; i++) {
+    body +=
+      `<circle cx="${(rng() * tile).toFixed(1)}" cy="${(rng() * tile).toFixed(1)}" ` +
+      `r="${dotR}" fill="${color}" fill-opacity="${(0.55 + rng() * 0.45).toFixed(2)}"/>`;
+  }
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${tile}" height="${tile}" ` +
+    `viewBox="0 0 ${tile} ${tile}">${body}</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Draw the ring noise tile (pixel-static + sparse scratches) into an
+ * offscreen canvas. Returns null when there's no `document` (Node test env);
+ * production callers must fall back to an emptyColor fill in that case.
+ */
+export function buildNoiseTileCanvas(color = "#888888", opts = {}) {
+  if (typeof document === "undefined") return null;
+  const tile = opts.tile ?? RING_TILE;
+  const seed = opts.seed ?? DEFAULT_SEED;
+  const pixDensity = opts.pixDensity ?? RING_PIX_DENSITY;
+  const scratchFactor = opts.scratchDensity ?? RING_SCRATCH_DENSITY_FACTOR;
+  const maxPx = opts.maxPx ?? RING_MAX_PIX_SIZE;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = tile;
+  canvas.height = tile;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  const rng = mulberry32(seed);
+
+  // Layer 1: pixel static. Mostly 1px squares, ~15% 2px. The bigger squares
+  // get dimmer so they don't visually clump.
+  ctx.fillStyle = color;
+  const pixArea = tile * tile;
+  const pixCount = Math.round(pixArea * pixDensity);
+  for (let i = 0; i < pixCount; i++) {
+    const x = Math.floor(rng() * tile);
+    const y = Math.floor(rng() * tile);
+    const r = rng();
+    let dotSz;
+    if (maxPx === 2) dotSz = r < 0.85 ? 1 : 2;
+    else dotSz = r < 0.7 ? 1 : r < 0.96 ? 2 : 3;
+    const opBase = 0.35 + rng() * 0.55;
+    ctx.globalAlpha = dotSz === 1 ? opBase : opBase * 0.6;
+    ctx.fillRect(x, y, dotSz, dotSz);
+  }
+
+  // Layer 2: sparse short scratches. Thin, dim, short — directional accent
+  // without competing with the pixel field.
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 0.6;
+  ctx.lineCap = "round";
+  const scratchCount = Math.round(pixArea * 0.06 * scratchFactor);
+  for (let i = 0; i < scratchCount; i++) {
+    const x = rng() * tile;
+    const y = rng() * tile;
+    const angle = rng() * Math.PI;
+    const len = 1.5 + rng() * 2.5;
+    ctx.globalAlpha = 0.25 + rng() * 0.35;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x + Math.cos(angle) * len, y + Math.sin(angle) * len);
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = 1;
+  return canvas;
+}
+
+/**
+ * Build a Chart.js-compatible CanvasPattern for the ring. Pass the
+ * destination chart's 2D context so the pattern is allocated in the right
+ * rendering context.
+ */
+export function buildNoiseCanvasPattern(ctx, color = "#888888", opts = {}) {
+  if (!ctx || typeof ctx.createPattern !== "function") return null;
+  const tile = buildNoiseTileCanvas(color, opts);
+  if (!tile) return null;
+  return ctx.createPattern(tile, "repeat");
+}
+
+/**
+ * Hash an arbitrary string (e.g. allergen + day-index) to a positive 32-bit
+ * integer suitable as a noise seed. Lets the card give each rendered circle
+ * its own seed so identical no-data layouts don't repeat across adjacent
+ * allergen rows.
+ */
+export function hashStringSeed(s) {
+  let h = 5381;
+  if (typeof s !== "string") s = String(s);
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 33) ^ s.charCodeAt(i);
+  }
+  return (h >>> 0) || 1;
+}

--- a/src/utils/no-data-pattern.js
+++ b/src/utils/no-data-pattern.js
@@ -23,6 +23,25 @@ const RING_MAX_PIX_SIZE = 2;
 const DEFAULT_SEED = 13;
 
 /**
+ * Escape a string for safe use inside an SVG/XML attribute value.
+ * The dot color is read from a CSS custom property and could in principle
+ * contain `"`, `<`, `>`, `&`, or `'` (custom properties accept arbitrary
+ * strings until they're used). Without escaping, a crafted property value
+ * could break out of the `fill="..."` attribute and inject SVG markup into
+ * the data URI -- including `<script>`, since SVG is script-capable.
+ * The order matters: `&` first, so we don't double-encode entity refs we
+ * introduce in later replacements.
+ */
+function escapeXmlAttr(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
  * Seedable PRNG. Stable output for a given seed so headless screenshots and
  * unit tests don't flake across runs.
  */
@@ -49,11 +68,13 @@ export function buildNoiseSvgUri(color = "#888888", opts = {}) {
   const dotR = 1.4;
   const area = tile * tile;
   const count = Math.round((area * density) / (Math.PI * dotR * dotR));
+  // Escape once so we don't re-do it on every dot.
+  const safeColor = escapeXmlAttr(color);
   let body = "";
   for (let i = 0; i < count; i++) {
     body +=
       `<circle cx="${(rng() * tile).toFixed(1)}" cy="${(rng() * tile).toFixed(1)}" ` +
-      `r="${dotR}" fill="${color}" fill-opacity="${(0.55 + rng() * 0.45).toFixed(2)}"/>`;
+      `r="${dotR}" fill="${safeColor}" fill-opacity="${(0.55 + rng() * 0.45).toFixed(2)}"/>`;
   }
   const svg =
     `<svg xmlns="http://www.w3.org/2000/svg" width="${tile}" height="${tile}" ` +

--- a/src/utils/no-data-pattern.js
+++ b/src/utils/no-data-pattern.js
@@ -162,8 +162,11 @@ export function buildNoiseCanvasPattern(ctx, color = "#888888", opts = {}) {
 export function hashStringSeed(s) {
   let h = 5381;
   if (typeof s !== "string") s = String(s);
+  // Math.imul keeps the multiplication in 32-bit integer space; plain
+  // `h * 33` would drift into IEEE-754 float at ~14 chars (33^14 > 2^53)
+  // and lose low-bit precision, increasing collisions on longer chart ids.
   for (let i = 0; i < s.length; i++) {
-    h = (h * 33) ^ s.charCodeAt(i);
+    h = Math.imul(h, 33) ^ s.charCodeAt(i);
   }
   return (h >>> 0) || 1;
 }

--- a/test/utils/no-data-pattern.test.js
+++ b/test/utils/no-data-pattern.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+
+// Tests run in the project's default node env (no jsdom). The canvas helpers
+// are guarded with `typeof document === "undefined" -> null` for exactly this
+// reason; we assert the SSR/test fallback here, and rely on the headless
+// browser smoke test for the real-canvas path.
+import {
+  buildNoiseSvgUri,
+  buildNoiseTileCanvas,
+  buildNoiseCanvasPattern,
+  hashStringSeed,
+} from "../../src/utils/no-data-pattern.js";
+
+describe("no-data-pattern", () => {
+  describe("buildNoiseSvgUri", () => {
+    it("returns a data:image/svg+xml URI", () => {
+      const uri = buildNoiseSvgUri();
+      expect(uri.startsWith("data:image/svg+xml;utf8,")).toBe(true);
+    });
+
+    it("URL-encodes the SVG body so the URI is safe inside CSS url() and HTML attributes", () => {
+      const uri = buildNoiseSvgUri();
+      // No raw '<' or '>' should leak through (they break HTML attributes).
+      expect(uri).not.toMatch(/[<>]/);
+      // Must contain the encoded <svg ...> opening tag.
+      expect(uri).toMatch(/%3Csvg/);
+    });
+
+    it("embeds the requested dot color", () => {
+      const uri = buildNoiseSvgUri("#aabbcc");
+      // encodeURIComponent("#") -> "%23"
+      expect(uri).toContain("%23aabbcc");
+    });
+
+    it("is deterministic for the same seed", () => {
+      const a = buildNoiseSvgUri("#888", { seed: 7 });
+      const b = buildNoiseSvgUri("#888", { seed: 7 });
+      expect(a).toBe(b);
+    });
+
+    it("changes when the seed changes", () => {
+      const a = buildNoiseSvgUri("#888", { seed: 1 });
+      const b = buildNoiseSvgUri("#888", { seed: 2 });
+      expect(a).not.toBe(b);
+    });
+
+    it("produces more dots at higher density", () => {
+      const sparse = buildNoiseSvgUri("#888", { density: 0.1, seed: 5 });
+      const dense = buildNoiseSvgUri("#888", { density: 0.6, seed: 5 });
+      const countSparse = (sparse.match(/circle/g) || []).length;
+      const countDense = (dense.match(/circle/g) || []).length;
+      expect(countDense).toBeGreaterThan(countSparse);
+    });
+  });
+
+  describe("buildNoiseTileCanvas", () => {
+    it("returns null when document is unavailable (server-side / node test env)", () => {
+      // Asserts the SSR guard (typeof document === "undefined" -> null) so the
+      // chart renderer's fall-through to emptyColor is exercised in tests too.
+      expect(buildNoiseTileCanvas("#888")).toBeNull();
+    });
+  });
+
+  describe("buildNoiseCanvasPattern", () => {
+    it("returns null when given a null context", () => {
+      expect(buildNoiseCanvasPattern(null)).toBeNull();
+    });
+
+    it("returns null when given a context-shaped object missing createPattern", () => {
+      expect(buildNoiseCanvasPattern({})).toBeNull();
+    });
+
+    it("returns null when document is unavailable, even with a valid-shaped context", () => {
+      // The guard order is: createPattern check -> tile build (which needs
+      // document). Pass a stub ctx with createPattern so we reach the tile
+      // step and exercise its SSR-null branch.
+      const stubCtx = { createPattern: () => "should not get here" };
+      expect(buildNoiseCanvasPattern(stubCtx, "#888")).toBeNull();
+    });
+  });
+
+  describe("hashStringSeed", () => {
+    it("returns a positive integer", () => {
+      const seed = hashStringSeed("chart-birch-0--1");
+      expect(seed).toBeGreaterThan(0);
+      expect(Number.isInteger(seed)).toBe(true);
+    });
+
+    it("is deterministic for the same input", () => {
+      expect(hashStringSeed("chart-grass-2--1")).toBe(
+        hashStringSeed("chart-grass-2--1"),
+      );
+    });
+
+    it("produces different seeds for adjacent chart ids", () => {
+      // Practical concern: adjacent no-data circles (same allergen, different
+      // day) must not share the same noise layout, otherwise clumps repeat.
+      const seeds = [
+        hashStringSeed("chart-birch-0--1"),
+        hashStringSeed("chart-birch-1--1"),
+        hashStringSeed("chart-birch-2--1"),
+      ];
+      expect(new Set(seeds).size).toBe(3);
+    });
+
+    it("coerces non-string input rather than throwing", () => {
+      expect(() => hashStringSeed(42)).not.toThrow();
+      expect(hashStringSeed(42)).toBeGreaterThan(0);
+    });
+
+    it("never returns 0 (would degenerate the PRNG)", () => {
+      // Empty string is the dangerous edge case; the function falls back to
+      // the djb2 initial value (positive non-zero).
+      expect(hashStringSeed("")).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/utils/no-data-pattern.test.js
+++ b/test/utils/no-data-pattern.test.js
@@ -32,6 +32,20 @@ describe("no-data-pattern", () => {
       expect(uri).toContain("%23aabbcc");
     });
 
+    it("escapes XML-significant characters in the color (defense vs SVG attribute injection)", () => {
+      // Custom CSS properties accept arbitrary strings. A crafted theme
+      // value containing `"` or `<` must not be able to break out of
+      // fill="..." and inject SVG markup into the data URI. Decode the
+      // URI back and assert the dangerous chars survived as entities.
+      const uri = buildNoiseSvgUri('red"><script>alert(1)</script>');
+      const decoded = decodeURIComponent(uri.replace(/^data:image\/svg\+xml;utf8,/, ""));
+      // Original payload's `"` and `<script>` must NOT appear verbatim.
+      expect(decoded).not.toContain('"><script>');
+      // Their entity-encoded forms must be present.
+      expect(decoded).toContain("&quot;");
+      expect(decoded).toContain("&lt;script&gt;");
+    });
+
     it("is deterministic for the same seed", () => {
       const a = buildNoiseSvgUri("#888", { seed: 7 });
       const b = buildNoiseSvgUri("#888", { seed: 7 });


### PR DESCRIPTION
## Background

PR #226 (#224) narrowed the state filter so entities in state="unknown"
are no longer dropped from `findAvailableSensors`. Without further changes,
those entities then render at level 0 -- visually identical to "real zero
pollen today", which is misleading. Adapters already emit `state: -1,
display_state: -1` for no-data entries (via `clampLevel(val, max, -1)` in
`src/utils/adapter-helpers.js`); this PR makes the renderer act on that
sentinel.

## What's new

- New utility `src/utils/no-data-pattern.js`. Two noise generators:
  - `buildNoiseSvgUri()` for the allergen icon: tile of small round dots
    (50% density default) used as CSS `background-image` under a mask of
    the SVG silhouette.
  - `buildNoiseCanvasPattern()` for the level circle: mixed 1-2px pixel
    static plus a sparse short-stroke "scratches" pass, returned as a
    Chart.js `CanvasPattern`. Per-circle seed (`hashStringSeed(container.id)`)
    so adjacent no-data circles don't display identical clumps.
- `_rebuildCharts` detects `level === -1` and fills every doughnut
  segment with the noise pattern. Falls back to `emptyColor` when
  `createPattern` is unavailable (SSR / headless paths).
- `_renderAllergenSvg` renders the no-data icon as a CSS-masked div with
  a faint solid translucent fill (anchors the silhouette so it stays
  readable against the textured ring) plus the noise pattern on top.
  Solid color uses `color-mix(in srgb, var(--primary-text-color) 15%,
  transparent)` so it follows the active HA theme.
- `_noDataDotColor()` helper reads `--primary-text-color` from computed
  style, with `#888` fallback for headless / detached rendering paths.
- New `data-state="no_data"` attribute on level-circle and icon elements,
  available for theme / card-mod overrides.
- New config `show_no_data_distinct: true` (default true), added to
  `LEVELS_DEFAULTS` so it spreads into every adapter stub config. Editor
  toggle added under the display-settings section alongside
  `show_empty_days`.

## i18n

`editor.show_no_data_distinct` translated for all 15 supported locales.

## Visual reference

POC mockups (gitignored): `tmp/no-data-poc/context-v3.html` and
`tmp/no-data-poc/icon-vs-ring.html`. Picked variants after iteration:
- **Icon**: solid translucent fill + 50% dot overlay
- **Ring**: pixel static (max 2px squares, dimmer at 2px) + sparse
  scratches (density 0.25, stroke-width 0.6), per-circle seed.

## Tests

`test/utils/no-data-pattern.test.js` covers the SVG URI generator,
SSR null-guards on the canvas helpers, and the chart-id hash helper
(positive int, deterministic, distinct seeds for adjacent ids,
non-string input coercion). Full suite: **990 passing**.

End-to-end visual smoke test was done in hass-test against:
- **GPL Sydney** (all entities `state=unknown`): all three allergens
  render as fuzzy icon + fuzzy ring.
- **GPL Hem / Kiev** (mixed): trees/grass have data and render normally;
  ogras/weeds is `unknown` and gets the fuzzy treatment, confirming
  per-allergen accuracy.

## Closes / related

Follow-up to #224 / PR #226 (no dedicated tracker issue; spec is in this
PR description). The icon-inside-ring layout that surfaced from the POC
mockups is tracked separately in #227.