### PR TITLE
(docs) Document badge, icon-in-ring, and no-data rendering for 3.3.0-beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Install one of the supported integrations above. The card auto-detects which ada
 - **Auto-Detection**: Automatically detects which integration to use based on your available sensors
 - **Visual Editor**: Full Home Assistant UI configuration support - no manual YAML editing required
 - **Scalable SVG Icons**: 24+ allergen icons rendered as lightweight, customizable SVG graphics
-- **Multiple Display Modes**: Support for minimal, daily, hourly, and twice-daily forecast layouts
+- **Multiple Display Modes**: Support for minimal, daily, hourly, and twice-daily forecast layouts; icon-in-ring layout places the allergen symbol inside the level ring
+- **Badge Element**: Companion `pollenprognos-badge` shows the current pollen level as a compact HA dashboard badge, ships in the same bundle, no extra install needed
 - **Full Localization**: Dynamic language support with 15 translations following Home Assistant's language setting
 - **Extensive Customization**: Configure colors, layouts, text size, sorting, and display options through the visual editor
 - **HACS Integration**: Official HACS repository with automatic updates and easy installation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,13 +362,13 @@ Multi-station configuration: set `location` to either the `config_entry_id` (Cro
 
 Badges are added to a dashboard view's `badges:` list (not `cards:`), either through the badge picker UI or via YAML.
 
-The badge is today-only: it always forces `mode: daily` regardless of your integration. It reuses the card's integration/location keys (`integration`, `city`, `region_id`, `location`, `entity_prefix`, `entity_suffix`, `entity_weather`, `allergens`) and all visual keys (`levels_*`, `allergen_*`, `icon_in_ring*`, `link_to_sensors`). Card-layout keys such as `title`, `minimal`, `days_to_show`, and multi-day options are not applicable to the badge.
+The badge is today-only: it always forces `mode: daily` regardless of your integration. It reuses the card's integration/location keys (`integration`, `city`, `region_id`, `location`, `entity_prefix`, `entity_suffix`, `entity_weather`, `allergens`) and the card's visual keys (`levels_*`, `allergen_*`, `icon_in_ring*`, `show_no_data_distinct`, `link_to_sensors`). Card-layout keys such as `title`, `minimal`, `days_to_show`, and multi-day options are not applicable to the badge.
 
 ### Badge options
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `badge_content` | `string` | `worst` | What the badge shows: `worst` (allergen with the highest current level), `aggregate` (integration's overall-risk sensor, available for GPL and Atmo out of the box; for SILAM add the index, `index`, to `allergens` first; falls back to `worst` everywhere else), `single` (one allergen set via `badge_single_allergen`), `row` (several allergens side by side). |
+| `badge_content` | `string` | `worst` | What the badge shows: `worst` (allergen with the highest current level), `aggregate` (integration's overall-risk sensor, available for GPL and Atmo out of the box; for SILAM add the index, `index`, to `allergens` and set `pollen_threshold: 0` so a low index is not filtered out; falls back to `worst` everywhere else), `single` (one allergen set via `badge_single_allergen`), `row` (several allergens side by side). |
 | `badge_single_allergen` | `string` | *(empty)* | The allergen key to show when `badge_content` is `single`. Must be a valid key for your integration (see [Valid allergen keys](#valid-allergen-keys)). |
 | `badge_visual` | `string` | `icon_in_ring` | Visual style: `icon_in_ring` (allergen icon inside the level ring), `ring_value` (numeric level centred in the ring), `ring_empty` (ring only), `icon_only` (bare allergen symbol, no ring). |
 | `badge_scale` | `number` | `1` | Scales the entire badge (height, padding, gap, label and ring together), based on Home Assistant's native badge size (`--ha-badge-size`, 36 px). `1` renders a standard-size HA badge. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ In this file:
   - [Google Pollen Levels (GPL)](#google-pollen-levels-gpl)
   - [Google Pollen (GP)](#google-pollen-gp)
   - [MeteoSwiss / hass-swissweather (MSW)](#meteoswiss--hass-swissweather-msw)
+- [Badge](#badge)
 - [Color System Overview](#color-system-overview)
   - [Allergen Icon Colors](#allergen-icon-colors)
   - [Level Circle Colors](#level-circle-colors)
@@ -62,6 +63,10 @@ In this file:
 | `allergen_stroke_width` | `integer` | `15` | Width of SVG icon outlines (0-100, step 5). Higher values create thicker outlines around allergen icons. When `levels_inherit_mode` is `inherit_allergen` and `allergen_levels_gap_synced` is `true` (default), this also controls level circle gap width via automatic synchronization. |
 | `allergen_stroke_color_synced` | `boolean` | `true` | When enabled, the stroke (outline) color of allergen icons matches the allergen level color instead of using `allergen_outline_color`. This provides better visual consistency by making both the fill and outline colors reflect the pollen severity level. |
 | `allergen_levels_gap_synced` | `boolean` | `true` | When enabled and `levels_inherit_mode` is `inherit_allergen`, the level circle gap width automatically syncs with `allergen_stroke_width` using the formula `levelGap = Math.round(strokeWidth / 30)`. Set to `false` to independently control the gap width without switching all level colors to custom mode. |
+| `icon_in_ring` | `boolean` | `false` | Place the allergen icon inside the level ring instead of above it. When enabled, the editor auto-thins `levels_thickness` from 60 to 35 to give the icon room (restored when disabled, unless you had set a custom thickness). For the `allergy_risk` allergen the level-reactive smiley icon variant is used automatically. |
+| `icon_in_ring_size_ratio` | `number` | `0.75` | Icon size as a fraction of the ring's inner hole. Only used when `icon_in_ring` is `true`. |
+| `icon_in_ring_color_mode` | `string` | `static` | Color mode for the icon inside the ring: `static` uses a fixed color, `follow_level` tints the icon to match the current pollen level. Only used when `icon_in_ring` is `true`. |
+| `icon_in_ring_static_color` | `string` | `var(--primary-text-color)` | Color for the icon when `icon_in_ring_color_mode` is `static`. Only used when `icon_in_ring` is `true`. |
 | `no_allergens_color` | `string` | `#a9cfe0` | Color for the "no allergens" icon displayed when no pollen data is available. This color is independent of the allergen level color system and can be customized separately. |
 | `text_size_ratio` | `number` | `1` | Global text scaling factor. |
 | `allergens` | `array<string>` | *(integration default)* | List of pollen types to show. |
@@ -350,6 +355,51 @@ birch, grass, alder, hazel, beech, ash, oak
 Categorical levels reported by the integration map to a native 5-level scale (0--4): `None` -> 0, `Low` -> 1, `Medium` -> 2, `Strong` -> 3, `Very Strong` -> 4. The card keeps each integration's native level count rather than stretching onto a shared 0--6 gradient; level circles render with five segments (None empty, Very Strong full) and severity strings come from the `card.levels5.0..4` i18n keys.
 
 Multi-station configuration: set `location` to either the `config_entry_id` (Crockford-base32 ULID, the visual editor's default), the device label (`name_by_user` or `name`, e.g. `Bern`), or the station code (e.g. `8000`). Leaving `location` empty selects the first discovered station. Stale `config_entry_id` values (e.g. after an integration reinstall) auto-recover to the first discovered station, mirroring DWD/GPL/GP/SILAM/Atmo behavior.
+
+## Badge
+
+`pollenprognos-badge` is a separate custom element that appears in Home Assistant's **badge picker** as "Pollenprognos Badge". It ships in the same JS bundle as the card, so no extra installation is needed.
+
+Badges are added to a dashboard view's `badges:` list (not `cards:`), either through the badge picker UI or via YAML.
+
+The badge is today-only: it always forces `mode: daily` regardless of your integration. It reuses the card's integration/location keys (`integration`, `city`, `region_id`, `location`, `entity_prefix`, `entity_suffix`, `entity_weather`, `allergens`) and all visual keys (`levels_*`, `allergen_*`, `icon_in_ring*`, `link_to_sensors`). Card-layout keys such as `title`, `minimal`, `days_to_show`, and multi-day options are not applicable to the badge.
+
+### Badge options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `badge_content` | `string` | `worst` | What the badge shows: `worst` (allergen with the highest current level), `aggregate` (integration's overall-risk sensor, available for GPL/SILAM/Atmo; falls back to `worst` elsewhere), `single` (one allergen set via `badge_single_allergen`), `row` (several allergens side by side). |
+| `badge_single_allergen` | `string` | *(empty)* | The allergen key to show when `badge_content` is `single`. Must be a valid key for your integration (see [Valid allergen keys](#valid-allergen-keys)). |
+| `badge_visual` | `string` | `icon_in_ring` | Visual style: `icon_in_ring` (allergen icon inside the level ring), `ring_value` (numeric level centred in the ring), `ring_empty` (ring only), `icon_only` (bare allergen symbol, no ring). |
+| `badge_scale` | `number` | `1` | Scales the entire badge (height, padding, gap, label and ring together), based on Home Assistant's native badge size (`--ha-badge-size`, 36 px). `1` renders a standard-size HA badge. |
+| `badge_label_position` | `string` | `right` | Where to place the label: `right` (beside the visual, the HA community convention) or `below` (under the visual). |
+| `badge_show_label` | `boolean` | `false` | Show the allergen short name or label next to the visual. |
+
+### Badge YAML examples
+
+**Pollenprognos: highest current allergen (icon in ring):**
+
+```yaml
+badges:
+  - type: custom:pollenprognos-badge
+    integration: pp
+    city: Stockholm
+    badge_content: worst
+    badge_visual: icon_in_ring
+```
+
+**Google Pollen Levels: overall risk:**
+
+```yaml
+badges:
+  - type: custom:pollenprognos-badge
+    integration: gpl
+    badge_content: aggregate
+    badge_visual: icon_in_ring
+    badge_show_label: true
+```
+
+`badge_content: aggregate` falls back to `worst` for integrations that do not expose an overall-risk sensor.
 
 ## Color System Overview
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,7 +368,7 @@ The badge is today-only: it always forces `mode: daily` regardless of your integ
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `badge_content` | `string` | `worst` | What the badge shows: `worst` (allergen with the highest current level), `aggregate` (integration's overall-risk sensor, available for GPL/SILAM/Atmo; falls back to `worst` elsewhere), `single` (one allergen set via `badge_single_allergen`), `row` (several allergens side by side). |
+| `badge_content` | `string` | `worst` | What the badge shows: `worst` (allergen with the highest current level), `aggregate` (integration's overall-risk sensor, available for GPL and Atmo out of the box; for SILAM add the index, `index`, to `allergens` first; falls back to `worst` everywhere else), `single` (one allergen set via `badge_single_allergen`), `row` (several allergens side by side). |
 | `badge_single_allergen` | `string` | *(empty)* | The allergen key to show when `badge_content` is `single`. Must be a valid key for your integration (see [Valid allergen keys](#valid-allergen-keys)). |
 | `badge_visual` | `string` | `icon_in_ring` | Visual style: `icon_in_ring` (allergen icon inside the level ring), `ring_value` (numeric level centred in the ring), `ring_empty` (ring only), `icon_only` (bare allergen symbol, no ring). |
 | `badge_scale` | `number` | `1` | Scales the entire badge (height, padding, gap, label and ring together), based on Home Assistant's native badge size (`--ha-badge-size`, 36 px). `1` renders a standard-size HA badge. |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,6 +154,35 @@ The card-side adapter was contributed by [@r3turnNull](https://github.com/r3turn
    - Resource type: JavaScript Module
 4. Reload your browser cache
 
+## Using the badge
+
+The card bundle also includes `pollenprognos-badge`, a compact badge element that shows the current pollen level directly in your dashboard's badge area. Because it ships in the same JS file as the card, no extra installation step is needed.
+
+**Add via the badge picker (recommended):**
+
+1. Open your dashboard and click **Edit Dashboard**
+2. Click **Add Badge** (or the badge area at the top of a view)
+3. Search for "Pollenprognos Badge" and select it
+4. Configure the badge in the visual editor (integration, location, allergen, visual style, scale, etc.)
+5. Click **Save**
+
+**Add via YAML:**
+
+Badges live in the `badges:` list of a view, not under `cards:`:
+
+```yaml
+badges:
+  - type: custom:pollenprognos-badge
+    integration: pp
+    city: Stockholm
+    badge_content: worst
+    badge_visual: icon_in_ring
+```
+
+See [configuration.md](configuration.md#badge) for all badge options.
+
+> **Badge not appearing in the picker?** This is usually a stale browser cache. See [troubleshooting.md](troubleshooting.md#badge-not-appearing-in-the-badge-picker) for steps.
+
 ## Step 3: Verify Installation
 
 1. Check that your pollen integration is creating sensors:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -163,7 +163,7 @@ The card bundle also includes `pollenprognos-badge`, a compact badge element tha
 1. Open your dashboard and click **Edit Dashboard**
 2. Click **Add Badge** (or the badge area at the top of a view)
 3. Search for "Pollenprognos Badge" and select it
-4. Configure the badge in the visual editor (integration, location, allergen, visual style, scale, etc.)
+4. Configure the badge in the visual editor (integration, location, content mode, visual style, scale, etc.; an allergen selector only appears for the `single` content mode)
 5. Click **Save**
 
 **Add via YAML:**

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,7 +32,7 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 
 The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location (`city`, `region_id`, or `location` depending on the integration), and `allergens` keys as the card.
 
-`badge_content: aggregate` uses the integration's overall-risk sensor. This sensor is available for **GPL** (`allergy_risk`), **SILAM** (`index`), and **Atmo** (`allergy_risk`/`qualite_globale`). For all other integrations the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
+`badge_content: aggregate` uses the integration's overall-risk sensor (the one the card tags as the summary). This is available out of the box for **GPL** (`allergy_risk`) and **Atmo** (`allergy_risk`, the pollen aggregate; Atmo's `qualite_globale` is air quality and is not used as the aggregate). For **SILAM** the aggregate is the index (`allergy_risk`), but SILAM does not enable it by default, so add `index` to the badge's `allergens` for `aggregate` to work. For all other integrations, and for SILAM without the index, the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
 
 ## Google Pollen Levels — design decisions
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,7 +32,7 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 
 The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location (`city`, `region_id`, or `location` depending on the integration), and `allergens` keys as the card.
 
-`badge_content: aggregate` uses the integration's overall-risk sensor (the one the card tags as the summary). This is available out of the box for **GPL** (`allergy_risk`) and **Atmo** (`allergy_risk`, the pollen aggregate; Atmo's `qualite_globale` is air quality and is not used as the aggregate). For **SILAM** the aggregate is the index (`allergy_risk`), but SILAM does not enable it by default, so add `index` to the badge's `allergens` for `aggregate` to work. For all other integrations, and for SILAM without the index, the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
+`badge_content: aggregate` uses the integration's overall-risk sensor (the one the card tags as the summary). This is available out of the box for **GPL** (`allergy_risk`) and **Atmo** (`allergy_risk`, the pollen aggregate; Atmo's `qualite_globale` is air quality and is not used as the aggregate). For **SILAM** the aggregate is the index, but SILAM does not enable it by default, so add `index` to the badge's `allergens` for `aggregate` to work. For all other integrations, and for SILAM without the index, the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
 
 ## Google Pollen Levels — design decisions
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -30,7 +30,7 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 
 ## Badge compatibility
 
-The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location, and `allergens` keys as the card.
+The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location (`city`, `region_id`, or `location` depending on the integration), and `allergens` keys as the card.
 
 `badge_content: aggregate` uses the integration's overall-risk sensor. This sensor is available for **GPL** (`allergy_risk`), **SILAM** (`index`), and **Atmo** (`allergy_risk`/`qualite_globale`). For all other integrations the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,7 +32,7 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 
 The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location (`city`, `region_id`, or `location` depending on the integration), and `allergens` keys as the card.
 
-`badge_content: aggregate` uses the integration's overall-risk sensor (the one the card tags as the summary). This is available out of the box for **GPL** (`allergy_risk`) and **Atmo** (`allergy_risk`, the pollen aggregate; Atmo's `qualite_globale` is air quality and is not used as the aggregate). For **SILAM** the aggregate is the index, but SILAM does not enable it by default, so add `index` to the badge's `allergens` for `aggregate` to work. For all other integrations, and for SILAM without the index, the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
+`badge_content: aggregate` uses the integration's overall-risk sensor (the one the card tags as the summary). This is available out of the box for **GPL** (`allergy_risk`) and **Atmo** (`allergy_risk`, the pollen aggregate; Atmo's `qualite_globale` is air quality and is not used as the aggregate). For **SILAM** the aggregate is the index, but SILAM does not enable it by default, so add `index` to the badge's `allergens`. SILAM also drops the index on low-pollen days under the default `pollen_threshold: 1` (level 0 is filtered out), so set `pollen_threshold: 0` on the badge to keep it visible when low. For all other integrations, and for SILAM without the index, the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
 
 ## Google Pollen Levels — design decisions
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -28,6 +28,12 @@ The card tries to auto-detect which adapter to use based on your sensors. The ta
 | **Google Pollen** | For `home-assistant-google-pollen` by svenove. Uses the same Google Pollen API but a different HA integration. Sensors are detected by the `google_pollen` platform or entity prefix `sensor.google_pollen_*`. Allergens are classified primarily via `unique_id` (language-independent) with `display_name` lookup as fallback, covering all 35 languages the API supports via pre-generated name maps. The API returns up to 4 days of forecast. Supports multi-location setups via separate config entries. Added in card **v3.1.0**. |
 | **MeteoSwiss / hass-swissweather** | For [`hass-swissweather`](https://github.com/izacus/hass-swissweather) by [@izacus](https://github.com/izacus). Adapter contributed by [@r3turnNull](https://github.com/r3turnNull) (#212). Sensors are detected by the `swissweather` platform; entity IDs follow `sensor.<device-slug>_pollen_<allergen>_level_at_<station>` (the device-slug prefix is added by HA from the device name and changes if you rename the device via `name_by_user`). MeteoSwiss publishes only current-day measurements, so `days_to_show` is fixed at 1 by the card regardless of config. Categorical levels (`None` / `Low` / `Medium` / `Strong` / `Very Strong`) are mapped to the integration's native 5-level scale (0--4), matching how the card keeps each integration's native level count without stretching onto the shared 0--6 gradient. Allergens supported: birch, grass, alder, hazel, beech, ash, oak. Multi-station setups: pick the station via the `location` field (accepts `config_entry_id` ULID, label, or station code). Added in card **v3.2.0**. |
 
+## Badge compatibility
+
+The `pollenprognos-badge` element works with all integrations listed above. Configure it with the same `integration`, location, and `allergens` keys as the card.
+
+`badge_content: aggregate` uses the integration's overall-risk sensor. This sensor is available for **GPL** (`allergy_risk`), **SILAM** (`index`), and **Atmo** (`allergy_risk`/`qualite_globale`). For all other integrations the badge automatically falls back to `badge_content: worst` (the allergen with the highest current level).
+
 ## Google Pollen Levels — design decisions
 
 The Google Pollen Levels (GPL) adapter uses a different detection strategy than the other adapters. This section explains the design choices and how sensor discovery works.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -44,6 +44,29 @@ For adapters with a different native level count, the card uses scale-specific k
 
 When adding a new locale, translate these scale-specific keys too. For the five-level scale, the conventional mapping is to reuse each language's existing `card.levels.{0,1,3,5,6}` strings (so the scale-5 entries read "None / Low / Moderate / High / Very High" or the locale's equivalents).
 
+## Badge editor keys
+
+The badge visual editor uses the following i18n keys. Translators should add these to every locale file; `src/locales/en.json` is the canonical reference.
+
+| Key | English value |
+|-----|---------------|
+| `editor.summary_badge_content` | `Badge content` |
+| `editor.helper_badge_content` | `What the badge shows.` |
+| `editor.badge_content_worst` | `Highest pollen level` |
+| `editor.badge_content_aggregate` | `Overall risk` |
+| `editor.badge_content_single` | `Single allergen` |
+| `editor.badge_content_row` | `Several (row)` |
+| `editor.badge_single_allergen` | `Allergen` |
+| `editor.badge_visual_icon_in_ring` | `Icon in ring` |
+| `editor.badge_visual_ring_value` | `Ring with value` |
+| `editor.badge_visual_ring_empty` | `Empty ring` |
+| `editor.badge_visual_icon_only` | `Icon only` |
+| `editor.badge_scale` | `Badge size (scale)` |
+| `editor.badge_label_position` | `Label position` |
+| `editor.badge_label_position_right` | `Right` |
+| `editor.badge_label_position_below` | `Below` |
+| `editor.badge_show_label` | `Show label` |
+
 ## Custom phrases
 
 In minimal mode some allergens may be shortened in a way you do not like. You can override text strings with the `phrases` options. Only include the keys you want to customise:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -90,6 +90,30 @@ integration: msw
 # location auto-detected; set config_entry_id, label or station code for multi-station setups
 ```
 
+## Adding a Badge
+
+The card bundle also ships a companion badge element. Badges appear in the top strip of a dashboard view and give you a compact, at-a-glance pollen indicator.
+
+**Via the badge picker:**
+
+1. Edit your dashboard and click **Add Badge**
+2. Search for "Pollenprognos Badge" and select it
+3. Configure integration, location, and allergen in the visual editor
+4. Click **Save**
+
+**Via YAML** (add to the `badges:` list of a view, not `cards:`):
+
+```yaml
+badges:
+  - type: custom:pollenprognos-badge
+    integration: pp
+    city: Stockholm
+    badge_content: worst
+    badge_visual: icon_in_ring
+```
+
+See [configuration.md](configuration.md#badge) for all badge options and [installation.md](installation.md#using-the-badge) for more detail.
+
 ## Common Customizations
 
 ### Minimal Layout
@@ -132,6 +156,19 @@ levels_colors:
   - "#FF001C"
 background_color: "var(--card-background-color)"
 ```
+
+### Icon Inside the Ring
+
+Display the allergen icon inside the level ring instead of above it:
+
+```yaml
+type: custom:pollenprognos-card
+city: Stockholm
+icon_in_ring: true
+icon_in_ring_color_mode: follow_level
+```
+
+The editor automatically adjusts `levels_thickness` to give the icon room. See [configuration.md](configuration.md#options) for `icon_in_ring_size_ratio` and `icon_in_ring_static_color`.
 
 ### More Days
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -98,7 +98,7 @@ The card bundle also ships a companion badge element. Badges appear in the top s
 
 1. Edit your dashboard and click **Add Badge**
 2. Search for "Pollenprognos Badge" and select it
-3. Configure integration, location, and allergen in the visual editor
+3. Configure integration, location, and content mode in the visual editor (a specific allergen is only selected in the `single` content mode)
 4. Click **Save**
 
 **Via YAML** (add to the `badges:` list of a view, not `cards:`):

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -59,7 +59,8 @@ A custom card for the DWD Pollenflug integration.
 - **Dynamic localization** in 15 languages that automatically follows Home Assistant's language setting
 - **Auto-detection** of available integrations and sensors
 - **HACS official repository** status with automatic updates
-- **Multiple display modes** including minimal, daily, hourly, and twice-daily forecast layouts
+- **Multiple display modes** including minimal, daily, hourly, and twice-daily forecast layouts; icon-in-ring places the allergen symbol inside the level ring
+- **Companion badge element** (`pollenprognos-badge`) that shows the current pollen level as a compact HA dashboard badge, included in the same bundle
 
 These features make it a comprehensive solution for pollen forecast display that works seamlessly across different data sources and regions.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -291,11 +291,11 @@ The badge picker lists `pollenprognos-badge` only after the browser has loaded t
 
 If the badge appears but shows nothing (no icon, no ring content):
 
-1. **Verify integration and location.** The badge uses the same sensor detection as the card. If a card with the same `integration`/`city`/`location` config finds sensors, the badge will too. Test with the matching card config first.
+1. **Verify integration and location.** The badge uses the same sensor detection as the card. If a card with the same `integration` and location fields (`city`, `region_id`, or `location`, depending on the integration) finds sensors, the badge will too. Test with the matching card config first.
 
 2. **Check `badge_content: single`.** When using single-allergen mode, `badge_single_allergen` must be set to a valid key for your integration. Check [configuration.md](configuration.md#valid-allergen-keys) for the correct keys.
 
-3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, available out of the box for GPL and Atmo. SILAM also has one (the index, key `allergy_risk`), but it is not in SILAM's default allergens, so add `index` to the badge's `allergens` for `aggregate` to work there. For every other case it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
+3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, available out of the box for GPL and Atmo. SILAM also has one (the index), but it is not in SILAM's default allergens, so add `index` to the badge's `allergens` for `aggregate` to work there. For every other case it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
 
 4. **Enable debug mode** on a card with the same config and check the browser console for detection messages (see [Debug console output](#6-debug-console-output-helpful-for-detection-issues)).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,6 +277,8 @@ Check Settings > System > Logs for errors from your pollen integration. Search f
 
 ---
 
+## Badge troubleshooting
+
 ### Badge not appearing in the badge picker
 
 The badge picker lists `pollenprognos-badge` only after the browser has loaded the current JS bundle. If it is missing after installation, the most likely cause is a stale browser cache (the same root cause as the card not loading).
@@ -295,7 +297,7 @@ If the badge appears but shows nothing (no icon, no ring content):
 
 2. **Check `badge_content: single`.** When using single-allergen mode, `badge_single_allergen` must be set to a valid key for your integration. Check [configuration.md](configuration.md#valid-allergen-keys) for the correct keys.
 
-3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, available out of the box for GPL and Atmo. SILAM also has one (the index), but it is not in SILAM's default allergens, so add `index` to the badge's `allergens` for `aggregate` to work there. For every other case it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
+3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, available out of the box for GPL and Atmo. SILAM also has one (the index), but it is not in SILAM's default allergens, so add `index` to the badge's `allergens`. On a low-pollen day the index sits at level 0, which the default `pollen_threshold: 1` filters out, so also set `pollen_threshold: 0` on the badge to keep the index visible when it is low. For every other case it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
 
 4. **Enable debug mode** on a card with the same config and check the browser console for detection messages (see [Debug console output](#6-debug-console-output-helpful-for-detection-issues)).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -279,7 +279,7 @@ Check Settings > System > Logs for errors from your pollen integration. Search f
 
 ### Badge not appearing in the badge picker
 
-The badge picker lists `pollenprognos-badge` only after the browser has loaded the current JS bundle. If it is missing after installation, the most likely cause is a stale browser cache (the same root cause as the card not loading). root cause as the card not loading.
+The badge picker lists `pollenprognos-badge` only after the browser has loaded the current JS bundle. If it is missing after installation, the most likely cause is a stale browser cache (the same root cause as the card not loading).
 
 **How to fix:**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -277,6 +277,30 @@ Check Settings > System > Logs for errors from your pollen integration. Search f
 
 ---
 
+### Badge not appearing in the badge picker
+
+The badge picker lists `pollenprognos-badge` only after the browser has loaded the current JS bundle. If it is missing after installation, the most likely cause is a stale browser cache (the same root cause as the card not loading). root cause as the card not loading.
+
+**How to fix:**
+
+1. Force-reload the page (Ctrl+Shift+R / Cmd+Shift+R); this is enough in most cases
+2. If the badge still does not appear, follow the full cache-clearing steps in [Cache and version problems](#cache-and-version-problems)
+3. Restarting Home Assistant (Settings > System > Restart) after a new HACS install ensures the resource is registered before the browser tries to use it
+
+### Badge renders empty
+
+If the badge appears but shows nothing (no icon, no ring content):
+
+1. **Verify integration and location.** The badge uses the same sensor detection as the card. If a card with the same `integration`/`city`/`location` config finds sensors, the badge will too. Test with the matching card config first.
+
+2. **Check `badge_content: single`.** When using single-allergen mode, `badge_single_allergen` must be set to a valid key for your integration. Check [configuration.md](configuration.md#valid-allergen-keys) for the correct keys.
+
+3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, which is only available for GPL, SILAM, and Atmo. For all other integrations it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
+
+4. **Enable debug mode** on a card with the same config and check the browser console for detection messages (see [Debug console output](#6-debug-console-output-helpful-for-detection-issues)).
+
+---
+
 ## Is it a card issue or an integration issue?
 
 Many reported issues turn out to be problems with the underlying integration, not the card itself. Here is how to tell:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -295,7 +295,7 @@ If the badge appears but shows nothing (no icon, no ring content):
 
 2. **Check `badge_content: single`.** When using single-allergen mode, `badge_single_allergen` must be set to a valid key for your integration. Check [configuration.md](configuration.md#valid-allergen-keys) for the correct keys.
 
-3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, which is only available for GPL, SILAM, and Atmo. For all other integrations it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
+3. **Check `badge_content: aggregate`.** This mode uses the integration's overall-risk sensor, available out of the box for GPL and Atmo. SILAM also has one (the index, key `allergy_risk`), but it is not in SILAM's default allergens, so add `index` to the badge's `allergens` for `aggregate` to work there. For every other case it falls back to `worst` automatically, so an empty badge here usually means no allergen data was found at all (see step 1).
 
 4. **Enable debug mode** on a card with the same config and check the browser console for detection messages (see [Debug console output](#6-debug-console-output-helpful-for-detection-issues)).
 

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -121,8 +121,17 @@ export function selectBadgeSensor(sensors, config) {
         typeof config?.badge_single_allergen === "string"
           ? config.badge_single_allergen
           : null;
+      // Sensors carry the canonical allergenReplaced (e.g. SILAM's index is
+      // canonicalized to "allergy_risk"), but badge_single_allergen holds the
+      // user-facing config key ("index"). Match on the raw key first, then on
+      // its canonical form, so a user can name the allergen with either.
+      const canonKey = key ? toCanonicalAllergenKey(key) : null;
       const found = key
-        ? sensors.find((s) => s && s.allergenReplaced === key)
+        ? sensors.find(
+            (s) =>
+              s &&
+              (s.allergenReplaced === key || s.allergenReplaced === canonKey),
+          )
         : null;
       return found ? [found] : worst();
     }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -121,18 +121,26 @@ export function selectBadgeSensor(sensors, config) {
         typeof config?.badge_single_allergen === "string"
           ? config.badge_single_allergen
           : null;
-      // Sensors carry the canonical allergenReplaced (e.g. SILAM's index is
-      // canonicalized to "allergy_risk"), but badge_single_allergen holds the
-      // user-facing config key ("index"). Match on the raw key first, then on
-      // its canonical form, so a user can name the allergen with either.
-      const canonKey = key ? toCanonicalAllergenKey(key) : null;
-      const found = key
-        ? sensors.find(
-            (s) =>
-              s &&
-              (s.allergenReplaced === key || s.allergenReplaced === canonKey),
-          )
-        : null;
+      if (!key) return worst();
+      // Sensors carry the adapter-normalized slug in allergenReplaced
+      // (PP "Björk" -> "bjork", DWD "gräser" -> "graeser", SILAM "index" ->
+      // "allergy_risk"), but badge_single_allergen holds the user-facing config
+      // key. Match it against each sensor by trying the raw value first, then
+      // the known normalization schemes, so the configured allergen resolves
+      // regardless of the integration's key style. Ordered candidates give a
+      // literal match priority over a normalized one.
+      const candidates = [
+        key,
+        toCanonicalAllergenKey(key),
+        normalize(key),
+        normalizeDWD(key),
+      ];
+      let found = null;
+      for (const cand of candidates) {
+        if (!cand) continue;
+        found = sensors.find((s) => s && s.allergenReplaced === cand);
+        if (found) break;
+      }
       return found ? [found] : worst();
     }
     case "row":

--- a/test/utils/select-badge-sensor.test.js
+++ b/test/utils/select-badge-sensor.test.js
@@ -80,6 +80,29 @@ describe("selectBadgeSensor", () => {
     ]);
   });
 
+  it("matches 'single' on the user-facing key when it canonicalizes (SILAM index)", () => {
+    // SILAM's index sensor carries the canonical allergenReplaced "allergy_risk",
+    // but a user names it with the config key "index". toCanonicalAllergenKey
+    // maps index -> allergy_risk, so the badge must still find it.
+    const sensors = [birch, grass, summary];
+    expect(
+      selectBadgeSensor(sensors, {
+        badge_content: "single",
+        badge_single_allergen: "index",
+      }),
+    ).toEqual([summary]);
+  });
+
+  it("still matches 'single' on the canonical key directly", () => {
+    const sensors = [birch, grass, summary];
+    expect(
+      selectBadgeSensor(sensors, {
+        badge_content: "single",
+        badge_single_allergen: "allergy_risk",
+      }),
+    ).toEqual([summary]);
+  });
+
   it("returns all sensors unchanged when mode is 'row'", () => {
     const sensors = [birch, grass, mugwort];
     expect(selectBadgeSensor(sensors, { badge_content: "row" })).toBe(sensors);

--- a/test/utils/select-badge-sensor.test.js
+++ b/test/utils/select-badge-sensor.test.js
@@ -103,6 +103,31 @@ describe("selectBadgeSensor", () => {
     ).toEqual([summary]);
   });
 
+  it("matches 'single' on a PP localized config key (Björk -> bjork)", () => {
+    // PP sensors store normalize(configKey): "Björk" -> "bjork". The badge
+    // config holds the localized key "Björk", so single must still resolve.
+    const ppBjork = { allergenReplaced: "bjork", day0: { state: 2 } };
+    const ppGras = { allergenReplaced: "gras", day0: { state: 1 } };
+    expect(
+      selectBadgeSensor([ppBjork, ppGras], {
+        badge_content: "single",
+        badge_single_allergen: "Björk",
+      }),
+    ).toEqual([ppBjork]);
+  });
+
+  it("matches 'single' on a DWD localized config key (gräser -> graeser)", () => {
+    // DWD sensors store normalizeDWD(configKey): "gräser" -> "graeser".
+    const dwdGraeser = { allergenReplaced: "graeser", day0: { state: 3 } };
+    const dwdBirke = { allergenReplaced: "birke", day0: { state: 1 } };
+    expect(
+      selectBadgeSensor([dwdGraeser, dwdBirke], {
+        badge_content: "single",
+        badge_single_allergen: "gräser",
+      }),
+    ).toEqual([dwdGraeser]);
+  });
+
   it("returns all sensors unchanged when mode is 'row'", () => {
     const sensors = [birch, grass, mugwort];
     expect(selectBadgeSensor(sensors, { badge_content: "row" })).toBe(sensors);


### PR DESCRIPTION
Documentation for the features shipped in 3.3.0-beta1 (badge support #235, icon-in-ring #227/#233, distinct no-data rendering #228), plus one related code fix surfaced during review.

## Documentation

- **Badge element** (`custom:pollenprognos-badge`): new `## Badge` section in `configuration.md` (options table + YAML examples), plus coverage in installation, quick-start, troubleshooting, integrations and localization.
- **icon-in-ring options**: `icon_in_ring`, `icon_in_ring_size_ratio`, `icon_in_ring_color_mode`, `icon_in_ring_static_color` added to the main Options table.
- README + related-projects feature bullets.

## Code (surfaced by review)

- `selectBadgeSensor` now resolves `badge_content: single` by matching the configured allergen against the sensor's adapter-normalized slug (raw, canonical, `normalize`, `normalizeDWD`). Previously single mode silently fell back to `worst` whenever the config key differed from the canonical slug (SILAM `index`, and the localized PP/DWD keys such as `Björk` / `gräser`). Adds contract tests for the SILAM, PP and DWD cases.

## Verification

- Every documented key, default and enum value checked against source.
- `npm run test` green (1088 passed); production build clean.