### PR TITLE
(logging) Translate Swedish debug/warn console messages to English

### DIFF
--- a/src/adapters/peu.js
+++ b/src/adapters/peu.js
@@ -575,7 +575,7 @@ export async function fetchForecast(hass, config) {
       // Threshold-filter
       if (meetsThreshold(dict.days, pollen_threshold)) sensors.push(dict);
     } catch (e) {
-      if (debug) console.warn(`Fel vid allergen ${allergen}:`, e);
+      if (debug) console.warn(`[PEU] Error for allergen ${allergen}:`, e);
     }
   }
 

--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -416,7 +416,7 @@ export async function fetchForecast(hass, config) {
       // Threshold filtering
       if (meetsThreshold(dict.days, pollen_threshold)) sensors.push(dict);
     } catch (e) {
-      console.warn(`[PP] Fel vid allergen ${allergen}:`, e);
+      console.warn(`[PP] Error for allergen ${allergen}:`, e);
     }
   }
 

--- a/src/adapters/silam.js
+++ b/src/adapters/silam.js
@@ -261,7 +261,7 @@ export async function fetchForecast(hass, config, forecastEvent = null) {
 
   if (!weatherEntity || !hass.states[weatherEntity]) {
     if (debug)
-      console.warn("[SILAM] Ingen weather-entity hittad:", weatherEntity);
+      console.warn("[SILAM] No weather entity found:", weatherEntity);
     return [];
   }
 
@@ -455,7 +455,7 @@ export async function fetchForecast(hass, config, forecastEvent = null) {
       const skipThreshold = autoAddedAllergyRisk && allergen === "allergy_risk";
       if (skipThreshold || meetsThreshold(dict.days, pollen_threshold)) sensors.push(dict);
     } catch (e) {
-      if (debug) console.warn(`[SILAM] Fel vid allergen ${allergen}:`, e);
+      if (debug) console.warn(`[SILAM] Error for allergen ${allergen}:`, e);
     }
   }
 

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1528,8 +1528,8 @@ class PollenPrognosCard extends LitElement {
     }
 
     if (this.debug) {
-      console.debug("[Card][Debug] Aktiv integration:", integration);
-      console.debug("[Card][Debug] Allergens i config:", cfg.allergens);
+      console.debug("[Card][Debug] Active integration:", integration);
+      console.debug("[Card][Debug] Allergens in config:", cfg.allergens);
     }
 
     // Compute header into a local variable, only assign if changed.
@@ -1898,7 +1898,7 @@ class PollenPrognosCard extends LitElement {
       return fetchPromise
         .then((sensors) => {
           if (this.debug) {
-            console.debug("[Card][Debug] Sensors före filtrering:", sensors);
+            console.debug("[Card][Debug] Sensors before filtering:", sensors);
             console.debug(
               `[Card][Debug] Adapter returned ${sensors.length} sensors:`,
               sensors.map((s) => ({
@@ -1918,15 +1918,15 @@ class PollenPrognosCard extends LitElement {
 
           if (this.debug) {
             // console.debug(
-            //   "[Card][Debug] Alla tillgängliga hass.states:",
+            //   "[Card][Debug] All available hass.states:",
             //   Object.keys(hass.states),
             // );
-            console.debug("[Card] Användaren har valt city:", cfg.city);
+            console.debug("[Card] User selected city:", cfg.city);
             console.debug(
-              "[Card] Användaren har valt allergener:",
+              "[Card] User selected allergens:",
               cfg.allergens,
             );
-            console.debug("[Card] Användaren har valt plats:", cfg.location);
+            console.debug("[Card] User selected location:", cfg.location);
           }
 
           const availableSensors = findAvailableSensors(cfg, hass, this.debug);
@@ -1961,7 +1961,7 @@ class PollenPrognosCard extends LitElement {
             this._updateSensorsAndColumns([], [], cfg);
             if (this.debug) {
               console.warn(
-                `[Card] Ingen sensor hittad för explicit vald plats: '${cfg.location}'`,
+                `[Card] No sensor found for explicitly selected location: '${cfg.location}'`,
               );
             }
             return;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -748,7 +748,7 @@ class PollenPrognosCardEditor extends LitElement {
       }
 
       if (this.debug)
-        console.debug("[Editor] färdig _config innan dispatch:", this._config);
+        console.debug("[Editor] Final _config before dispatch:", this._config);
 
       // 18. Hantera tap_action för editorn
       if (this._config.tap_action) {
@@ -1934,7 +1934,7 @@ class PollenPrognosCardEditor extends LitElement {
       label: this._t(`sort_${opt}`),
     }));
     if (this.debug) {
-      console.debug("Aktuellt språk (lang):", this._lang);
+      console.debug("[Editor] Current language (lang):", this._lang);
       console.debug("Sort label test:", this._t("sort_value_ascending"));
     }
 


### PR DESCRIPTION
Fixes #225.

## What's translated

Per the project language convention (CLAUDE.md: docs / comments /
commits in English; user-facing UI via `t()`), the developer
diagnostics across card, editor, and adapters were still Swedish.
They are debug-only (mostly gated by `debug: true`) so no `t()`
localization needed -- just plain English.

Fresh grep before fixing caught two strings the original issue list
missed, plus one commented-out instance.

### Per file

- **src/pollenprognos-card.js** (8 strings, 1 was commented out)
  - "Aktiv integration" -> "Active integration"
  - "Allergens i config" -> "Allergens in config"
  - "Sensors före filtrering" -> "Sensors before filtering"
  - "Alla tillgängliga hass.states" (commented) -> "All available hass.states"
  - "Användaren har valt city" -> "User selected city"
  - "Användaren har valt allergener" -> "User selected allergens" *(not in original list)*
  - "Användaren har valt plats" -> "User selected location"
  - "Ingen sensor hittad för explicit vald plats" -> "No sensor found for explicitly selected location"
- **src/pollenprognos-editor.js** (2 strings)
  - "färdig _config innan dispatch" -> "Final _config before dispatch"
  - "Aktuellt språk (lang)" -> "Current language (lang)" *(also gains `[Editor]` prefix)*
- **src/adapters/pp.js** (1 string)
  - "Fel vid allergen" -> "Error for allergen"
- **src/adapters/peu.js** (1 string)
  - "Fel vid allergen" -> "Error for allergen" *(also gains `[PEU]` prefix; was the only adapter log without one)*
- **src/adapters/silam.js** (2 strings)
  - "Ingen weather-entity hittad" -> "No weather entity found"
  - "Fel vid allergen" -> "Error for allergen"

Five commits, one per file scope.

## Out of scope

- Swedish inline code comments throughout the editor (large surface,
  separate concern; not what #225 asks for).
- `src/index.js:13` HACS card description (user-facing text, would
  need real i18n, not a debug log).
- City names with Swedish diacritics in `src/constants.js` (proper
  nouns, must stay).

## Verification

- `npm test -- --run`: 991 passing.
- Grep guard re-run: no Swedish console strings left in `src/`.
- No hass-test deploy needed (debug-only logs, no user-visible change).