### PR TITLE
Gate summary block presentation and columns behind opt-in (#237 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - `show_summary_plants_in_season` (bool, default `true`, GPL only) — an "In season" row listing the plants currently in pollen season.
   The two GPL qualifier rows read Pollen Levels v2.1.0 data: top types from the summary sensor's category codes, and the in-season plant list from the sibling `plants_in_season_today` entity (resolved by config entry, since pollenlevels splits a location across devices). Both lists are localized to the card's own language, independent of the language the integration fetched in. All existing config keys are unchanged; with the block off the card looks exactly as before.
 
+### Fixed
+- The summary block's "Top types" / "In season" qualifier rows and the separator no longer render unless `show_summary_block` is explicitly enabled. Previously, GPL's default config could show these rows unintentionally because the adapter always attaches `topPollen` / `plantsInSeasonList` to the allergy_risk sensor and `allergy_risk_top` defaults to true. Follow-up to #222 / #237.
+- Standalone summary mode (`show_summary_block` on, `show_summary_row` off) no longer renders empty future day columns inherited from the hidden detail rows. Column count is now derived from the displayed row set instead of the full unfiltered sensor list.
+
 ### Documentation
 - `docs/configuration.md`: documented the five summary-block options in the options table, added a GPL summary-block paragraph and YAML examples, and noted the level-only block support in the SILAM and Atmo sections.
 - `docs/integrations.md`: documented the GPL summary-block design decisions — card-language localization of the top types and config-entry-scoped resolution of the sibling in-season entity.

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -12,6 +12,8 @@ import {
   resolveLocationByKey,
   normalizeManualPrefix,
   selectDisplaySensors,
+  coerceBool,
+  computeDisplayDays,
 } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 import { PLU_ALIAS_MAP } from "./adapters/plu.js";
@@ -571,22 +573,7 @@ class PollenPrognosCard extends LitElement {
         "available sensors",
       );
     }
-    let daysCount = 0;
-    // MSW only exposes same-day measurements upstream; never display
-    // synthetic empty future days for it even if the user set days_to_show > 1.
-    const effectiveDaysToShow =
-      cfg.integration === "msw" ? 1 : cfg.days_to_show;
-    if (cfg.show_empty_days) {
-      daysCount = effectiveDaysToShow;
-    } else {
-      // Use max real days across all sensors (not just the first one)
-      for (const s of filtered) {
-        if (!s.days || !s.days.length) continue;
-        const realDays = s.days.filter((d) => d.state >= 0).length;
-        const count = Math.min(realDays, effectiveDaysToShow);
-        if (count > daysCount) daysCount = count;
-      }
-    }
+    const daysCount = computeDisplayDays(filtered, cfg);
     const expectedDisplayCols = Array.from({ length: daysCount }, (_, i) => i);
 
     // Determine if an update is required. Always update when data has not been loaded yet.
@@ -2428,7 +2415,16 @@ class PollenPrognosCard extends LitElement {
 
     const textSizeRatio = this.config?.text_size_ratio ?? 1;
     const daysBold = Boolean(this.config.days_boldfaced);
-    const cols = this.displayCols;
+    // Compute column count from the displayed row set, not the full sensor list.
+    // When standalone summary mode is active (show_summary_block on,
+    // show_summary_row off), rowSensors contains only the aggregate which has
+    // no future days; using this.displayCols (derived from the full list) would
+    // add empty future columns. When the block is off rowSensors === this.sensors
+    // so the result is identical to the old this.displayCols path.
+    const cols = Array.from(
+      { length: computeDisplayDays(rowSensors, this.config) },
+      (_, i) => i,
+    );
     
     // Number of segments in the level circle depends on the integration.
     // PEU, Kleenex and MSW use four segments (native 5-level scale, 0=None
@@ -2747,6 +2743,7 @@ class PollenPrognosCard extends LitElement {
                 // (issue #222) and not disabled via show_summary_separator
                 // (default on). Reuses the block-separator style.
                 const summarySeparator =
+                  coerceBool(this.config.show_summary_block) &&
                   sIdx > 0 &&
                   rowSensors[sIdx - 1]?.isSummary &&
                   !sensor.isSummary &&
@@ -2781,6 +2778,7 @@ class PollenPrognosCard extends LitElement {
    * of <tr> so the caller can spread into flatMap.
    */
   _renderSummaryExtrasRows(sensor, totalCols, textSizeRatio, showAllergenColumn) {
+    if (!coerceBool(this.config.show_summary_block)) return [];
     const rows = [];
     const valueColspan = showAllergenColumn ? totalCols - 1 : totalCols;
     // Match the regular allergen text rows (same size/colour), not a dimmed

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -64,6 +64,38 @@ export function selectDisplaySensors(sensors, config) {
 }
 
 /**
+ * Compute the number of day columns to render for a given sensor list and
+ * config. Extracted from _updateSensorsAndColumns so that _renderNormalHtml
+ * can recompute columns from the *displayed* row set rather than the full
+ * unfiltered sensor list -- needed for standalone summary mode where
+ * selectDisplaySensors returns only the aggregate (which has no future days)
+ * while the detail sensors it hides may have several.
+ *
+ * Reproduces the logic in _updateSensorsAndColumns exactly:
+ *   - MSW is always clamped to 1 day regardless of days_to_show.
+ *   - show_empty_days skips the sensor scan and returns the configured count.
+ *   - Otherwise: max over sensors of min(realDays, effectiveDaysToShow),
+ *     where realDays = days with state >= 0; sensors without a days array are
+ *     skipped.
+ *
+ * @param {object[]} sensors - Sensor array to derive column count from.
+ * @param {object}   cfg     - Card config object.
+ * @returns {number}
+ */
+export function computeDisplayDays(sensors, cfg) {
+  const effectiveDaysToShow = cfg.integration === "msw" ? 1 : cfg.days_to_show;
+  if (cfg.show_empty_days) return effectiveDaysToShow;
+  let daysCount = 0;
+  for (const s of sensors) {
+    if (!s.days || !s.days.length) continue;
+    const realDays = s.days.filter((d) => d.state >= 0).length;
+    const count = Math.min(realDays, effectiveDaysToShow);
+    if (count > daysCount) daysCount = count;
+  }
+  return daysCount;
+}
+
+/**
  * Clamp a sensor value to a valid level range.
  *
  * @param {*}      v         - Raw sensor value (will be coerced via Number()).

--- a/test/utils/compute-display-days.test.js
+++ b/test/utils/compute-display-days.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { computeDisplayDays } from "../../src/utils/adapter-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a sensor with N valid days (state >= 0) followed by M invalid ones. */
+function makeSensor(validDays, invalidDays = 0) {
+  const days = [];
+  for (let i = 0; i < validDays; i++) days.push({ state: i }); // state 0..N-1, all >= 0
+  for (let i = 0; i < invalidDays; i++) days.push({ state: -1 });
+  return { days };
+}
+
+/** Sensor with a days array where all entries have state >= 0. */
+const sensor3 = makeSensor(3);
+const sensor5 = makeSensor(5);
+const sensor1 = makeSensor(1);
+
+/** Aggregate-only sensor: exactly one day with valid state. */
+const aggregateOnly = makeSensor(1);
+
+// ---------------------------------------------------------------------------
+// show_empty_days: true
+// ---------------------------------------------------------------------------
+
+describe("computeDisplayDays: show_empty_days", () => {
+  it("returns days_to_show directly when show_empty_days is truthy", () => {
+    const cfg = { days_to_show: 5, show_empty_days: true };
+    expect(computeDisplayDays([sensor3], cfg)).toBe(5);
+  });
+
+  it("returns days_to_show even if sensors have fewer real days", () => {
+    const cfg = { days_to_show: 7, show_empty_days: true };
+    expect(computeDisplayDays([sensor1], cfg)).toBe(7);
+  });
+
+  it("ignores sensor data entirely when show_empty_days is set", () => {
+    const cfg = { days_to_show: 3, show_empty_days: true };
+    // No sensors at all — should still return days_to_show
+    expect(computeDisplayDays([], cfg)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MSW integration clamps to 1
+// ---------------------------------------------------------------------------
+
+describe("computeDisplayDays: MSW integration", () => {
+  it("clamps to 1 regardless of days_to_show", () => {
+    const cfg = { integration: "msw", days_to_show: 5 };
+    expect(computeDisplayDays([sensor5], cfg)).toBe(1);
+  });
+
+  it("clamps to 1 even when days_to_show is 1 explicitly", () => {
+    const cfg = { integration: "msw", days_to_show: 1 };
+    expect(computeDisplayDays([sensor3], cfg)).toBe(1);
+  });
+
+  it("clamps to 1 for msw with show_empty_days false and a multi-day sensor", () => {
+    const cfg = { integration: "msw", days_to_show: 5, show_empty_days: false };
+    expect(computeDisplayDays([sensor5], cfg)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standalone aggregate scenario (the fix motivation)
+// ---------------------------------------------------------------------------
+
+describe("computeDisplayDays: standalone aggregate scenario", () => {
+  // An allergy_risk summary sensor has only today's data (one day with
+  // state >= 0). The detail sensors it accompanies have multiple days.
+  // When the card passes only the aggregate to computeDisplayDays (standalone
+  // summary block mode), it should return 1. When both are passed it should
+  // return the larger count from the detail sensors.
+
+  const aggregateSensor = makeSensor(1); // today only
+  const detailA = makeSensor(4);
+  const detailB = makeSensor(3);
+
+  it("returns 1 when only the aggregate sensor is present", () => {
+    const cfg = { days_to_show: 5 };
+    expect(computeDisplayDays([aggregateSensor], cfg)).toBe(1);
+  });
+
+  it("returns the detail sensor count when aggregate and details are present", () => {
+    const cfg = { days_to_show: 5 };
+    expect(computeDisplayDays([aggregateSensor, detailA, detailB], cfg)).toBe(4);
+  });
+
+  it("proves columns shrink to 1 in standalone mode vs full mode", () => {
+    const cfg = { days_to_show: 5 };
+    const standaloneCount = computeDisplayDays([aggregateSensor], cfg);
+    const fullCount = computeDisplayDays([aggregateSensor, detailA, detailB], cfg);
+    expect(standaloneCount).toBe(1);
+    expect(fullCount).toBeGreaterThan(standaloneCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sensors without a days array are skipped
+// ---------------------------------------------------------------------------
+
+describe("computeDisplayDays: sensors without days array", () => {
+  it("returns 0 for empty sensor list", () => {
+    expect(computeDisplayDays([], { days_to_show: 5 })).toBe(0);
+  });
+
+  it("skips sensors that have no days property", () => {
+    const noDays = { allergenReplaced: "birch" }; // no .days
+    expect(computeDisplayDays([noDays], { days_to_show: 5 })).toBe(0);
+  });
+
+  it("skips sensors with empty days array", () => {
+    const emptyDays = { days: [] };
+    expect(computeDisplayDays([emptyDays], { days_to_show: 5 })).toBe(0);
+  });
+
+  it("counts only sensors that have a days array, ignoring those that do not", () => {
+    const noDays = { allergenReplaced: "birch" };
+    const cfg = { days_to_show: 5 };
+    expect(computeDisplayDays([noDays, sensor3], cfg)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// min(realDays, days_to_show) clamping
+// ---------------------------------------------------------------------------
+
+describe("computeDisplayDays: clamping to days_to_show", () => {
+  it("caps sensor with more real days than days_to_show", () => {
+    const cfg = { days_to_show: 3 };
+    // sensor5 has 5 real days; should be capped to 3
+    expect(computeDisplayDays([sensor5], cfg)).toBe(3);
+  });
+
+  it("returns the actual count when real days is less than days_to_show", () => {
+    const cfg = { days_to_show: 7 };
+    expect(computeDisplayDays([sensor3], cfg)).toBe(3);
+  });
+
+  it("takes the max across multiple sensors", () => {
+    const cfg = { days_to_show: 5 };
+    // sensor1 = 1 day, sensor3 = 3 days; max(1,3) = 3
+    expect(computeDisplayDays([sensor1, sensor3], cfg)).toBe(3);
+  });
+
+  it("days with state < 0 do not count toward realDays", () => {
+    // 2 valid + 3 invalid; realDays = 2
+    const mixed = makeSensor(2, 3);
+    const cfg = { days_to_show: 5 };
+    expect(computeDisplayDays([mixed], cfg)).toBe(2);
+  });
+
+  it("a sensor with all invalid days contributes 0", () => {
+    const allInvalid = makeSensor(0, 4);
+    const cfg = { days_to_show: 5 };
+    expect(computeDisplayDays([allInvalid], cfg)).toBe(0);
+  });
+
+  it("returns days_to_show when all sensors have more real days than configured", () => {
+    const cfg = { days_to_show: 2 };
+    expect(computeDisplayDays([sensor3, sensor5], cfg)).toBe(2);
+  });
+});


### PR DESCRIPTION
Follow-up to #237 (summary block for aggregate pollen risk, #222), addressing two Codex P2 findings posted after that PR merged. The feature is still unreleased, so these are pre-release bugfixes; both target 3.3.0.

## Findings addressed

**1. Summary extras / separator rendered without opt-in.** GPL always tags `allergy_risk` as `isSummary` and attaches `topPollen` / `plantsInSeasonList`, and `allergy_risk_top` defaults `true` so the aggregate is pinned first even with the summary block off. The render gated the "Top types" / "In season" rows only on their per-toggles (default `true`) and the separator only on `show_summary_separator` (default `true`) — never on the master `show_summary_block`. So default GPL config surfaced these without the user enabling the block. Both the qualifier rows and the separator `<hr>` are now gated on `show_summary_block` (via `coerceBool`).

**2. Empty future columns in standalone summary mode.** With `show_summary_block: true, show_summary_row: false`, `selectDisplaySensors` returns only the aggregate, but the table used `this.displayCols`, computed from the full unfiltered sensor list. When hidden detail rows had future forecast days but the aggregate is today-only (GPL/Atmo/SILAM), extra empty day headers rendered. Column count is now computed from the displayed row set (`rowSensors`) via a new pure `computeDisplayDays` helper extracted from `_updateSensorsAndColumns`. With the block off `rowSensors === this.sensors`, so default behavior is unchanged.

The adapter `isSummary` tagging is intentionally left unchanged — only the card-side presentation is gated.

## Tests
- New `test/utils/compute-display-days.test.js` (19 cases): `show_empty_days`, msw clamp-to-1, the standalone shrink scenario, sensors without a `days` array, and `min(realDays, days_to_show)` clamping.
- Existing GPL adapter tagging assertions unchanged and passing.
- Full suite: 1071 tests green.