### PR TITLE
(editor) Share Translations & strings (locale + custom phrases) with the badge

### DIFF
--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2311,7 +2311,8 @@ export class PollenEditorBase extends LitElement {
           </ha-formfield>
           <ha-button
             outlined
-            @click=${() => this._resetPhrases(selectedLang)}
+            @click=${() =>
+              this._resetPhrases(this._selectedPhraseLang || selectedLang)}
           >
             ${this._t("phrases_apply")}
           </ha-button>
@@ -2325,7 +2326,7 @@ export class PollenEditorBase extends LitElement {
                   .value=${full[a] || ""}
                   @input=${(e) => {
                     const p = {
-                      ...(c.phrases || {}),
+                      ...phrases,
                       full: { ...full, [a]: e.target.value },
                     };
                     this._updateConfig("phrases", p);
@@ -2344,7 +2345,7 @@ export class PollenEditorBase extends LitElement {
                   .value=${short[a] || ""}
                   @input=${(e) => {
                     const p = {
-                      ...(c.phrases || {}),
+                      ...phrases,
                       short: { ...short, [a]: e.target.value },
                     };
                     this._updateConfig("phrases", p);
@@ -2367,7 +2368,7 @@ export class PollenEditorBase extends LitElement {
                           const lv = [...levels];
                           lv[i] = e.target.value;
                           this._updateConfig("phrases", {
-                            ...(c.phrases || {}),
+                            ...phrases,
                             levels: lv,
                           });
                         }}
@@ -2390,7 +2391,7 @@ export class PollenEditorBase extends LitElement {
                         @input=${(e) => {
                           const dd = { ...days, [i]: e.target.value };
                           this._updateConfig("phrases", {
-                            ...(c.phrases || {}),
+                            ...phrases,
                             days: dd,
                           });
                         }}
@@ -2406,7 +2407,7 @@ export class PollenEditorBase extends LitElement {
             .value=${phrases.no_information || ""}
             @input=${(e) =>
               this._updateConfig("phrases", {
-                ...(c.phrases || {}),
+                ...phrases,
                 no_information: e.target.value,
               })}
           ></ha-textfield>

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -323,12 +323,12 @@ export class PollenEditorBase extends LitElement {
     if (!this._hass || !this._config || this._config.date_locale != null) {
       return;
     }
-    const detected = detectLang(this._hass, null);
+    // Prefer HA's full locale tag (e.g. "sv-SE"); fall back to the bare
+    // detected language code ("sv"), which is a valid tag -- not a fabricated
+    // `${lang}-${LANG}` ("en-EN") that no locale actually uses.
     this._config = {
       ...this._config,
-      date_locale:
-        this._hass?.locale?.language ||
-        `${detected}-${detected.toUpperCase()}`,
+      date_locale: this._hass?.locale?.language || detectLang(this._hass, null),
     };
   }
 

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2273,9 +2273,12 @@ export class PollenEditorBase extends LitElement {
     const days = isObj(phrases.days) ? phrases.days : {};
     // Default the language selector from the config's date_locale (not just the
     // HA language) so an existing per-locale override is reflected before the
-    // user touches the dropdown.
+    // user touches the dropdown. Guard date_locale to a string: detectLang
+    // calls .slice() on it, so a non-string YAML value would throw here.
+    const dateLocale =
+      typeof c.date_locale === "string" ? c.date_locale : undefined;
     const selectedLang =
-      this._selectedPhraseLang || detectLang(this._hass, c.date_locale);
+      this._selectedPhraseLang || detectLang(this._hass, dateLocale);
     return html`
       <!-- Translations & strings -->
       <details>

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -309,6 +309,24 @@ export class PollenEditorBase extends LitElement {
   }
 
   /**
+   * Prefill date_locale in the rendered config from the current HA locale when
+   * the user hasn't set one, so the editor's locale field shows the active
+   * locale instead of being blank (matching the card editor). Display-only: it
+   * mutates the render config, not _userConfig, so an untouched value is not
+   * baked into the saved YAML. Call from a subclass `set hass`.
+   */
+  _autofillDateLocale() {
+    if (!this._config || this._config.date_locale) return;
+    const detected = detectLang(this._hass, null);
+    this._config = {
+      ...this._config,
+      date_locale:
+        this._hass?.locale?.language ||
+        `${detected}-${detected.toUpperCase()}`,
+    };
+  }
+
+  /**
    * Returns the allergen list for the current integration.
    * Equivalent to the render()-local `allergens` variable in the card editor.
    */

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2259,11 +2259,19 @@ export class PollenEditorBase extends LitElement {
     const c = this._editorConfig();
     const allergens = this._currentAllergens();
     const numLevels = this._currentNumLevels();
-    const phrases = c.phrases || {};
-    const full = phrases.full || {};
-    const short = phrases.short || {};
-    const levels = phrases.levels || [];
-    const days = phrases.days || {};
+    // Type-guard every phrases subfield: YAML can supply a wrong type (e.g.
+    // phrases.levels as an object), which would otherwise break rendering.
+    const isObj = (v) => v != null && typeof v === "object" && !Array.isArray(v);
+    const phrases = isObj(c.phrases) ? c.phrases : {};
+    const full = isObj(phrases.full) ? phrases.full : {};
+    const short = isObj(phrases.short) ? phrases.short : {};
+    const levels = Array.isArray(phrases.levels) ? phrases.levels : [];
+    const days = isObj(phrases.days) ? phrases.days : {};
+    // Default the language selector from the config's date_locale (not just the
+    // HA language) so an existing per-locale override is reflected before the
+    // user touches the dropdown.
+    const selectedLang =
+      this._selectedPhraseLang || detectLang(this._hass, c.date_locale);
     return html`
       <!-- Translations & strings -->
       <details>
@@ -2294,7 +2302,7 @@ export class PollenEditorBase extends LitElement {
                   })),
                 },
               }}
-              .value=${this._selectedPhraseLang || this._lang}
+              .value=${selectedLang}
               @value-changed=${(e) => {
                 const v = e.detail?.value;
                 if (v !== undefined) this._selectedPhraseLang = v;
@@ -2303,8 +2311,7 @@ export class PollenEditorBase extends LitElement {
           </ha-formfield>
           <ha-button
             outlined
-            @click=${() =>
-              this._resetPhrases(this._selectedPhraseLang || this._lang)}
+            @click=${() => this._resetPhrases(selectedLang)}
           >
             ${this._t("phrases_apply")}
           </ha-button>

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -36,7 +36,7 @@
 //     the caller must maintain that flag based on the returned state.
 
 import { LitElement, html } from "lit";
-import { t, detectLang } from "../i18n.js";
+import { t, detectLang, SUPPORTED_LOCALES } from "../i18n.js";
 import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
 import {
@@ -2183,6 +2183,227 @@ export class PollenEditorBase extends LitElement {
               </ha-formfield>
             `
           : ""}
+      </details>
+    `;
+  }
+
+  // Presentation hooks for the phrases section: subclasses that do not display
+  // level names or day labels (e.g. the badge) override these to false.
+  _showPhraseLevels() {
+    return true;
+  }
+
+  _showPhraseDays() {
+    return true;
+  }
+
+  /**
+   * Seed config.phrases with the localized default names for the chosen
+   * language (the "Apply translations" action), and set date_locale to it.
+   * Shared by the card and badge editors. Uses _currentAllergens() so the
+   * GPL/GP installed plants are included via the editor's discovered list.
+   */
+  _resetPhrases(lang) {
+    if (this.debug) console.debug("[Editor] resetPhrases - lang:", lang);
+    this._updateConfig("date_locale", lang);
+
+    const integration = this._config?.integration;
+    const rawKeys = this._currentAllergens();
+
+    const full = {};
+    const short = {};
+    rawKeys.forEach((raw) => {
+      const normKey = normalize(raw);
+      const canonKey = toCanonicalAllergenKey(normKey);
+      // SILAM's aggregate uses the user-facing 'index' name, not 'allergy_risk'.
+      const transKey = normKey === "index" ? "index" : canonKey;
+      full[raw] = t(`editor.phrases_full.${transKey}`, lang);
+      short[raw] = t(`editor.phrases_short.${transKey}`, lang);
+    });
+
+    const numLevels = this._currentNumLevels();
+    // 5-level integrations (MSW, PEU, Kleenex) use the scale-specific severity
+    // labels rather than the first five of the 7-level palette.
+    const levelKeyPrefix =
+      integration === "msw" ||
+      integration === "peu" ||
+      integration === "kleenex"
+        ? "editor.phrases_levels5"
+        : "editor.phrases_levels";
+    const levels = Array.from({ length: numLevels }, (_, i) =>
+      t(`${levelKeyPrefix}.${i}`, lang),
+    );
+
+    const days = {
+      0: t(`editor.phrases_days.0`, lang),
+      1: t(`editor.phrases_days.1`, lang),
+      2: t(`editor.phrases_days.2`, lang),
+    };
+
+    this._updateConfig("phrases", {
+      full,
+      short,
+      levels,
+      days,
+      no_information: t("editor.no_information", lang),
+    });
+  }
+
+  /**
+   * The "Translations & strings" section (locale override + custom phrases),
+   * shared by the card and badge editors. Level-name and day-label subsections
+   * are gated by _showPhraseLevels() / _showPhraseDays() so the badge (which
+   * renders neither) can hide them. Null-safe on config.phrases.
+   */
+  _renderPhrasesSection() {
+    const c = this._editorConfig();
+    const allergens = this._currentAllergens();
+    const numLevels = this._currentNumLevels();
+    const phrases = c.phrases || {};
+    const full = phrases.full || {};
+    const short = phrases.short || {};
+    const levels = phrases.levels || [];
+    const days = phrases.days || {};
+    return html`
+      <!-- Translations & strings -->
+      <details>
+        <summary>${this._t("summary_translation_and_strings")}</summary>
+        <div class="section-helper">
+          ${this._t("helper_translation_and_strings")}
+        </div>
+        <ha-formfield label="${this._t("locale")}">
+          <ha-textfield
+            .value=${c.date_locale || ""}
+            @input=${(e) => this._updateConfig("date_locale", e.target.value)}
+          ></ha-textfield>
+        </ha-formfield>
+        <h3>${this._t("phrases")}</h3>
+        <div class="preset-buttons">
+          <ha-formfield label="${this._t("phrases_translate_all")}">
+            <ha-selector
+              .hass=${this._hass}
+              .selector=${{
+                select: {
+                  mode: "dropdown",
+                  options: SUPPORTED_LOCALES.map((code) => ({
+                    value: code,
+                    label:
+                      new Intl.DisplayNames([this._lang], {
+                        type: "language",
+                      }).of(code) || code,
+                  })),
+                },
+              }}
+              .value=${this._selectedPhraseLang || this._lang}
+              @value-changed=${(e) => {
+                const v = e.detail?.value;
+                if (v !== undefined) this._selectedPhraseLang = v;
+              }}
+            ></ha-selector>
+          </ha-formfield>
+          <ha-button
+            outlined
+            @click=${() =>
+              this._resetPhrases(this._selectedPhraseLang || this._lang)}
+          >
+            ${this._t("phrases_apply")}
+          </ha-button>
+        </div>
+        <details>
+          <summary>${this._t("phrases_full")}</summary>
+          ${allergens.map(
+            (a) => html`
+              <ha-formfield .label=${a}>
+                <ha-textfield
+                  .value=${full[a] || ""}
+                  @input=${(e) => {
+                    const p = {
+                      ...(c.phrases || {}),
+                      full: { ...full, [a]: e.target.value },
+                    };
+                    this._updateConfig("phrases", p);
+                  }}
+                ></ha-textfield>
+              </ha-formfield>
+            `,
+          )}
+        </details>
+        <details>
+          <summary>${this._t("phrases_short")}</summary>
+          ${allergens.map(
+            (a) => html`
+              <ha-formfield .label=${a}>
+                <ha-textfield
+                  .value=${short[a] || ""}
+                  @input=${(e) => {
+                    const p = {
+                      ...(c.phrases || {}),
+                      short: { ...short, [a]: e.target.value },
+                    };
+                    this._updateConfig("phrases", p);
+                  }}
+                ></ha-textfield>
+              </ha-formfield>
+            `,
+          )}
+        </details>
+        ${this._showPhraseLevels()
+          ? html`
+              <details>
+                <summary>${this._t("phrases_levels")}</summary>
+                ${Array.from({ length: numLevels }, (_, i) => i).map(
+                  (i) => html`
+                    <ha-formfield .label=${i}>
+                      <ha-textfield
+                        .value=${levels[i] || ""}
+                        @input=${(e) => {
+                          const lv = [...levels];
+                          lv[i] = e.target.value;
+                          this._updateConfig("phrases", {
+                            ...(c.phrases || {}),
+                            levels: lv,
+                          });
+                        }}
+                      ></ha-textfield>
+                    </ha-formfield>
+                  `,
+                )}
+              </details>
+            `
+          : ""}
+        ${this._showPhraseDays()
+          ? html`
+              <details>
+                <summary>${this._t("phrases_days")}</summary>
+                ${[0, 1, 2].map(
+                  (i) => html`
+                    <ha-formfield .label=${i}>
+                      <ha-textfield
+                        .value=${days[i] || ""}
+                        @input=${(e) => {
+                          const dd = { ...days, [i]: e.target.value };
+                          this._updateConfig("phrases", {
+                            ...(c.phrases || {}),
+                            days: dd,
+                          });
+                        }}
+                      ></ha-textfield>
+                    </ha-formfield>
+                  `,
+                )}
+              </details>
+            `
+          : ""}
+        <ha-formfield label="${this._t("no_information")}">
+          <ha-textfield
+            .value=${phrases.no_information || ""}
+            @input=${(e) =>
+              this._updateConfig("phrases", {
+                ...(c.phrases || {}),
+                no_information: e.target.value,
+              })}
+          ></ha-textfield>
+        </ha-formfield>
       </details>
     `;
   }

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -316,7 +316,13 @@ export class PollenEditorBase extends LitElement {
    * baked into the saved YAML. Call from a subclass `set hass`.
    */
   _autofillDateLocale() {
-    if (!this._config || this._config.date_locale) return;
+    // Require hass (detectLang needs it; without it we'd lock to "en"), require
+    // a built _config, and only fill when date_locale is genuinely unset
+    // (undefined/null) -- an explicit "" is user intent (autodetect) and is
+    // left alone. Safe to call from both setConfig and set hass, in any order.
+    if (!this._hass || !this._config || this._config.date_locale != null) {
+      return;
+    }
     const detected = detectLang(this._hass, null);
     this._config = {
       ...this._config,
@@ -2306,7 +2312,7 @@ export class PollenEditorBase extends LitElement {
         </div>
         <ha-formfield label="${this._t("locale")}">
           <ha-textfield
-            .value=${c.date_locale || ""}
+            .value=${dateLocale || ""}
             @input=${(e) => this._updateConfig("date_locale", e.target.value)}
           ></ha-textfield>
         </ha-formfield>

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2189,6 +2189,10 @@ export class PollenEditorBase extends LitElement {
 
   // Presentation hooks for the phrases section: subclasses that do not display
   // level names or day labels (e.g. the badge) override these to false.
+  _showPhraseShort() {
+    return true;
+  }
+
   _showPhraseLevels() {
     return true;
   }
@@ -2336,25 +2340,29 @@ export class PollenEditorBase extends LitElement {
             `,
           )}
         </details>
-        <details>
-          <summary>${this._t("phrases_short")}</summary>
-          ${allergens.map(
-            (a) => html`
-              <ha-formfield .label=${a}>
-                <ha-textfield
-                  .value=${short[a] || ""}
-                  @input=${(e) => {
-                    const p = {
-                      ...phrases,
-                      short: { ...short, [a]: e.target.value },
-                    };
-                    this._updateConfig("phrases", p);
-                  }}
-                ></ha-textfield>
-              </ha-formfield>
-            `,
-          )}
-        </details>
+        ${this._showPhraseShort()
+          ? html`
+              <details>
+                <summary>${this._t("phrases_short")}</summary>
+                ${allergens.map(
+                  (a) => html`
+                    <ha-formfield .label=${a}>
+                      <ha-textfield
+                        .value=${short[a] || ""}
+                        @input=${(e) => {
+                          const p = {
+                            ...phrases,
+                            short: { ...short, [a]: e.target.value },
+                          };
+                          this._updateConfig("phrases", p);
+                        }}
+                      ></ha-textfield>
+                    </ha-formfield>
+                  `,
+                )}
+              </details>
+            `
+          : ""}
         ${this._showPhraseLevels()
           ? html`
               <details>

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -86,6 +86,11 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     // config (user-origin keys) that we dispatch back, so stub defaults are
     // never baked into the saved YAML. Mirrors the card editor.
     this._userConfig = { ...config };
+
+    // Seed the phrases language selector from the config's locale override
+    // (mirrors the card editor), so an existing date_locale is reflected even
+    // before hass arrives.
+    this._selectedPhraseLang = detectLang(this._hass, config.date_locale);
   }
 
   // ------------------------------------------------------------------ //

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -106,9 +106,11 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
    */
   set hass(hass) {
     this._hass = hass;
-    // _selectedPhraseLang holds only the user's explicit dropdown pick; the
-    // shared phrases section derives the shown language from it or from
-    // detectLang(hass, date_locale) at render time, so nothing is seeded here.
+    // Prefill the locale field from the current HA locale (display-only),
+    // matching the card editor, so it isn't left blank. _selectedPhraseLang
+    // holds only the user's explicit dropdown pick; the shared phrases section
+    // derives the shown language at render time, so it is not seeded here.
+    this._autofillDateLocale();
     this.requestUpdate();
   }
 

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -85,11 +85,14 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     // config (user-origin keys) that we dispatch back, so stub defaults are
     // never baked into the saved YAML. Mirrors the card editor.
     this._userConfig = { ...config };
-    // _selectedPhraseLang is intentionally NOT seeded here. It holds only the
-    // user's explicit dropdown pick; the shared phrases section derives the
-    // shown/applied language at render time from it or from
-    // detectLang(hass, date_locale), which honours an existing date_locale
-    // override regardless of whether hass or setConfig arrived first.
+
+    // Prefill the locale field from the current HA locale (display-only),
+    // matching the card. HA sets `hass` before `setConfig` for the badge
+    // editor, so the set-hass call alone runs while _config is still unset;
+    // call it here too (the helper no-ops without hass), so whichever arrives
+    // last triggers the prefill. _selectedPhraseLang is intentionally NOT
+    // seeded; the shared phrases section derives the shown language at render.
+    this._autofillDateLocale();
   }
 
   // ------------------------------------------------------------------ //

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -20,6 +20,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     return {
       _config: { type: Object },
       hass: { type: Object },
+      _selectedPhraseLang: { state: true },
     };
   }
 
@@ -217,6 +218,17 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
   // a false affordance here — hide it. The ring sub-fields (size ratio, colour)
   // remain available for tuning the icon_in_ring visual mode.
   _showIconInRingToggle() {
+    return false;
+  }
+
+  // The badge shows the allergen name only (no level text, no day columns), so
+  // hide the level-name and day-label customization in the phrases section. The
+  // language selector and full/short allergen names remain.
+  _showPhraseLevels() {
+    return false;
+  }
+
+  _showPhraseDays() {
     return false;
   }
 
@@ -426,6 +438,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         ${this._renderAllergenIconsSection()}
         ${this._renderLevelCirclesSection()}
         ${this._renderIconInRingSection()}
+        ${this._renderPhrasesSection()}
       </div>
     `;
   }

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -85,11 +85,11 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     // config (user-origin keys) that we dispatch back, so stub defaults are
     // never baked into the saved YAML. Mirrors the card editor.
     this._userConfig = { ...config };
-    // Note: _selectedPhraseLang is NOT seeded here. Seeding it before `hass`
-    // arrives would lock it to "en" (detectLang(null, undefined)), and the
-    // `set hass` guard would then never refresh it. The set hass seeding plus
-    // the render-time fallback (detectLang(hass, c.date_locale), which honours
-    // date_locale even without hass) cover all cases.
+    // _selectedPhraseLang is intentionally NOT seeded here. It holds only the
+    // user's explicit dropdown pick; the shared phrases section derives the
+    // shown/applied language at render time from it or from
+    // detectLang(hass, date_locale), which honours an existing date_locale
+    // override regardless of whether hass or setConfig arrived first.
   }
 
   // ------------------------------------------------------------------ //

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -86,11 +86,11 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     // config (user-origin keys) that we dispatch back, so stub defaults are
     // never baked into the saved YAML. Mirrors the card editor.
     this._userConfig = { ...config };
-
-    // Seed the phrases language selector from the config's locale override
-    // (mirrors the card editor), so an existing date_locale is reflected even
-    // before hass arrives.
-    this._selectedPhraseLang = detectLang(this._hass, config.date_locale);
+    // Note: _selectedPhraseLang is NOT seeded here. Seeding it before `hass`
+    // arrives would lock it to "en" (detectLang(null, undefined)), and the
+    // `set hass` guard would then never refresh it. The set hass seeding plus
+    // the render-time fallback (detectLang(hass, c.date_locale), which honours
+    // date_locale even without hass) cover all cases.
   }
 
   // ------------------------------------------------------------------ //
@@ -227,8 +227,14 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
   }
 
   // The badge shows the allergen name only (no level text, no day columns), so
-  // hide the level-name and day-label customization in the phrases section. The
-  // language selector and full/short allergen names remain.
+  // hide the level-name and day-label customization. It also can't enable
+  // allergens_abbreviated (that toggle is card-only), so allergenShort always
+  // equals the full name -- the short-name fields would never affect the badge,
+  // so hide them too. Only the language selector + full allergen names remain.
+  _showPhraseShort() {
+    return false;
+  }
+
   _showPhraseLevels() {
     return false;
   }

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -4,7 +4,6 @@
 // Extends PollenEditorBase to share integration/location and allergen sections.
 
 import { html, css } from "lit";
-import { detectLang } from "./i18n.js";
 import { getStubConfig } from "./adapter-registry.js";
 import { PollenEditorBase, deepMerge } from "./editor/base.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
@@ -107,10 +106,9 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
    */
   set hass(hass) {
     this._hass = hass;
-    // Update selected phrase language on first hass arrival
-    if (!this._selectedPhraseLang) {
-      this._selectedPhraseLang = detectLang(hass, this._config?.date_locale);
-    }
+    // _selectedPhraseLang holds only the user's explicit dropdown pick; the
+    // shared phrases section derives the shown language from it or from
+    // detectLang(hass, date_locale) at render time, so nothing is seeded here.
     this.requestUpdate();
   }
 
@@ -227,12 +225,13 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
   }
 
   // The badge shows the allergen name only (no level text, no day columns), so
-  // hide the level-name and day-label customization. It also can't enable
-  // allergens_abbreviated (that toggle is card-only), so allergenShort always
-  // equals the full name -- the short-name fields would never affect the badge,
-  // so hide them too. Only the language selector + full allergen names remain.
+  // hide the level-name and day-label customization. The badge label uses
+  // allergenShort, which equals the full name UNLESS allergens_abbreviated is
+  // set; the badge editor has no abbreviated toggle, but a YAML config can set
+  // it, in which case the short names DO show -- so expose the short-name fields
+  // only when allergens_abbreviated is enabled.
   _showPhraseShort() {
-    return false;
+    return this._editorConfig()?.allergens_abbreviated === true;
   }
 
   _showPhraseLevels() {

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -85,8 +85,9 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     this.installedPpLocations = [];
     this.installedDwdLocations = [];
     this._initDone = false;
-    // Ensure phrase language defaults to a sensible locale
-    this._selectedPhraseLang = detectLang();
+    // _selectedPhraseLang holds only the user's explicit dropdown choice; the
+    // displayed/applied language is derived at render time from it or from
+    // detectLang(hass, date_locale), so it is never auto-seeded here.
     this._allergensExplicit = false;
     this._origAllergensSet = false;
     this._userAllergens = null;
@@ -117,8 +118,6 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         config.icon_in_ring === true &&
         incomingThickness === ICON_IN_RING_DEFAULT_THICKNESS;
       if (config.phrases) this._userConfig.phrases = config.phrases;
-      // Default language for phrases uses locale or falls back to Home Assistant
-      this._selectedPhraseLang = detectLang(this._hass, config.date_locale);
 
       // 1. Identify stub values and clone incoming config
       // Normalize integration to lowercase (user may type "SILAM" in YAML)
@@ -636,10 +635,6 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     if (this._hass === hass) return; // Avoid unnecessary work
     this._hass = hass;
     const explicit = this._integrationExplicit;
-    if (!this._initDone) {
-      // Default dropdown language mirrors locale or Home Assistant setting
-      this._selectedPhraseLang = detectLang(hass, this._config.date_locale);
-    }
 
     // Hitta alla sensor-ID för PP, DWD, PEU, SILAM, PLU
     // Build set of PLU allergen slugs for more specific detection

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1,18 +1,15 @@
 // src/pollenprognos-editor.js
 import { html, css } from "lit";
-import { t, detectLang, SUPPORTED_LOCALES } from "./i18n.js";
+import { detectLang } from "./i18n.js";
 import { deepEqual } from "./utils/confcompare.js";
 import {
   LEVELS_DEFAULTS,
   ICON_IN_RING_DEFAULT_THICKNESS,
 } from "./utils/levels-defaults.js";
 import { COSMETIC_FIELDS } from "./constants.js";
-import { normalize } from "./utils/normalize.js";
 
 // Shared editor base (deepMerge, section methods, helpers)
 import { PollenEditorBase, deepMerge } from "./editor/base.js";
-import { allergenListForIntegration } from "./editor/integration-allergens.js";
-import { numLevelsForIntegration } from "./utils/level-counts.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
@@ -33,7 +30,6 @@ import { findLocationBySlug } from "./utils/adapter-helpers.js";
 import {
   PP_POSSIBLE_CITIES,
   DWD_REGIONS,
-  toCanonicalAllergenKey,
 } from "./constants.js";
 
 import silamAllergenMap from "./adapters/silam_allergen_map.json" assert { type: "json" };
@@ -47,79 +43,6 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     super._resetAll();
   }
 
-  _resetPhrases(lang) {
-    if (this.debug) console.debug("[Editor] resetPhrases – lang:", lang);
-
-    // Sätt alltid date_locale precis efter valt språk
-    this._updateConfig("date_locale", lang);
-
-    // Välj rätt lista med raw-allergener
-    // Discover GPL/GP allergens if applicable
-    let gplDiscoveredPlants = [];
-    if (this._config.integration === "gpl" && this._hass) {
-      gplDiscoveredPlants = discoverGplAllergens(this._hass, this._config.location, false);
-      gplDiscoveredPlants = gplDiscoveredPlants.filter((k) => !GPL_BASE_ALLERGENS.includes(k));
-    }
-    let gpDiscoveredPlants = [];
-    if (this._config.integration === "gp" && this._hass) {
-      gpDiscoveredPlants = discoverGpAllergens(this._hass, this._config.location, false);
-      gpDiscoveredPlants = gpDiscoveredPlants.filter((k) => !GP_BASE_ALLERGENS.includes(k));
-    }
-
-    const rawKeys = allergenListForIntegration(this._config.integration, {
-      installedGplPlants: gplDiscoveredPlants,
-      installedGpPlants: gpDiscoveredPlants,
-    });
-
-    // Börja bygga nytt phrases-objekt
-    const full = {};
-    const short = {};
-
-    // Använd canonical nyckel för lookup i locale-filerna
-    rawKeys.forEach((raw) => {
-      const normKey = normalize(raw); // ex 'alm' eller 'erle'
-      const canonKey = toCanonicalAllergenKey(normKey); // t.ex. 'alder'
-      // Use the SILAM-specific name 'index' instead of 'allergy_risk'
-      const transKey = normKey === "index" ? "index" : canonKey;
-      full[raw] = t(`editor.phrases_full.${transKey}`, lang);
-      short[raw] = t(`editor.phrases_short.${transKey}`, lang);
-    });
-
-    // Native level count (incl. level 0). Shared with the rendering mixin and
-    // the editor base via numLevelsForIntegration so the count cannot drift.
-    const numLevels = numLevelsForIntegration(this._config.integration);
-
-    // Use scale-specific phrase defaults so 5-level integrations (MSW, PEU,
-    // Kleenex) surface semantically-correct severity labels in the editor
-    // instead of borrowing the first five strings from the wider 7-level
-    // palette. Other scales fall back to the legacy editor.phrases_levels.0..6
-    // keys until per-scale entries are added for them.
-    const levelKeyPrefix =
-      this._config.integration === "msw" ||
-      this._config.integration === "peu" ||
-      this._config.integration === "kleenex"
-        ? "editor.phrases_levels5"
-        : "editor.phrases_levels";
-    const levels = Array.from({ length: numLevels }, (_, i) =>
-      t(`${levelKeyPrefix}.${i}`, lang),
-    );
-
-    const days = {
-      0: t(`editor.phrases_days.0`, lang),
-      1: t(`editor.phrases_days.1`, lang),
-      2: t(`editor.phrases_days.2`, lang),
-    };
-    const noInformation = t("editor.no_information", lang);
-
-    // Tillämpa allt på config
-    this._updateConfig("phrases", {
-      full,
-      short,
-      levels,
-      days,
-      no_information: noInformation,
-    });
-  }
 
   static get properties() {
     return {
@@ -1827,131 +1750,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         <!-- §8 Icon in ring -->
         ${this._renderIconInRingSection()}
 
-        <!-- §9 Translations & strings -->
-        <details>
-          <summary>${this._t("summary_translation_and_strings")}</summary>
-          <div class="section-helper">${this._t("helper_translation_and_strings")}</div>
-          <ha-formfield label="${this._t("locale")}">
-            <ha-textfield
-              .value=${c.date_locale}
-              @input=${(e) => this._updateConfig("date_locale", e.target.value)}
-            ></ha-textfield>
-          </ha-formfield>
-          <h3>${this._t("phrases")}</h3>
-          <div class="preset-buttons">
-            <ha-formfield label="${this._t("phrases_translate_all")}">
-              <ha-selector
-                .hass=${this._hass}
-                .selector=${{
-                  select: {
-                    mode: "dropdown",
-                    options: SUPPORTED_LOCALES.map((code) => ({
-                      value: code,
-                      label:
-                        new Intl.DisplayNames([this._lang], {
-                          type: "language",
-                        }).of(code) || code,
-                    })),
-                  },
-                }}
-                .value=${this._selectedPhraseLang}
-                @value-changed=${(e) => {
-                  const v = e.detail?.value;
-                  if (v !== undefined) this._selectedPhraseLang = v;
-                }}
-              ></ha-selector>
-            </ha-formfield>
-            <!-- Use Home Assistant's button with outlined style for clarity -->
-            <ha-button
-              outlined
-              @click=${() => this._resetPhrases(this._selectedPhraseLang)}
-            >
-              ${this._t("phrases_apply")}
-            </ha-button>
-          </div>
-          <details>
-            <summary>${this._t("phrases_full")}</summary>
-            ${allergens.map(
-              (a) => html`
-                <ha-formfield .label=${a}>
-                  <ha-textfield
-                    .value=${c.phrases.full[a] || ""}
-                    @input=${(e) => {
-                      const p = {
-                        ...c.phrases,
-                        full: { ...c.phrases.full, [a]: e.target.value },
-                      };
-                      this._updateConfig("phrases", p);
-                    }}
-                  ></ha-textfield>
-                </ha-formfield>
-              `,
-            )}
-          </details>
-          <details>
-            <summary>${this._t("phrases_short")}</summary>
-            ${allergens.map(
-              (a) => html`
-                <ha-formfield .label=${a}>
-                  <ha-textfield
-                    .value=${c.phrases.short[a] || ""}
-                    @input=${(e) => {
-                      const p = {
-                        ...c.phrases,
-                        short: { ...c.phrases.short, [a]: e.target.value },
-                      };
-                      this._updateConfig("phrases", p);
-                    }}
-                  ></ha-textfield>
-                </ha-formfield>
-              `,
-            )}
-          </details>
-          <details>
-            <summary>${this._t("phrases_levels")}</summary>
-            ${Array.from({ length: numLevels }, (_, i) => i).map(
-              (i) => html`
-                <ha-formfield .label=${i}>
-                  <ha-textfield
-                    .value=${c.phrases.levels[i] || ""}
-                    @input=${(e) => {
-                      const lv = [...c.phrases.levels];
-                      lv[i] = e.target.value;
-                      const p = { ...c.phrases, levels: lv };
-                      this._updateConfig("phrases", p);
-                    }}
-                  ></ha-textfield>
-                </ha-formfield>
-              `,
-            )}
-          </details>
-          <details>
-            <summary>${this._t("phrases_days")}</summary>
-            ${[0, 1, 2].map(
-              (i) => html`
-                <ha-formfield .label=${i}>
-                  <ha-textfield
-                    .value=${c.phrases.days[i] || ""}
-                    @input=${(e) => {
-                      const dd = { ...c.phrases.days, [i]: e.target.value };
-                      this._updateConfig("phrases", { ...c.phrases, days: dd });
-                    }}
-                  ></ha-textfield>
-                </ha-formfield>
-              `,
-            )}
-          </details>
-          <ha-formfield label="${this._t("no_information")}">
-            <ha-textfield
-              .value=${c.phrases.no_information || ""}
-              @input=${(e) =>
-                this._updateConfig("phrases", {
-                  ...c.phrases,
-                  no_information: e.target.value,
-                })}
-            ></ha-textfield>
-          </ha-formfield>
-        </details>
+        ${this._renderPhrasesSection()}
 
         <!-- §10 Card interactivity -->
         <details>


### PR DESCRIPTION
The badge shipped without the localization/customization the card has: no way to override the display language per locale, nor to customize allergen names. Bring it to the badge via the shared editor base, following the standing 'maximum shared code, minimum duplication' principle.

## What
- Move `_renderPhrasesSection()` + `_resetPhrases()` + `_selectedPhraseLang` from the card editor into the shared `PollenEditorBase`.
- Card editor delegates to the shared method (behaviour unchanged) and drops the now-unused imports.
- Badge editor renders the section, gating the level-name and day-label sub-blocks off via new `_showPhraseLevels()` / `_showPhraseDays()` hooks (the badge shows only the allergen name), so it exposes the **language selector + custom full/short allergen names**.
- The section is null-safe on `config.phrases`.

## Why no runtime change
Localization happens at fetch time: adapters read `config.phrases` + `config.date_locale` and bake localized `allergenCapitalized`/`allergenShort` into the sensor dict. The badge already passes its config to `fetchForecast` and auto-detects the HA locale, so once the editor writes `phrases`/`date_locale` the badge picks them up. No badge element change, no new i18n keys.

## Verification
- `npm run test` green (1130); `npm run build` clean.
- hass-test: the badge editor now shows Translations & strings; a badge with custom `phrases.full` shows the custom name; a badge with `date_locale: de` shows German allergen names.

Targeted for 3.3.0-beta2 (not cutting the beta yet).