### PR TITLE
(refactor) Consolidate shared card/badge code; fix kleenex/plu level counts

### DIFF
--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -47,46 +47,39 @@ import {
 } from "../utils/levels-defaults.js";
 import { getAllAdapterIds } from "../adapter-registry.js";
 import {
-  stubConfigDWD,
   discoverDwdSensors,
   DWD_ENTITY_ID_RE,
 } from "../adapters/dwd.js";
 import {
-  PEU_ALLERGENS,
   discoverPeuSensors,
   extractPeuLocationSlugFromEntityId,
 } from "../adapters/peu.js";
-import { SILAM_ALLERGENS } from "../adapters/silam.js";
-import { stubConfigKleenex } from "../adapters/kleenex/index.js";
-import { stubConfigPLU } from "../adapters/plu.js";
 import {
-  ATMO_ALLERGENS,
   discoverAtmoSensors,
   findAtmoLocationBySlug,
 } from "../adapters/atmo.js";
 import {
-  GPL_BASE_ALLERGENS,
   discoverGplSensors,
   discoverGplAllergens,
 } from "../adapters/gpl/index.js";
 import {
-  GP_BASE_ALLERGENS,
   discoverGpSensors,
   discoverGpAllergens,
 } from "../adapters/gp/index.js";
-import { stubConfigMSW, discoverMswSensors } from "../adapters/msw.js";
+import { discoverMswSensors } from "../adapters/msw.js";
 import {
   discoverSilamSensors,
   resolveDiscoveredLocation,
 } from "../utils/silam.js";
 import { findLocationBySlug } from "../utils/adapter-helpers.js";
+import { numLevelsForIntegration } from "../utils/level-counts.js";
+import { allergenListForIntegration } from "./integration-allergens.js";
 import {
   PP_POSSIBLE_CITIES,
   DWD_REGIONS,
   toCanonicalAllergenKey,
 } from "../constants.js";
 import {
-  stubConfigPP,
   discoverPpSensors,
   extractCitySlugFromEntityId as extractPpCitySlugFromEntityId,
 } from "../adapters/pp.js";
@@ -321,25 +314,10 @@ export class PollenEditorBase extends LitElement {
    */
   _currentAllergens() {
     const c = this._editorConfig();
-    return c.integration === "dwd"
-      ? stubConfigDWD.allergens
-      : c.integration === "peu"
-        ? PEU_ALLERGENS
-        : c.integration === "silam"
-          ? SILAM_ALLERGENS
-          : c.integration === "kleenex"
-            ? stubConfigKleenex.allergens
-            : c.integration === "plu"
-              ? stubConfigPLU.allergens
-              : c.integration === "gpl"
-                ? [...GPL_BASE_ALLERGENS, ...(this.installedGplPlants || [])]
-                : c.integration === "gp"
-                  ? [...GP_BASE_ALLERGENS, ...(this.installedGpPlants || [])]
-                  : c.integration === "atmo"
-                ? ATMO_ALLERGENS
-                : c.integration === "msw"
-                  ? stubConfigMSW.allergens
-                  : stubConfigPP.allergens;
+    return allergenListForIntegration(c.integration, {
+      installedGplPlants: this.installedGplPlants || [],
+      installedGpPlants: this.installedGpPlants || [],
+    });
   }
 
   /**
@@ -348,15 +326,7 @@ export class PollenEditorBase extends LitElement {
    */
   _currentNumLevels() {
     const c = this._editorConfig();
-    return c.integration === "dwd"
-      ? 4
-      : c.integration === "peu" || c.integration === "msw"
-        ? 5
-        : c.integration === "gpl" || c.integration === "gp"
-          ? 6
-          : c.integration === "plu"
-            ? 4
-            : 7;
+    return numLevelsForIntegration(c.integration);
   }
 
   /**

--- a/src/editor/integration-allergens.js
+++ b/src/editor/integration-allergens.js
@@ -1,0 +1,54 @@
+// Single source for the per-integration allergen list used by the editor. Both
+// the shared editor base (_currentAllergens) and the card editor's phrase reset
+// previously inlined the same integration if-chain; keeping it here means a new
+// integration's allergen list is declared in one place. (Level counts live in
+// ../utils/level-counts.js, shared with the rendering mixin.)
+
+import { stubConfigDWD } from "../adapters/dwd.js";
+import { PEU_ALLERGENS } from "../adapters/peu.js";
+import { SILAM_ALLERGENS } from "../adapters/silam.js";
+import { stubConfigKleenex } from "../adapters/kleenex/index.js";
+import { stubConfigPLU } from "../adapters/plu.js";
+import { ATMO_ALLERGENS } from "../adapters/atmo.js";
+import { GPL_BASE_ALLERGENS } from "../adapters/gpl/index.js";
+import { GP_BASE_ALLERGENS } from "../adapters/gp/index.js";
+import { stubConfigMSW } from "../adapters/msw.js";
+import { stubConfigPP } from "../adapters/pp.js";
+
+/**
+ * The raw allergen keys for an integration, in editor-display order.
+ *
+ * GPL and GP append the location's discovered plants to their base list, so the
+ * caller passes them in via opts (the base editor uses its stored
+ * installedGplPlants/installedGpPlants; the card editor passes a fresh
+ * discovery). Everything else returns its static stub list.
+ *
+ * @param {string} integration
+ * @param {{installedGplPlants?: string[], installedGpPlants?: string[]}} [opts]
+ * @returns {string[]}
+ */
+export function allergenListForIntegration(integration, opts = {}) {
+  const { installedGplPlants = [], installedGpPlants = [] } = opts;
+  switch (integration) {
+    case "dwd":
+      return stubConfigDWD.allergens;
+    case "peu":
+      return PEU_ALLERGENS;
+    case "silam":
+      return SILAM_ALLERGENS;
+    case "kleenex":
+      return stubConfigKleenex.allergens;
+    case "plu":
+      return stubConfigPLU.allergens;
+    case "gpl":
+      return [...GPL_BASE_ALLERGENS, ...installedGplPlants];
+    case "gp":
+      return [...GP_BASE_ALLERGENS, ...installedGpPlants];
+    case "atmo":
+      return ATMO_ALLERGENS;
+    case "msw":
+      return stubConfigMSW.allergens;
+    default:
+      return stubConfigPP.allergens;
+  }
+}

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -21,6 +21,7 @@ import {
   filterSensorsPostFetch,
   selectBadgeSensor,
   coerceBool,
+  scaleRingLevel,
 } from "./utils/adapter-helpers.js";
 import {
   LEVELS_DEFAULTS,
@@ -318,10 +319,10 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       <div class="ppb ${labelBelow ? "ppb--below" : "ppb--right"}" style="${hostStyle}">
         ${picks.map((sensor) => {
           const normalizedLevel = Number(sensor.day0?.state) || 0;
-          const ringLevel =
-            this.config.integration === "dwd"
-              ? normalizedLevel * 2
-              : normalizedLevel;
+          const ringLevel = scaleRingLevel(
+            this.config.integration,
+            normalizedLevel,
+          );
           const svgKey = this._getSvgKey(sensor.allergenReplaced);
           const rawNum =
             sensor.day0?.display_state ?? sensor.day0?.state ?? ringLevel;

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -28,6 +28,7 @@ import {
   ICON_IN_RING_DEFAULT_THICKNESS,
 } from "./utils/levels-defaults.js";
 import { LevelCircleMixin } from "./rendering/level-circle-mixin.js";
+import { ringIconStyles } from "./rendering/ring-icon-styles.js";
 import silamAllergenMap from "./adapters/silam_allergen_map.json" assert { type: "json" };
 
 class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
@@ -415,6 +416,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
   static get styles() {
     return css`
+      ${ringIconStyles}
       :host {
         display: inline-flex;
         align-items: center;
@@ -495,55 +497,27 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       }
 
       /*
-       * The following rules mirror the card's shadow-DOM CSS verbatim.
-       * They must live here because _rebuildCharts() injects .ring-icon
-       * and .level-value-text directly into this element's renderRoot.
+       * .ring-icon, .ring-icon svg, .level-value-text and the no-data icon
+       * rules live in the shared ringIconStyles fragment (spliced above), so
+       * they stay byte-identical to the card. _rebuildCharts injects
+       * .ring-icon / .level-value-text into this element's renderRoot, which
+       * the fragment covers. The rules below are badge-specific and
+       * intentionally differ from the card.
        */
 
-      /* Icon centered inside the level ring (#227). Sized inline by
-         _rebuildCharts based on ring thickness and icon_in_ring_size_ratio.
-         color is inherited so SVG fill="currentColor" follows. */
-      .ring-icon {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        pointer-events: none;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .ring-icon svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-        fill: currentColor;
-      }
-      /* No <g fill=...> override here: SVGs that intentionally set
-         fill="none" (e.g. no_allergens uses fill="none" with
-         stroke="currentColor") must keep that. The svg-level
-         fill: currentColor handles every allergen icon whose <g> has
-         fill="currentColor" or no fill attr. */
-
+      /* Badge ring wrapper: no card-style sizing/margin (the badge sizes the
+         ring inline via badge_scale and spaces items with .ppb-item flex gap). */
       .level-circle {
         line-height: 0;
       }
 
-      .level-value-text {
-        max-width: 100%;
-        max-height: 100%;
-        overflow: hidden;
-        text-align: center;
-        white-space: nowrap;
-      }
-
       /*
-       * Rules below are required by _renderAllergenSvg (inherited from
-       * LevelCircleMixin) for the icon_only badge_visual mode.
-       * Copied verbatim from the card's shadow-DOM CSS with one intentional
-       * deviation: margin is 0 (not "0 auto 6px auto") because the badge
-       * controls spacing via its .ppb-item flex gap, not bottom-margin.
-       * Same deviation applies to .pp-icon-error.
+       * .pp-icon / .pp-icon-error are required by _renderAllergenSvg (inherited
+       * from LevelCircleMixin) for the icon_only badge_visual mode. They differ
+       * from the card by one intentional deviation: margin is 0 (not
+       * "0 auto 6px auto") because the badge controls spacing via its .ppb-item
+       * flex gap. The shared .pp-icon svg / svg g / no-data rules come from the
+       * ringIconStyles fragment.
        */
 
       .pp-icon {
@@ -556,38 +530,6 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         min-height: 0;
         margin: 0;
         color: var(--pp-icon-color, var(--primary-text-color));
-      }
-
-      .pp-icon svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-      }
-
-      .pp-icon svg g {
-        stroke: var(--pp-icon-stroke, none);
-        stroke-width: var(--pp-icon-stroke-width, 1);
-      }
-
-      .pp-icon-no-data {
-        -webkit-mask-image: var(--pp-icon-no-data-mask);
-        mask-image: var(--pp-icon-no-data-mask);
-        -webkit-mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-        -webkit-mask-position: center;
-        mask-position: center;
-        -webkit-mask-size: contain;
-        mask-size: contain;
-        -webkit-mask-mode: alpha;
-        mask-mode: alpha;
-        background-image: var(--pp-icon-no-data-noise);
-        background-repeat: repeat;
-        background-color: rgba(136, 136, 136, 0.15);
-        background-color: color-mix(
-          in srgb,
-          var(--primary-text-color, #888888) 15%,
-          transparent
-        );
       }
 
       .pp-icon-error {

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -13,6 +13,7 @@ import {
   selectDisplaySensors,
   coerceBool,
   computeDisplayDays,
+  scaleRingLevel,
 } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 import { PLU_ALIAS_MAP } from "./adapters/plu.js";
@@ -1636,10 +1637,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             // saturate the ring at high raw-risk values. Mirrors what
             // _renderNormalHtml does per-cell.
             const normalizedLevel = Number(sensor.day0?.state) || 0;
-            const ringLevel =
-              this.config.integration === "dwd"
-                ? normalizedLevel * 2
-                : normalizedLevel;
+            const ringLevel = scaleRingLevel(
+              this.config.integration,
+              normalizedLevel,
+            );
             const clickable =
               this.config.link_to_sensors !== false && !!sensor.entity_id;
             const onClickEntity = (e) => {
@@ -1974,16 +1975,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                           const displayVal = Number(
                             sensor.days[i]?.display_state ?? normalized,
                           );
-                          let levelVal = normalized;
-                          if (this.config.integration === "dwd") {
-                            levelVal = normalized * 2;
-                          } else if (
-                            this.config.integration === "peu" ||
-                            this.config.integration === "kleenex" ||
-                            this.config.integration === "plu"
-                          ) {
-                            levelVal = normalized;
-                          }
+                          const levelVal = scaleRingLevel(
+                            this.config.integration,
+                            normalized,
+                          );
                           const ringOpts = {
                             colors,
                             emptyColor,

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1756,40 +1756,12 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       (_, i) => i,
     );
     
-    // Number of segments in the level circle depends on the integration.
-    // PEU, Kleenex and MSW use four segments (native 5-level scale, 0=None
-    // = empty); GPL/GP use five (native 0-5); PLU uses three; others use
-    // six. Match each integration's native level count so the maximum state
-    // fills the chart (no never-filled trailing segment).
-    let segments = 6;
-    if (
-      this.config.integration === "peu" ||
-      this.config.integration === "kleenex" ||
-      this.config.integration === "msw"
-    ) {
-      segments = 4;
-    } else if (this.config.integration === "gpl" || this.config.integration === "gp") {
-      segments = 5;
-    } else if (this.config.integration === "plu") {
-      segments = 3;
-    }
-    
-    // Build colors array using the new inheritance system.
-    // Chart segments represent pollen levels 1..segments (level 0 = empty),
-    // so segments matches the integration's native non-empty level count
-    // (4 for PEU/Kleenex/MSW, 5 for GPL/GP, 3 for PLU, 6 for the others).
-    const rawColors = [];
-    for (let i = 0; i < segments; i++) {
-      rawColors.push(this._levelColorForLevel(i + 1)); // i=0 -> level 1, i=1 -> level 2, etc.
-    }
-    const colors = rawColors;
-    const emptyColor = this.config.levels_empty_color ?? "var(--divider-color)";
-    
-    const gapColor = this._getGapColor();
-      
-    const thickness =
-      this.config.levels_thickness ?? LEVELS_DEFAULTS.levels_thickness;
-    const gap = this.config.levels_gap ?? LEVELS_DEFAULTS.levels_gap;
+    // Ring geometry/colors come from the shared mixin helper
+    // (_buildLevelRingConfig): segment count per integration (PEU/Kleenex/MSW
+    // 4, GPL/GP 5, PLU 3, others 6), the level-color array, empty/gap colors,
+    // thickness and gap. Same derivation minimal mode and the badge use.
+    const { colors, emptyColor, gapColor, thickness, gap } =
+      this._buildLevelRingConfig();
     const iconSize = Number(this.config.icon_size) || 48;
     const iconRatio = Number(this.config.levels_icon_ratio) || 1;
     const size = Math.min(100, Math.max(1, iconSize * iconRatio));

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -36,6 +36,7 @@ import {
 } from "./constants.js";
 import silamAllergenMap from "./adapters/silam_allergen_map.json" assert { type: "json" };
 import { LevelCircleMixin } from "./rendering/level-circle-mixin.js";
+import { ringIconStyles } from "./rendering/ring-icon-styles.js";
 
 class PollenPrognosCard extends LevelCircleMixin(LitElement) {
   _forecastUnsub = null; // Unsubscribe-funktion
@@ -2305,6 +2306,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
 
   static get styles() {
     return css`
+      ${ringIconStyles}
       /* normalhtml */
       .forecast {
         width: 100%; /* Fyll hela kortet! */
@@ -2385,49 +2387,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         color: var(--pp-icon-color, var(--primary-text-color));
       }
 
-      .pp-icon svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-      }
-
-      .pp-icon svg g {
-        stroke: var(--pp-icon-stroke, none);
-        stroke-width: var(--pp-icon-stroke-width, 1);
-      }
-
-      /* No-data icon: silhouette filled with a faint solid color (anchors
-         the shape so it stays readable against a heavily textured ring)
-         plus a noise pattern on top (carries the "no data" cue). The icon
-         SVG acts as the mask; mask-mode: alpha is set explicitly so SVG
-         paths filled with black act as the opaque part of the mask in
-         Chrome (its default for SVG-via-url is luminance, which would
-         invert the result). */
-      .pp-icon-no-data {
-        -webkit-mask-image: var(--pp-icon-no-data-mask);
-        mask-image: var(--pp-icon-no-data-mask);
-        -webkit-mask-repeat: no-repeat;
-        mask-repeat: no-repeat;
-        -webkit-mask-position: center;
-        mask-position: center;
-        -webkit-mask-size: contain;
-        mask-size: contain;
-        -webkit-mask-mode: alpha;
-        mask-mode: alpha;
-        background-image: var(--pp-icon-no-data-noise);
-        background-repeat: repeat;
-        /* Plain rgba fallback first so the icon still gets a translucent
-           anchor on browsers without color-mix() support (older WebKit /
-           legacy Chromium builds shipped via plugin-legacy). The
-           color-mix() declaration overrides it on modern browsers and
-           tracks --primary-text-color through theme switches. */
-        background-color: rgba(136, 136, 136, 0.15);
-        background-color: color-mix(
-          in srgb,
-          var(--primary-text-color, #888888) 15%,
-          transparent
-        );
-      }
+      /* .pp-icon svg, .pp-icon svg g and .pp-icon-no-data live in the shared
+         ringIconStyles fragment (identical in card and badge). */
 
       .pp-icon-placeholder {
         display: flex;
@@ -2485,30 +2446,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         color: var(--primary-text-color);
       }
 
-      /* Icon centered inside the level ring (#227). Sized inline by
-         _rebuildCharts based on ring thickness and icon_in_ring_size_ratio.
-         color is inherited so SVG fill="currentColor" follows. */
-      .ring-icon {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        pointer-events: none;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .ring-icon svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-        fill: currentColor;
-      }
-      /* No <g fill=...> override here: SVGs that intentionally set
-         fill="none" (e.g. no_allergens uses fill="none" with
-         stroke="currentColor") must keep that. The svg-level
-         fill: currentColor handles every allergen icon whose <g> has
-         fill="currentColor" or no fill attr. */
+      /* .ring-icon and .ring-icon svg live in the shared ringIconStyles
+         fragment (identical in card and badge). */
 
       .forecast-content {
         width: 100%;
@@ -2631,13 +2570,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         display: block;
         vertical-align: middle;
       }
-      .level-value-text {
-        max-width: 100%;
-        max-height: 100%;
-        overflow: hidden;
-        text-align: center;
-        white-space: nowrap;
-      }
+      /* .level-value-text lives in the shared ringIconStyles fragment. */
 
       /* No allergens display */
       .no-allergens-container {

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -7,6 +7,7 @@ import {
   ICON_IN_RING_DEFAULT_THICKNESS,
 } from "./utils/levels-defaults.js";
 import { COSMETIC_FIELDS } from "./constants.js";
+import { normalize } from "./utils/normalize.js";
 
 // Shared editor base (deepMerge, section methods, helpers)
 import { PollenEditorBase, deepMerge } from "./editor/base.js";

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -89,13 +89,15 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     // the editor base via numLevelsForIntegration so the count cannot drift.
     const numLevels = numLevelsForIntegration(this._config.integration);
 
-    // Use scale-specific phrase defaults so 5-level integrations (MSW, PEU)
-    // surface semantically-correct severity labels in the editor instead of
-    // borrowing strings from the wider 7-level palette. Other scales fall
-    // back to the legacy editor.phrases_levels.0..6 keys until per-scale
-    // entries are added for them.
+    // Use scale-specific phrase defaults so 5-level integrations (MSW, PEU,
+    // Kleenex) surface semantically-correct severity labels in the editor
+    // instead of borrowing the first five strings from the wider 7-level
+    // palette. Other scales fall back to the legacy editor.phrases_levels.0..6
+    // keys until per-scale entries are added for them.
     const levelKeyPrefix =
-      this._config.integration === "msw" || this._config.integration === "peu"
+      this._config.integration === "msw" ||
+      this._config.integration === "peu" ||
+      this._config.integration === "kleenex"
         ? "editor.phrases_levels5"
         : "editor.phrases_levels";
     const levels = Array.from({ length: numLevels }, (_, i) =>

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -19,7 +19,7 @@ import { getStubConfig } from "./adapter-registry.js";
 import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
 import { PEU_ALLERGENS, discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
-import { stubConfigPLU, PLU_ALIAS_MAP } from "./adapters/plu.js";
+import { PLU_ALIAS_MAP } from "./adapters/plu.js";
 import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
 import { GPL_BASE_ALLERGENS, GPL_ATTRIBUTION, discoverGplSensors, discoverGplAllergens } from "./adapters/gpl/index.js";
 import { GP_BASE_ALLERGENS, discoverGpSensors, discoverGpAllergens } from "./adapters/gp/index.js";

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -10,19 +10,19 @@ import { COSMETIC_FIELDS } from "./constants.js";
 
 // Shared editor base (deepMerge, section methods, helpers)
 import { PollenEditorBase, deepMerge } from "./editor/base.js";
+import { allergenListForIntegration } from "./editor/integration-allergens.js";
+import { numLevelsForIntegration } from "./utils/level-counts.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
 import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
-import { stubConfigDWD, discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
+import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
 import { PEU_ALLERGENS, discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
-import { SILAM_ALLERGENS } from "./adapters/silam.js";
-import { stubConfigKleenex } from "./adapters/kleenex/index.js";
 import { stubConfigPLU, PLU_ALIAS_MAP } from "./adapters/plu.js";
-import { ATMO_ALLERGENS, discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
+import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
 import { GPL_BASE_ALLERGENS, GPL_ATTRIBUTION, discoverGplSensors, discoverGplAllergens } from "./adapters/gpl/index.js";
 import { GP_BASE_ALLERGENS, discoverGpSensors, discoverGpAllergens } from "./adapters/gp/index.js";
-import { stubConfigMSW, discoverMswSensors } from "./adapters/msw.js";
+import { discoverMswSensors } from "./adapters/msw.js";
 import {
   discoverSilamSensors,
   resolveDiscoveredLocation,
@@ -65,24 +65,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       gpDiscoveredPlants = gpDiscoveredPlants.filter((k) => !GP_BASE_ALLERGENS.includes(k));
     }
 
-    const rawKeys =
-      this._config.integration === "dwd"
-        ? stubConfigDWD.allergens
-        : this._config.integration === "peu"
-          ? PEU_ALLERGENS
-          : this._config.integration === "silam"
-            ? SILAM_ALLERGENS
-            : this._config.integration === "kleenex"
-              ? stubConfigKleenex.allergens
-              : this._config.integration === "atmo"
-                ? ATMO_ALLERGENS
-                : this._config.integration === "gpl"
-                  ? [...GPL_BASE_ALLERGENS, ...gplDiscoveredPlants]
-                  : this._config.integration === "gp"
-                    ? [...GP_BASE_ALLERGENS, ...gpDiscoveredPlants]
-                    : this._config.integration === "msw"
-                      ? stubConfigMSW.allergens
-                      : stubConfigPP.allergens;
+    const rawKeys = allergenListForIntegration(this._config.integration, {
+      installedGplPlants: gplDiscoveredPlants,
+      installedGpPlants: gpDiscoveredPlants,
+    });
 
     // Börja bygga nytt phrases-objekt
     const full = {};
@@ -98,19 +84,9 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       short[raw] = t(`editor.phrases_short.${transKey}`, lang);
     });
 
-    // Levels och days hämtas precis som tidigare
-    const numLevels =
-      this._config.integration === "dwd"
-        ? 4
-        : this._config.integration === "peu" || this._config.integration === "msw"
-          ? 5
-          : this._config.integration === "gpl" || this._config.integration === "gp"
-            ? 6
-            : this._config.integration === "silam"
-              ? 7
-              : this._config.integration === "atmo"
-                ? 7
-                : 7;
+    // Native level count (incl. level 0). Shared with the rendering mixin and
+    // the editor base via numLevelsForIntegration so the count cannot drift.
+    const numLevels = numLevelsForIntegration(this._config.integration);
 
     // Use scale-specific phrase defaults so 5-level integrations (MSW, PEU)
     // surface semantically-correct severity labels in the editor instead of

--- a/src/rendering/level-circle-mixin.js
+++ b/src/rendering/level-circle-mixin.js
@@ -372,13 +372,11 @@ export const LevelCircleMixin = (Base) =>
     }
 
     /**
-     * Ring geometry/colors for the minimal-mode icon-in-ring render path.
-     * Returns the opts blob passed to _renderLevelCircle (minus per-cell
-     * values like size/iconKey/iconColor which the caller fills in).
-     *
-     * Note: _renderNormalHtml currently re-implements the same segment /
-     * color / thickness / gap derivation inline. A follow-up could refactor
-     * both call sites to share this helper.
+     * Ring geometry/colors for the level-circle render path. Returns the opts
+     * blob passed to _renderLevelCircle (minus per-cell values like
+     * size/iconKey/iconColor which the caller fills in). Shared by the card
+     * (normal and minimal modes) and the badge, so the segment count, color
+     * array, thickness and gap are derived in one place.
      */
     _buildLevelRingConfig() {
       const segments = ringSegmentsForIntegration(this.config?.integration);

--- a/src/rendering/level-circle-mixin.js
+++ b/src/rendering/level-circle-mixin.js
@@ -11,6 +11,7 @@ import { html } from "lit";
 import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { getSvgContent } from "../pollenprognos-svgs.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
+import { ringSegmentsForIntegration } from "../utils/level-counts.js";
 import { buildNoiseCanvasPattern, buildNoiseSvgUri, hashStringSeed } from "../utils/no-data-pattern.js";
 import { ALLERGEN_ICON_FALLBACK, toCanonicalAllergenKey } from "../constants.js";
 import {
@@ -380,21 +381,7 @@ export const LevelCircleMixin = (Base) =>
      * both call sites to share this helper.
      */
     _buildLevelRingConfig() {
-      let segments = 6;
-      if (
-        this.config?.integration === "peu" ||
-        this.config?.integration === "kleenex" ||
-        this.config?.integration === "msw"
-      ) {
-        segments = 4;
-      } else if (
-        this.config?.integration === "gpl" ||
-        this.config?.integration === "gp"
-      ) {
-        segments = 5;
-      } else if (this.config?.integration === "plu") {
-        segments = 3;
-      }
+      const segments = ringSegmentsForIntegration(this.config?.integration);
       const colors = [];
       for (let i = 0; i < segments; i++) {
         colors.push(this._levelColorForLevel(i + 1));

--- a/src/rendering/ring-icon-styles.js
+++ b/src/rendering/ring-icon-styles.js
@@ -1,0 +1,94 @@
+import { css } from "lit";
+
+/**
+ * Shadow-DOM CSS shared verbatim by the card and the badge.
+ *
+ * These rules style elements that LevelCircleMixin injects (or renders) into
+ * each component's own renderRoot: the ring-centre icon (`_rebuildCharts`),
+ * the numeric ring value, and the bare allergen SVG (`_renderAllergenSvg`).
+ * Because the mixin writes into each element's shadow tree, the rules must be
+ * present in BOTH shadow roots; importing one `css` fragment keeps the two
+ * copies in sync instead of duplicating the source.
+ *
+ * Only byte-identical rules live here. Rules that legitimately differ between
+ * the card and the badge (e.g. `.pp-icon` margin, `.level-circle` sizing) stay
+ * local to each component with their own explanatory comments.
+ */
+export const ringIconStyles = css`
+  /* Icon centered inside the level ring (#227). Sized inline by
+     _rebuildCharts based on ring thickness and icon_in_ring_size_ratio.
+     color is inherited so SVG fill="currentColor" follows. */
+  .ring-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .ring-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    fill: currentColor;
+  }
+  /* No <g fill=...> override here: SVGs that intentionally set
+     fill="none" (e.g. no_allergens uses fill="none" with
+     stroke="currentColor") must keep that. The svg-level
+     fill: currentColor handles every allergen icon whose <g> has
+     fill="currentColor" or no fill attr. */
+
+  .level-value-text {
+    max-width: 100%;
+    max-height: 100%;
+    overflow: hidden;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .pp-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .pp-icon svg g {
+    stroke: var(--pp-icon-stroke, none);
+    stroke-width: var(--pp-icon-stroke-width, 1);
+  }
+
+  /* No-data icon: silhouette filled with a faint solid color (anchors
+     the shape so it stays readable against a heavily textured ring)
+     plus a noise pattern on top (carries the "no data" cue). The icon
+     SVG acts as the mask; mask-mode: alpha is set explicitly so SVG
+     paths filled with black act as the opaque part of the mask in
+     Chrome (its default for SVG-via-url is luminance, which would
+     invert the result). */
+  .pp-icon-no-data {
+    -webkit-mask-image: var(--pp-icon-no-data-mask);
+    mask-image: var(--pp-icon-no-data-mask);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-mode: alpha;
+    mask-mode: alpha;
+    background-image: var(--pp-icon-no-data-noise);
+    background-repeat: repeat;
+    /* Plain rgba fallback first so the icon still gets a translucent
+       anchor on browsers without color-mix() support (older WebKit /
+       legacy Chromium builds shipped via plugin-legacy). The
+       color-mix() declaration overrides it on modern browsers and
+       tracks --primary-text-color through theme switches. */
+    background-color: rgba(136, 136, 136, 0.15);
+    background-color: color-mix(
+      in srgb,
+      var(--primary-text-color, #888888) 15%,
+      transparent
+    );
+  }
+`;

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -229,7 +229,10 @@ export function clampLevel(v, maxLevel = 6, nanResult = -1) {
  * rule.
  *
  * @param {string} integration   - The card/badge `integration` id.
- * @param {number} normalizedLevel - The sensor's normalized level (>= 0).
+ * @param {number} normalizedLevel - The sensor's normalized level. A negative
+ *   no-data sentinel (e.g. -1) is preserved (and doubled to -2 for DWD), so the
+ *   caller's no-data handling still sees a negative value; non-numeric input
+ *   coerces to 0.
  * @returns {number} The level to render the ring at.
  */
 export function scaleRingLevel(integration, normalizedLevel) {

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -69,11 +69,15 @@ export function selectDisplaySensors(sensors, config) {
  * Sensors carry the adapter-normalized slug in `allergenReplaced` (PP
  * "Björk" -> "bjork", DWD "gräser" -> "graeser", SILAM "index" ->
  * "allergy_risk"), while config keys (config.allergens, badge_single_allergen)
- * hold whatever the user/editor wrote. Both sides reduce to the same canonical
- * allergen key via toCanonicalAllergenKey(normalize(x)), so a key resolves
- * regardless of the integration's key style. A literal match on the raw
- * `allergenReplaced` is tried first, so an exact key always wins over a merely
- * canonical-equal one.
+ * hold whatever the user/editor wrote. The config key is reduced to a canonical
+ * allergen key via BOTH the generic slug normalization and DWD's umlaut/ß
+ * expansion (ä->ae, ß->ss); the sensor side reduces via the generic
+ * normalization (its value is already adapter-normalized). A match on either
+ * canonical form resolves the sensor, so a key works regardless of the
+ * integration's key style. Trying normalizeDWD as well matters for DWD keys
+ * like "Beifuß", where generic normalize would drop the ß ("beifu") and miss
+ * the "beifuss" sensor. A literal match on the raw `allergenReplaced` is tried
+ * first, so an exact key always wins over a merely canonical-equal one.
  *
  * This is the single shared "config allergen key -> sensor" resolver. The badge
  * uses it for single mode today; the card can reuse it if it ever gains a
@@ -94,13 +98,18 @@ export function matchSensorByAllergenKey(sensors, configKey) {
     (s) => s && typeof s.allergenReplaced === "string" && s.allergenReplaced === configKey,
   );
   if (literal) return literal;
-  const wanted = toCanonicalAllergenKey(normalize(configKey));
+  // Canonical candidates for the config key, via both the generic slug
+  // normalization and DWD's umlaut/ß expansion, so DWD keys resolve too.
+  const wanted = new Set([
+    toCanonicalAllergenKey(normalize(configKey)),
+    toCanonicalAllergenKey(normalizeDWD(configKey)),
+  ]);
   return (
     sensors.find(
       (s) =>
         s &&
         typeof s.allergenReplaced === "string" &&
-        toCanonicalAllergenKey(normalize(s.allergenReplaced)) === wanted,
+        wanted.has(toCanonicalAllergenKey(normalize(s.allergenReplaced))),
     ) || null
   );
 }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -199,6 +199,23 @@ export function clampLevel(v, maxLevel = 6, nanResult = -1) {
 }
 
 /**
+ * Scale a normalized pollen level for ring rendering. DWD reports a coarse
+ * 0-3 scale, but the doughnut ring is drawn on the shared 0-6 geometry, so DWD
+ * levels are doubled to fill the ring; every other integration renders its
+ * level unchanged. Single source for the card (normal + minimal modes) and the
+ * badge, which previously each inlined the `integration === "dwd" ? n * 2 : n`
+ * rule.
+ *
+ * @param {string} integration   - The card/badge `integration` id.
+ * @param {number} normalizedLevel - The sensor's normalized level (>= 0).
+ * @returns {number} The level to render the ring at.
+ */
+export function scaleRingLevel(integration, normalizedLevel) {
+  const n = Number(normalizedLevel) || 0;
+  return integration === "dwd" ? n * 2 : n;
+}
+
+/**
  * Sort a sensors array in-place using one of the standard sort keys.
  * Adapter-specific post-sorts (tiered, pin-to-top) are applied by the caller.
  *

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -64,6 +64,48 @@ export function selectDisplaySensors(sensors, config) {
 }
 
 /**
+ * Resolve a user-facing allergen config key to its sensor.
+ *
+ * Sensors carry the adapter-normalized slug in `allergenReplaced` (PP
+ * "Björk" -> "bjork", DWD "gräser" -> "graeser", SILAM "index" ->
+ * "allergy_risk"), while config keys (config.allergens, badge_single_allergen)
+ * hold whatever the user/editor wrote. Both sides reduce to the same canonical
+ * allergen key via toCanonicalAllergenKey(normalize(x)), so a key resolves
+ * regardless of the integration's key style. A literal match on the raw
+ * `allergenReplaced` is tried first, so an exact key always wins over a merely
+ * canonical-equal one.
+ *
+ * This is the single shared "config allergen key -> sensor" resolver. The badge
+ * uses it for single mode today; the card can reuse it if it ever gains a
+ * single-allergen display. Typeguarded so a non-string key (YAML can deliver a
+ * number/null) or a sensor without a string allergenReplaced is skipped, never
+ * thrown on.
+ *
+ * @param {object[]} sensors   - normalized sensor dicts.
+ * @param {string}   configKey - the user-facing allergen key to resolve.
+ * @returns {object|null} the matching sensor, or null.
+ */
+export function matchSensorByAllergenKey(sensors, configKey) {
+  if (!Array.isArray(sensors) || typeof configKey !== "string" || !configKey) {
+    return null;
+  }
+  // Literal match first: an exact allergenReplaced wins over a normalized one.
+  const literal = sensors.find(
+    (s) => s && typeof s.allergenReplaced === "string" && s.allergenReplaced === configKey,
+  );
+  if (literal) return literal;
+  const wanted = toCanonicalAllergenKey(normalize(configKey));
+  return (
+    sensors.find(
+      (s) =>
+        s &&
+        typeof s.allergenReplaced === "string" &&
+        toCanonicalAllergenKey(normalize(s.allergenReplaced)) === wanted,
+    ) || null
+  );
+}
+
+/**
  * Badge support (issue #235): pick which sensor(s) a compact badge renders,
  * given the badge content mode. A badge is tiny and typically shows ONE thing,
  * so this returns a short list (usually length 1) that the badge render path
@@ -117,30 +159,10 @@ export function selectBadgeSensor(sensors, config) {
     case "aggregate":
       return summary ? [summary] : worst();
     case "single": {
-      const key =
-        typeof config?.badge_single_allergen === "string"
-          ? config.badge_single_allergen
-          : null;
-      if (!key) return worst();
-      // Sensors carry the adapter-normalized slug in allergenReplaced
-      // (PP "Björk" -> "bjork", DWD "gräser" -> "graeser", SILAM "index" ->
-      // "allergy_risk"), but badge_single_allergen holds the user-facing config
-      // key. Match it against each sensor by trying the raw value first, then
-      // the known normalization schemes, so the configured allergen resolves
-      // regardless of the integration's key style. Ordered candidates give a
-      // literal match priority over a normalized one.
-      const candidates = [
-        key,
-        toCanonicalAllergenKey(key),
-        normalize(key),
-        normalizeDWD(key),
-      ];
-      let found = null;
-      for (const cand of candidates) {
-        if (!cand) continue;
-        found = sensors.find((s) => s && s.allergenReplaced === cand);
-        if (found) break;
-      }
+      const found = matchSensorByAllergenKey(
+        sensors,
+        config?.badge_single_allergen,
+      );
       return found ? [found] : worst();
     }
     case "row":

--- a/src/utils/level-counts.js
+++ b/src/utils/level-counts.js
@@ -1,0 +1,50 @@
+// Single source for per-integration level counts, shared by the rendering
+// mixin (ring geometry) and the editor (level-color pickers + phrase
+// defaults). Keeping both counts here means a new integration's level scale is
+// declared once, and the ring and the editor can never disagree.
+
+/**
+ * Number of NON-EMPTY ring segments (doughnut arcs) for an integration, i.e.
+ * the highest level the ring can fill. Level 0 ("none") is the empty track and
+ * is not a segment, so this is the native max level.
+ *
+ * Native max level by integration (from each adapter's clamp): PEU/Kleenex/MSW
+ * cap at 4, GPL/GP at 5, PLU at 3, and PP/SILAM/Atmo at 6. DWD is special: its
+ * native 0-3 scale is doubled (see scaleRingLevel) to fill the 0-6 ring, so its
+ * ring shows 6 segments even though it has only 4 native levels.
+ *
+ * @param {string} integration
+ * @returns {number}
+ */
+export function ringSegmentsForIntegration(integration) {
+  switch (integration) {
+    case "peu":
+    case "kleenex":
+    case "msw":
+      return 4;
+    case "gpl":
+    case "gp":
+      return 5;
+    case "plu":
+      return 3;
+    default:
+      // pp, dwd, silam, atmo
+      return 6;
+  }
+}
+
+/**
+ * Total native level count INCLUDING level 0 ("none"). Drives the editor's
+ * level-color pickers and the number of phrase-level defaults generated.
+ *
+ * Equals ringSegments + 1 for every integration EXCEPT DWD: DWD's ring shows 6
+ * scaled segments but it has only 4 native levels (0-3), so the editor should
+ * offer 4 level entries, not 7.
+ *
+ * @param {string} integration
+ * @returns {number}
+ */
+export function numLevelsForIntegration(integration) {
+  if (integration === "dwd") return 4;
+  return ringSegmentsForIntegration(integration) + 1;
+}

--- a/test/utils/level-counts.test.js
+++ b/test/utils/level-counts.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  ringSegmentsForIntegration,
+  numLevelsForIntegration,
+} from "../../src/utils/level-counts.js";
+
+// Single source for per-integration level counts, shared by the rendering mixin
+// (ring segments) and the editor (level-color pickers + phrase defaults). These
+// must match each adapter's native level scale; the table below is the contract.
+
+// [integration, ringSegments, numLevels]
+const EXPECTED = [
+  ["pp", 6, 7],
+  ["silam", 6, 7],
+  ["atmo", 6, 7],
+  ["gpl", 5, 6],
+  ["gp", 5, 6],
+  ["peu", 4, 5],
+  ["kleenex", 4, 5],
+  ["msw", 4, 5],
+  ["plu", 3, 4],
+  // DWD is special: native 0-3 (4 levels) doubled onto the 6-segment ring.
+  ["dwd", 6, 4],
+];
+
+describe("ringSegmentsForIntegration", () => {
+  for (const [integration, segments] of EXPECTED) {
+    it(`${integration} -> ${segments} segments`, () => {
+      expect(ringSegmentsForIntegration(integration)).toBe(segments);
+    });
+  }
+
+  it("defaults unknown integrations to 6", () => {
+    expect(ringSegmentsForIntegration("something-new")).toBe(6);
+    expect(ringSegmentsForIntegration(undefined)).toBe(6);
+  });
+});
+
+describe("numLevelsForIntegration", () => {
+  for (const [integration, , numLevels] of EXPECTED) {
+    it(`${integration} -> ${numLevels} levels`, () => {
+      expect(numLevelsForIntegration(integration)).toBe(numLevels);
+    });
+  }
+
+  it("equals ringSegments + 1 for every integration except DWD", () => {
+    for (const [integration] of EXPECTED) {
+      if (integration === "dwd") continue;
+      expect(numLevelsForIntegration(integration)).toBe(
+        ringSegmentsForIntegration(integration) + 1,
+      );
+    }
+  });
+});

--- a/test/utils/match-sensor-by-allergen-key.test.js
+++ b/test/utils/match-sensor-by-allergen-key.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { matchSensorByAllergenKey } from "../../src/utils/adapter-helpers.js";
+
+// matchSensorByAllergenKey is the single shared "config allergen key -> sensor"
+// resolver. Sensors store the adapter-normalized slug in allergenReplaced; the
+// matcher reduces both that and the config key to the canonical allergen key so
+// a key resolves regardless of the integration's key style, with a literal
+// match taking priority.
+
+const pp = { allergenReplaced: "bjork" }; // normalize("Björk")
+const dwd = { allergenReplaced: "graeser" }; // normalizeDWD("gräser")
+const silamIndex = { allergenReplaced: "allergy_risk" }; // SILAM index canonical
+const english = { allergenReplaced: "birch" };
+
+describe("matchSensorByAllergenKey", () => {
+  it("matches a PP localized key (Björk -> bjork)", () => {
+    expect(matchSensorByAllergenKey([pp, english], "Björk")).toBe(pp);
+  });
+
+  it("matches a DWD localized key (gräser -> graeser)", () => {
+    expect(matchSensorByAllergenKey([dwd, english], "gräser")).toBe(dwd);
+  });
+
+  it("matches the SILAM index by its user-facing key", () => {
+    expect(matchSensorByAllergenKey([silamIndex, english], "index")).toBe(
+      silamIndex,
+    );
+  });
+
+  it("matches on the canonical key directly", () => {
+    expect(matchSensorByAllergenKey([silamIndex], "allergy_risk")).toBe(
+      silamIndex,
+    );
+    expect(matchSensorByAllergenKey([english], "birch")).toBe(english);
+  });
+
+  it("prefers a literal allergenReplaced match over a canonical-equal one", () => {
+    // Both reduce to canonical "birch"; the literal "birch" sensor must win.
+    const literal = { allergenReplaced: "birch" };
+    const localized = { allergenReplaced: "bjork" };
+    expect(matchSensorByAllergenKey([localized, literal], "birch")).toBe(
+      literal,
+    );
+  });
+
+  it("returns null when no sensor matches", () => {
+    expect(matchSensorByAllergenKey([pp, dwd], "oak")).toBeNull();
+  });
+
+  it("is typeguarded against non-string keys and bad input", () => {
+    expect(matchSensorByAllergenKey([english], 3)).toBeNull();
+    expect(matchSensorByAllergenKey([english], null)).toBeNull();
+    expect(matchSensorByAllergenKey([english], "")).toBeNull();
+    expect(matchSensorByAllergenKey(null, "birch")).toBeNull();
+    // A sensor without a string allergenReplaced is skipped, not thrown on.
+    expect(matchSensorByAllergenKey([{ allergenReplaced: 5 }, english], "birch")).toBe(
+      english,
+    );
+  });
+});

--- a/test/utils/match-sensor-by-allergen-key.test.js
+++ b/test/utils/match-sensor-by-allergen-key.test.js
@@ -21,6 +21,15 @@ describe("matchSensorByAllergenKey", () => {
     expect(matchSensorByAllergenKey([dwd, english], "gräser")).toBe(dwd);
   });
 
+  it("matches a DWD key with ß (Beifuß -> beifuss)", () => {
+    // Generic normalize drops the ß ("beifu"); only normalizeDWD expands it to
+    // "beifuss" to match the sensor. The matcher must try both.
+    const dwdMugwort = { allergenReplaced: "beifuss" };
+    expect(matchSensorByAllergenKey([dwdMugwort, english], "Beifuß")).toBe(
+      dwdMugwort,
+    );
+  });
+
   it("matches the SILAM index by its user-facing key", () => {
     expect(matchSensorByAllergenKey([silamIndex, english], "index")).toBe(
       silamIndex,

--- a/test/utils/scale-ring-level.test.js
+++ b/test/utils/scale-ring-level.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { scaleRingLevel } from "../../src/utils/adapter-helpers.js";
+
+// scaleRingLevel is the single source for the DWD ring-scaling rule that the
+// card (normal + minimal) and badge previously inlined. DWD's coarse 0-3 scale
+// is doubled to fill the shared 0-6 ring geometry; every other integration
+// renders its level unchanged.
+
+describe("scaleRingLevel", () => {
+  it("doubles DWD levels", () => {
+    expect(scaleRingLevel("dwd", 0)).toBe(0);
+    expect(scaleRingLevel("dwd", 1)).toBe(2);
+    expect(scaleRingLevel("dwd", 3)).toBe(6);
+  });
+
+  it("passes other integrations through unchanged", () => {
+    for (const integration of ["pp", "peu", "kleenex", "plu", "silam", "gpl", "atmo", "msw"]) {
+      expect(scaleRingLevel(integration, 4)).toBe(4);
+    }
+  });
+
+  it("coerces non-numeric input to 0", () => {
+    expect(scaleRingLevel("pp", undefined)).toBe(0);
+    expect(scaleRingLevel("dwd", null)).toBe(0);
+    expect(scaleRingLevel("dwd", "x")).toBe(0);
+  });
+
+  it("doubles a numeric string for DWD", () => {
+    expect(scaleRingLevel("dwd", "2")).toBe(4);
+  });
+});

--- a/test/utils/select-badge-sensor.test.js
+++ b/test/utils/select-badge-sensor.test.js
@@ -128,6 +128,18 @@ describe("selectBadgeSensor", () => {
     ).toEqual([dwdGraeser]);
   });
 
+  it("falls back to worst when 'single' allergen is not a string (YAML quirk)", () => {
+    const sensors = [birch, grass, mugwort];
+    for (const bad of [3, null, {}, ["birch"]]) {
+      expect(
+        selectBadgeSensor(sensors, {
+          badge_content: "single",
+          badge_single_allergen: bad,
+        }),
+      ).toEqual([grass]);
+    }
+  });
+
   it("returns all sensors unchanged when mode is 'row'", () => {
     const sensors = [birch, grass, mugwort];
     expect(selectBadgeSensor(sensors, { badge_content: "row" })).toBe(sensors);


### PR DESCRIPTION
Behavior-preserving consolidation so card and badge share one implementation per concern instead of parallel pathways that must be maintained on two (or four) fronts. Follow-up to the badge feature (#235).

## Changes (one commit each)

1. **Shared ring-icon CSS fragment** (`src/rendering/ring-icon-styles.js`): the byte-identical `.ring-icon` / `.level-value-text` / `.pp-icon svg` / `.pp-icon-no-data` rules were copied in both card and badge styles; now spliced from one fragment. Rules that legitimately differ (`.pp-icon` margin, `.level-circle`) stay local.
2. **`scaleRingLevel` helper**: the DWD `level * 2` ring-scaling rule was inlined in three places (card normal, card minimal, badge); now one helper. Collapses a dead no-op branch.
3. **Card normal mode uses `_buildLevelRingConfig()`**: the mixin helper that minimal mode and the badge already use, instead of re-deriving segment count / colors / thickness / gap inline.
4. **Single source for allergen list and level counts**: `allergenListForIntegration` (editor) and `ringSegmentsForIntegration` / `numLevelsForIntegration` (`src/utils/level-counts.js`, shared with the rendering mixin). This corrects two latent level-count bugs the duplication hid: **Kleenex** reported 7 editor levels (native scale is 5) and the card editor's phrase reset reported 7 for **PLU** (native 4); both now match the ring geometry.
5. **`matchSensorByAllergenKey`**: the badge's single mode resolved `badge_single_allergen` by shotgunning four normalizers against `allergenReplaced`; now one shared resolver that reduces both sides to the canonical key (with a literal-match priority and typeguards). One place knows config-key -> sensor mapping; a new adapter's key style needs no badge-specific change.

## Verification

- `npm run test` green (29 files); the existing single-mode contract tests (SILAM `index`, PP `Björk`, DWD `gräser`, canonical key) pass unchanged, proving the matcher is equivalent to the old shotgun.
- New unit tests: `scaleRingLevel`, `level-counts`, `matchSensorByAllergenKey`, plus a non-string `badge_single_allergen` typeguard case.
- Production build clean. No config keys changed; no rendering change (ring segment counts unchanged). The only behavior change is the kleenex/plu editor level-count correction.