### PR TITLE
Shared integration autodetect: bring the badge to card parity (#235)

### DIFF
--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -9,6 +9,12 @@ import { PollenEditorBase, deepMerge } from "./editor/base.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import { coerceBool } from "./utils/adapter-helpers.js";
 import { deepEqual } from "./utils/confcompare.js";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  detectedIntegrationIds,
+  autoSelectLocation,
+} from "./utils/autodetect.js";
 
 class PollenPrognosBadgeEditor extends PollenEditorBase {
   // ------------------------------------------------------------------ //
@@ -100,15 +106,28 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
   // ------------------------------------------------------------------ //
 
   /**
-   * Store hass so section methods (_renderIntegrationSection etc.) can
-   * read this._hass. For the badge MVP we don't run full integration
-   * auto-detection; _buildIntegrationOptions() falls back gracefully to
-   * the alphabetical list when _detectedIntegrations is empty.
+   * Store hass and run the same autodetection the card editor does, so the
+   * integration dropdown marks installed integrations, the location dropdown
+   * is populated, and a freshly added badge prefills the integration + first
+   * location of whatever is actually installed (issue #235). Detection is
+   * shared with the card via src/utils/autodetect.js.
    *
    * @param {object} hass
    */
   set hass(hass) {
+    const changed = this._hass !== hass;
     this._hass = hass;
+
+    if (this._config && changed) {
+      const detection = detectIntegrationStates(hass);
+      // Drives the integration dropdown's installed-first sort.
+      this._detectedIntegrations = detectedIntegrationIds(detection);
+      // Populate the location dropdown lists read by _renderIntegrationSection.
+      this._populateInstalledLocations(detection, hass);
+      // Prefill integration + first location when the user hasn't set them.
+      this._maybeAutofill(detection, hass);
+    }
+
     // Prefill the locale field from the current HA locale (display-only),
     // matching the card editor, so it isn't left blank. _selectedPhraseLang
     // holds only the user's explicit dropdown pick; the shared phrases section
@@ -119,6 +138,136 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
 
   get hass() {
     return this._hass;
+  }
+
+  // Integration -> the config key its location is stored under.
+  static get _LOCATION_KEYS() {
+    return { pp: "city", dwd: "region_id" };
+  }
+
+  _locationKeyFor(integration) {
+    return PollenPrognosBadgeEditor._LOCATION_KEYS[integration] || "location";
+  }
+
+  /**
+   * Build the installed-location lists the shared integration section reads
+   * (installedPpLocations, installedDwdLocations, ...). The badge is new, so
+   * there are no legacy slug configs to preserve: this is the discovery-first
+   * path only (the card editor keeps the richer legacy-compat variant). Lists
+   * are [key, label] pairs; the dropdown shows label, stores key.
+   *
+   * @param {ReturnType<typeof detectIntegrationStates>} detection
+   * @param {object} hass
+   */
+  _populateInstalledLocations(detection, hass) {
+    const toList = (discovery) =>
+      Array.from(discovery.locations.entries()).map(([key, loc]) => [
+        key,
+        loc.label,
+      ]);
+
+    // PP / DWD / PEU via memoized discovery getters.
+    const ppDiscovery = detection.getPpDiscovery();
+    this.installedPpLocations = ppDiscovery.locations.size
+      ? toList(ppDiscovery)
+      : Array.from(
+          new Set(
+            detection.states.pp.map((id) =>
+              id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
+            ),
+          ),
+        ).map((slug) => [slug, slug]);
+
+    const dwdDiscovery = detection.getDwdDiscovery();
+    this.installedDwdLocations = dwdDiscovery.locations.size
+      ? toList(dwdDiscovery)
+      : Array.from(
+          new Set(detection.states.dwd.map((id) => id.split("_").pop())),
+        )
+          .sort((a, b) => Number(a) - Number(b))
+          .map((id) => [id, id]);
+
+    const peuDiscovery = detection.getPeuDiscovery();
+    this.installedPeuLocations = peuDiscovery.locations.size
+      ? toList(peuDiscovery)
+      : Array.from(
+          new Set(
+            detection.states.peu
+              .map((eid) => hass.states[eid]?.attributes?.location_slug || null)
+              .filter(Boolean),
+          ),
+        ).map((slug) => [slug, slug]);
+
+    // SILAM / Atmo / GP via eager discovery; GPL / MSW via memoized getters.
+    this.installedSilamLocations = toList(detection.discovery.silam);
+    this.installedAtmoLocations = toList(detection.discovery.atmo);
+    this.installedGpLocations = toList(detection.discovery.gp);
+    this.installedGplLocations = toList(detection.getGplDiscovery());
+    this.installedMswLocations = toList(detection.getMswDiscovery());
+
+    // Kleenex has no discovery helper; derive slugs from the *_date sensors.
+    this.installedKleenexLocations = Array.from(
+      new Set(
+        detection.stateIds
+          .map((id) => {
+            const m =
+              typeof id === "string" &&
+              id.match(/^sensor\.kleenex_pollen_radar_(.+)_date$/);
+            return m ? m[1] : null;
+          })
+          .filter(Boolean),
+      ),
+    ).map((slug) => [slug, slug]);
+  }
+
+  /**
+   * Prefill the integration (when the user hasn't pinned one) and the first
+   * available location for the active integration (when none is set and not in
+   * manual mode), then dispatch config-changed once if anything changed. The
+   * diff-before-dispatch guard prevents an HA update loop on every hass tick.
+   *
+   * @param {ReturnType<typeof detectIntegrationStates>} detection
+   * @param {object} hass
+   */
+  _maybeAutofill(detection, hass) {
+    const userSetIntegration = Object.prototype.hasOwnProperty.call(
+      this._userConfig || {},
+      "integration",
+    );
+
+    const next = { ...this._config };
+
+    if (!userSetIntegration) {
+      const picked = pickIntegration(detection, { explicit: false });
+      if (picked && picked !== next.integration) {
+        next.integration = picked;
+      }
+    }
+
+    const integration = next.integration;
+    const locKey = this._locationKeyFor(integration);
+    const userSetLocation = Object.prototype.hasOwnProperty.call(
+      this._userConfig || {},
+      locKey,
+    );
+    if (!userSetLocation && next[locKey] !== "manual" && !next[locKey]) {
+      const sel = autoSelectLocation(integration, next, hass, detection);
+      if (sel) next[sel.key] = sel.value;
+    }
+
+    if (!deepEqual(this._config, next)) {
+      this._config = next;
+      this._userConfig = { ...this._userConfig };
+      if (!userSetIntegration) this._userConfig.integration = next.integration;
+      if (next[locKey] != null) this._userConfig[locKey] = next[locKey];
+      this.dispatchEvent(
+        new CustomEvent("config-changed", {
+          detail: { config: this._userConfig },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
   }
 
   // ------------------------------------------------------------------ //

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -15,6 +15,7 @@ import {
   detectedIntegrationIds,
   autoSelectLocation,
 } from "./utils/autodetect.js";
+import { extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 
 class PollenPrognosBadgeEditor extends PollenEditorBase {
   // ------------------------------------------------------------------ //
@@ -92,12 +93,17 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     // never baked into the saved YAML. Mirrors the card editor.
     this._userConfig = { ...config };
 
+    // HA sets `hass` before `setConfig` for the badge editor, so the set hass()
+    // autodetect was skipped while _config was still unset. Now that _config is
+    // initialized, run it here so a freshly added badge prefills the installed
+    // integration + first location and the dropdowns are populated.
+    if (this._hass) this._runAutodetect();
+
     // Prefill the locale field from the current HA locale (display-only),
-    // matching the card. HA sets `hass` before `setConfig` for the badge
-    // editor, so the set-hass call alone runs while _config is still unset;
-    // call it here too (the helper no-ops without hass), so whichever arrives
-    // last triggers the prefill. _selectedPhraseLang is intentionally NOT
-    // seeded; the shared phrases section derives the shown language at render.
+    // matching the card. The helper no-ops without hass, so whichever of
+    // hass/setConfig arrives last triggers the prefill. _selectedPhraseLang is
+    // intentionally NOT seeded; the shared phrases section derives the shown
+    // language at render time.
     this._autofillDateLocale();
   }
 
@@ -118,15 +124,10 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     const changed = this._hass !== hass;
     this._hass = hass;
 
-    if (this._config && changed) {
-      const detection = detectIntegrationStates(hass);
-      // Drives the integration dropdown's installed-first sort.
-      this._detectedIntegrations = detectedIntegrationIds(detection);
-      // Populate the location dropdown lists read by _renderIntegrationSection.
-      this._populateInstalledLocations(detection, hass);
-      // Prefill integration + first location when the user hasn't set them.
-      this._maybeAutofill(detection, hass);
-    }
+    // Only when _config is already initialized; if hass arrives first (the
+    // ordering HA uses for the badge editor), setConfig runs detection once it
+    // sets _config — see the _runAutodetect() call there.
+    if (this._config && changed) this._runAutodetect();
 
     // Prefill the locale field from the current HA locale (display-only),
     // matching the card editor, so it isn't left blank. _selectedPhraseLang
@@ -138,6 +139,20 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
 
   get hass() {
     return this._hass;
+  }
+
+  /**
+   * Run the shared autodetection: mark installed integrations for the dropdown
+   * sort, populate the location dropdown lists, and prefill integration + first
+   * location. Called from both set hass() and setConfig() because HA can set
+   * either first; needs both _hass and _config.
+   */
+  _runAutodetect() {
+    if (!this._hass || !this._config) return;
+    const detection = detectIntegrationStates(this._hass);
+    this._detectedIntegrations = detectedIntegrationIds(detection);
+    this._populateInstalledLocations(detection, this._hass);
+    this._maybeAutofill(detection, this._hass);
   }
 
   // Integration -> the config key its location is stored under.
@@ -172,9 +187,9 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       ? toList(ppDiscovery)
       : Array.from(
           new Set(
-            detection.states.pp.map((id) =>
-              id.slice("sensor.pollen_".length).replace(/_[^_]+$/, ""),
-            ),
+            detection.states.pp
+              .map((id) => extractPpCitySlugFromEntityId(id))
+              .filter(Boolean),
           ),
         ).map((slug) => [slug, slug]);
 

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -31,6 +31,13 @@ import {
 } from "./utils/levels-defaults.js";
 import { LevelCircleMixin } from "./rendering/level-circle-mixin.js";
 import { ringIconStyles } from "./rendering/ring-icon-styles.js";
+import { deepEqual } from "./utils/confcompare.js";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  autoSelectLocation,
+  normalizeIntegration,
+} from "./utils/autodetect.js";
 import silamAllergenMap from "./adapters/silam_allergen_map.json" assert { type: "json" };
 
 class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
@@ -86,10 +93,20 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
   /**
    * Default stub config surfaced in the HA badge picker.
    * No `type` key — HA badge convention differs from card convention.
+   *
+   * Autodetects the integration from hass (when HA provides it) so a freshly
+   * added badge shows real data instead of always defaulting to PollenPrognos.
+   * HA may call getStubConfig with no hass, so fall back to "pp" then.
    */
-  static getStubConfig(_hass, _entities, _entitiesFallback) {
+  static getStubConfig(hass, _entities, _entitiesFallback) {
+    let integration = "pp";
+    if (hass) {
+      integration =
+        pickIntegration(detectIntegrationStates(hass), { explicit: false }) ||
+        "pp";
+    }
     return {
-      integration: "pp",
+      integration,
       badge_content: "worst",
       icon_in_ring: true,
     };
@@ -100,10 +117,42 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
   // ---------------------------------------------------------------------- //
 
   setConfig(config) {
-    // Normalize integration: trim + lowercase if string.
-    let integration = config.integration;
-    if (integration && typeof integration === "string") {
-      integration = integration.trim().toLowerCase();
+    this._userConfig = { ...config };
+    // Whether the user pinned an integration. When they didn't, set hass()
+    // re-resolves integration + location from hass so a no-config badge shows
+    // real data (mirrors the card element).
+    this._integrationExplicit = Object.prototype.hasOwnProperty.call(
+      config,
+      "integration",
+    );
+    this.config = this._buildConfig(config, this._hass);
+
+    // Trigger a data fetch if hass is already available.
+    if (this._hass) {
+      this._fetchSensors(this._hass);
+    }
+  }
+
+  /**
+   * Build the badge's effective config from a raw user config and (optionally)
+   * hass. When the integration is not explicit and hass is available, the
+   * integration and its first location are autodetected (shared with the card
+   * via src/utils/autodetect.js). Stub defaults fill in the rest; badge_visual
+   * drives the engine flags. Pure aside from reading hass.
+   *
+   * @param {object} config  raw user config
+   * @param {object|null} hass
+   * @returns {object}
+   */
+  _buildConfig(config, hass) {
+    const explicit = Object.prototype.hasOwnProperty.call(config, "integration");
+    let integration = normalizeIntegration(config.integration);
+
+    // Autodetect integration when the user didn't pin one.
+    let detection = null;
+    if (!explicit && hass) {
+      detection = detectIntegrationStates(hass);
+      integration = pickIntegration(detection, { explicit: false }) || integration;
     }
 
     const stub = getStubConfig(integration) || getStubConfig("pp");
@@ -164,7 +213,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // Merge order: stub → badge-oriented defaults → user config, so user
     // always wins for plain keys. The badge-derived engine flags are applied
     // AFTER the spread so badge_visual stays the single source of truth.
-    this.config = {
+    const built = {
       ...stub,
       badge_content: "worst",
       badge_show_label: false,
@@ -190,12 +239,17 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       mode: "daily",
     };
 
-    this._userConfig = { ...config };
-
-    // Trigger a data fetch if hass is already available.
-    if (this._hass) {
-      this._fetchSensors(this._hass);
+    // Auto-select the first location for the detected integration when the
+    // user didn't set one (and isn't in manual mode). Reuses the detection
+    // computed above; the guard keeps an explicit "manual" / user value.
+    if (!explicit && hass && detection) {
+      const sel = autoSelectLocation(integration, built, hass, detection);
+      if (sel && built[sel.key] !== "manual" && !built[sel.key]) {
+        built[sel.key] = sel.value;
+      }
     }
+
+    return built;
   }
 
   // ---------------------------------------------------------------------- //
@@ -205,6 +259,13 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
   set hass(hass) {
     if (this._hass === hass) return;
     this._hass = hass;
+    // When the integration is not explicit, re-resolve integration + location
+    // from the new hass so a no-config badge (picker default) renders real
+    // data. Only reassign when something changed to avoid render churn.
+    if (this._userConfig && !this._integrationExplicit) {
+      const next = this._buildConfig(this._userConfig, hass);
+      if (!deepEqual(this.config, next)) this.config = next;
+    }
     this._fetchSensors(hass);
   }
 

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -94,22 +94,23 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
    * Default stub config surfaced in the HA badge picker.
    * No `type` key — HA badge convention differs from card convention.
    *
-   * Autodetects the integration from hass (when HA provides it) so a freshly
-   * added badge shows real data instead of always defaulting to PollenPrognos.
-   * HA may call getStubConfig with no hass, so fall back to "pp" then.
+   * When HA provides hass and an integration is detected, pin it so a freshly
+   * added badge shows real data. When hass is absent (the documented no-arg
+   * badge stub call) OR nothing is detected, OMIT `integration`: both the badge
+   * element and editor treat a present `integration` as a user pin via
+   * hasOwnProperty, so emitting a "pp" fallback here would wrongly suppress
+   * autodetect on a DWD/PEU-only install. Without it, autodetect runs once hass
+   * is available.
    */
   static getStubConfig(hass, _entities, _entitiesFallback) {
-    let integration = "pp";
+    const base = { badge_content: "worst", icon_in_ring: true };
     if (hass) {
-      integration =
-        pickIntegration(detectIntegrationStates(hass), { explicit: false }) ||
-        "pp";
+      const integration = pickIntegration(detectIntegrationStates(hass), {
+        explicit: false,
+      });
+      if (integration) return { integration, ...base };
     }
-    return {
-      integration,
-      badge_content: "worst",
-      icon_in_ring: true,
-    };
+    return base;
   }
 
   // ---------------------------------------------------------------------- //

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -17,21 +17,24 @@ import {
   resolveNumericValue,
 } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
-import { PLU_ALIAS_MAP } from "./adapters/plu.js";
-import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
-import { GPL_ATTRIBUTION, discoverGplSensors } from "./adapters/gpl/index.js";
-import { discoverGpSensors } from "./adapters/gp/index.js";
-import { discoverMswSensors } from "./adapters/msw.js";
-import { discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
-import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
-import { discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
+// Sensor detection / integration pick / location auto-select are shared with
+// the card editor and the badge via src/utils/autodetect.js. The adapter
+// imports kept below are the ones still used by the header label-resolution
+// block in set hass() (slug extractors + location resolvers).
+import { findAtmoLocationBySlug } from "./adapters/atmo.js";
+import { extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
+import { extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import {
   findSilamWeatherEntity,
-  discoverSilamSensors,
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
 import { deepEqual } from "./utils/confcompare.js";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  autoSelectLocation,
+} from "./utils/autodetect.js";
 import {
   DWD_REGIONS,
   PP_POSSIBLE_CITIES,
@@ -599,225 +602,37 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     if (this.debug)
       console.debug("[Card] set hass called; explicit:", explicit);
 
-    // Sensordetektion
-    // Build set of PLU allergen slugs for more specific detection
-    const pluAllergenSlugs = new Set(
-      Object.values(PLU_ALIAS_MAP).flat()
-    );
-
-    const ppStates = Object.keys(hass.states).filter(
-      (id) => {
-        if (typeof id !== "string") return false;
-        if (!id.startsWith("sensor.pollen_")) return false;
-        if (id.startsWith("sensor.pollenflug_")) return false;
-        // Exclude MSW (hass-swissweather) entities: sensor.pollen_<allergen>_level_at_<station>
-        if (id.includes("_level_at_")) return false;
-
-        // Match both manual mode (sensor.pollen_<allergen>) and city mode (sensor.pollen_<allergen>_<city>)
-        const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
-        if (!match) return false;
-
-        const allergenSlug = match[1];
-        // Exclude known PLU allergens to avoid misclassification
-        // PLU uses sensor.pollen_<allergen> pattern with specific allergen list
-        // PP manual mode also uses sensor.pollen_<allergen> but with different allergens
-        if (!match[2] && pluAllergenSlugs.has(allergenSlug)) {
-          // Single underscore AND known PLU allergen → likely PLU, not PP
-          return false;
-        }
-
-        return true;
+    // Sensordetektion — shared autodetect (see src/utils/autodetect.js).
+    // Destructure local aliases with the same names the header block below
+    // already uses, so only the scan/pick/location logic moves to the shared
+    // module while the rest of set hass() is untouched. The lazy discovery
+    // getters preserve the per-tick discovery call count on large installs.
+    const detection = detectIntegrationStates(hass, { debug: this.debug });
+    // peuStates + the discovery objects/getters below are consumed by the
+    // header label-resolution block further down; the per-integration state
+    // lists used only for the pick/location are handled inside the shared
+    // module, so they are not destructured here.
+    const {
+      states: { peu: peuStates },
+      discovery: {
+        silam: silamDiscovery,
+        atmo: atmoDiscovery,
+        gp: gpDiscovery,
       },
-    );
-    // DWD: match the integration's pollenflug_<allergen>_<region> segment
-    // whether or not HA has prepended a device-name slug (#217).
-    const dwdStates = Object.keys(hass.states).filter(
-      (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
-    );
-    const peuStates = Object.keys(hass.states).filter(
-      (id) =>
-        typeof id === "string" && id.startsWith("sensor.polleninformation_"),
-    );
-    // SILAM: primary via hass.entities, fallback via regex
-    const silamDiscovery = discoverSilamSensors(hass, this.debug);
+      getPpDiscovery,
+      getDwdDiscovery,
+      getPeuDiscovery,
+      getGplDiscovery,
+      getMswDiscovery,
+    } = detection;
     this._silamDiscovery = silamDiscovery;
-    let silamStates = [];
-    if (silamDiscovery.locations.size > 0) {
-      for (const [, loc] of silamDiscovery.locations) {
-        for (const eid of loc.sensors.values()) {
-          silamStates.push(eid);
-        }
-      }
-    }
-    if (!silamStates.length) {
-      silamStates = Object.keys(hass.states).filter(
-        (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-      );
-    }
-    const kleenexStates = Object.keys(hass.states).filter(
-      (id) =>
-        typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
-    );
-    const pluStates = Object.keys(hass.states).filter(
-      (id) => {
-        if (typeof id !== "string") return false;
-        const match = /^sensor\.pollen_([^_]+)$/.exec(id);
-        if (!match) return false;
-        const allergenSlug = match[1];
-        // Only match if it's a known PLU allergen
-        return pluAllergenSlugs.has(allergenSlug);
-      },
-    );
-    // ATMO: primary via discovery (handles prefixed entity IDs and
-    // device-based detection); fallback to regex for older HA registries.
-    const atmoDiscovery = discoverAtmoSensors(hass, this.debug);
-    let atmoStates = [];
-    if (atmoDiscovery.locations.size > 0) {
-      for (const [, loc] of atmoDiscovery.locations) {
-        for (const eid of loc.entities.values()) {
-          atmoStates.push(eid);
-        }
-      }
-    }
-    if (!atmoStates.length) {
-      // Legacy fallback for older HA registries without device/platform metadata.
-      // Matches both current niveau_{slug} and legacy niveau_alerte_{slug}.
-      atmoStates = Object.keys(hass.states).filter(
-        (id) =>
-          typeof id === "string" &&
-          /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
-          !/_j_\d+$/.test(id),
-      );
-    }
-    // GPL: use hass.entities (primary) or attribution (fallback)
-    let gplStates = [];
-    if (hass.entities) {
-      gplStates = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === "pollenlevels" && !entry.entity_category)
-        .map(([eid]) => eid);
-    }
-    if (!gplStates.length) {
-      gplStates = Object.keys(hass.states).filter((id) => {
-        const s = hass.states[id];
-        return s?.attributes?.attribution === GPL_ATTRIBUTION
-          && s.attributes.device_class !== "date"
-          && s.attributes.device_class !== "timestamp";
-      });
-    }
-    // GP (svenove/google_pollen): full discovery once; state list derived
-    // from it so the header auto-title path can reuse the same result later.
-    const gpDiscovery = discoverGpSensors(hass, this.debug);
-    let gpStates = [];
-    if (gpDiscovery.locations.size > 0) {
-      for (const [, loc] of gpDiscovery.locations) {
-        for (const eid of loc.entities.values()) {
-          gpStates.push(eid);
-        }
-      }
-    }
-    if (!gpStates.length) {
-      if (hass.entities) {
-        gpStates = Object.entries(hass.entities)
-          .filter(([, entry]) => entry.platform === "google_pollen" && !entry.entity_category)
-          .map(([eid]) => eid);
-      }
-      if (!gpStates.length) {
-        gpStates = Object.keys(hass.states).filter((id) =>
-          typeof id === "string" && id.startsWith("sensor.google_pollen_")
-        );
-      }
-    }
-    // MSW (MeteoSwiss / hass-swissweather). Entity IDs follow
-    // sensor.<device-slug>_pollen_<allergen>_level_at_<station>; the
-    // <device-slug> prefix is added by HA from the device's friendly name and
-    // varies per install. Primary detection uses hass.entities platform check
-    // (same as SILAM/GP); fallback regex covers older HA registries.
-    const mswLevelRe =
-      /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
-    let mswStates = [];
-    if (hass.entities) {
-      mswStates = Object.entries(hass.entities)
-        .filter(([eid, entry]) =>
-          entry.platform === "swissweather" &&
-          !entry.entity_category &&
-          mswLevelRe.test(eid),
-        )
-        .map(([eid]) => eid);
-    }
-    if (!mswStates.length) {
-      mswStates = Object.keys(hass.states).filter(
-        (id) =>
-          typeof id === "string" &&
-          /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-      );
-    }
 
-    // Discovery results for adapters whose header label resolution would
-    // otherwise re-scan the registry. SILAM, Atmo, and GP are already cached
-    // above; PP, DWD, PEU, and GPL go here so the header block can reuse the
-    // same result instead of calling discover*Sensors a second time per HA
-    // update.
-    let _ppDiscovery = null;
-    let _dwdDiscovery = null;
-    let _peuDiscovery = null;
-    let _gplDiscovery = null;
-    let _mswDiscovery = null;
-    const getPpDiscovery = () => {
-      if (_ppDiscovery === null) _ppDiscovery = discoverPpSensors(hass, this.debug);
-      return _ppDiscovery;
-    };
-    const getDwdDiscovery = () => {
-      if (_dwdDiscovery === null) _dwdDiscovery = discoverDwdSensors(hass, this.debug);
-      return _dwdDiscovery;
-    };
-    const getPeuDiscovery = () => {
-      if (_peuDiscovery === null) _peuDiscovery = discoverPeuSensors(hass, this.debug);
-      return _peuDiscovery;
-    };
-    const getGplDiscovery = () => {
-      if (_gplDiscovery === null) _gplDiscovery = discoverGplSensors(hass, this.debug);
-      return _gplDiscovery;
-    };
-    const getMswDiscovery = () => {
-      if (_mswDiscovery === null) _mswDiscovery = discoverMswSensors(hass, this.debug);
-      return _mswDiscovery;
-    };
-
-    if (this.debug) {
-      console.debug("Sensor states detected:");
-      console.debug("PP:", ppStates);
-      console.debug("DWD:", dwdStates);
-      console.debug("PEU:", peuStates);
-      console.debug("SILAM:", silamStates);
-      console.debug("KLEENEX:", kleenexStates);
-      console.debug("PLU:", pluStates);
-      console.debug("ATMO:", atmoStates);
-      console.debug("GPL:", gplStates);
-      console.debug("GP:", gpStates);
-      console.debug("MSW:", mswStates);
-    }
-
-    // Bestäm integration (PEU går före DWD)
-    let integration = this._userConfig.integration;
-
-    // Normalize integration name to handle case sensitivity and whitespace
-    if (integration && typeof integration === "string") {
-      integration = integration.trim().toLowerCase();
-    }
-
-    if (!explicit) {
-      const skip = this._skipIntegrations;
-      if (ppStates.length && !skip.has("pp")) integration = "pp";
-      else if (pluStates.length && !skip.has("plu")) integration = "plu";
-      else if (peuStates.length && !skip.has("peu")) integration = "peu";
-      else if (dwdStates.length && !skip.has("dwd")) integration = "dwd";
-      else if (silamStates.length && !skip.has("silam")) integration = "silam";
-      else if (kleenexStates.length && !skip.has("kleenex")) integration = "kleenex";
-      else if (atmoStates.length && !skip.has("atmo")) integration = "atmo";
-      else if (gpStates.length && !skip.has("gp")) integration = "gp";
-      else if (gplStates.length && !skip.has("gpl")) integration = "gpl";
-      else if (mswStates.length && !skip.has("msw")) integration = "msw";
-    }
+    // Bestäm integration (shared priority pick honouring explicit + skip set).
+    let integration = pickIntegration(detection, {
+      explicit,
+      userIntegration: this._userConfig.integration,
+      skip: this._skipIntegrations,
+    });
 
     // Plocka rätt stub
     let baseStub = getStubConfig(integration);
@@ -886,159 +701,16 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       }
     }
 
-    // Automatic region/city/location detection unless manual mode is selected
-    if (
-      integration === "dwd" &&
-      cfg.region_id !== "manual" &&
-      !cfg.region_id &&
-      dwdStates.length
-    ) {
-      cfg.region_id = Array.from(
-        new Set(dwdStates.map((id) => id.split("_").pop())),
-      ).sort((a, b) => Number(a) - Number(b))[0];
+    // Automatic region/city/location detection unless manual mode is selected.
+    // Shared autoSelectLocation() returns { key, value } for the integration;
+    // the "manual"/already-set guard stays here so PLU's earlier city/region
+    // deletion and explicit "manual" mode keep their meaning. (The card element
+    // now also auto-selects GP/MSW locations, matching the editor.)
+    const autoLoc = autoSelectLocation(integration, cfg, hass, detection);
+    if (autoLoc && cfg[autoLoc.key] !== "manual" && !cfg[autoLoc.key]) {
+      cfg[autoLoc.key] = autoLoc.value;
       if (this.debug)
-        console.debug("[Card] Auto-set region_id:", cfg.region_id);
-    } else if (
-      integration === "pp" &&
-      cfg.city !== "manual" &&
-      !cfg.city &&
-      ppStates.length
-    ) {
-      cfg.city = ppStates[0]
-        .slice("sensor.pollen_".length)
-        .replace(/_[^_]+$/, "");
-      if (this.debug) console.debug("[Card] Auto-set city:", cfg.city);
-    } else if (
-      integration === "peu" &&
-      cfg.location !== "manual" &&
-      !cfg.location &&
-      peuStates.length
-    ) {
-      // Samla alla location_slug från entity attributes (om de finns)
-      const peuLocations = Array.from(
-        new Set(
-          peuStates
-            .map((eid) => {
-              const attr = hass.states[eid]?.attributes || {};
-              return attr.location_slug || null;
-            })
-            .filter(Boolean),
-        ),
-      );
-      cfg.location = peuLocations[0] || null;
-      if (this.debug)
-        console.debug(
-          "[Card][PEU] Auto-set location (location_slug):",
-          cfg.location,
-          peuLocations,
-        );
-    } else if (
-      integration === "silam" &&
-      cfg.location !== "manual" &&
-      !cfg.location &&
-      silamStates.length
-    ) {
-      // Primärt: discovery-baserad auto-select (config_entry_id)
-      if (silamDiscovery.locations.size > 0) {
-        const firstLocId = silamDiscovery.locations.keys().next().value;
-        cfg.location = firstLocId || null;
-        if (this.debug)
-          console.debug(
-            "[Card][SILAM] Auto-set location (discovery):",
-            cfg.location,
-            [...silamDiscovery.locations.keys()],
-          );
-      } else {
-        // Fallback: regex-baserad auto-select (slug)
-        const silamLocations = Array.from(
-          new Set(
-            silamStates
-              .map((eid) => {
-                const m = eid.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
-                return m ? m[1] : null;
-              })
-              .filter(Boolean),
-          ),
-        );
-        cfg.location = silamLocations[0] || null;
-        if (this.debug)
-          console.debug(
-            "[Card][SILAM] Auto-set location (regex):",
-            cfg.location,
-            silamLocations,
-          );
-      }
-    } else if (
-      integration === "kleenex" &&
-      cfg.location !== "manual" &&
-      !cfg.location &&
-      kleenexStates.length
-    ) {
-      // Look specifically for *_date sensors to extract location
-      const kleenexDateSensors = Object.keys(hass.states).filter(
-        (id) =>
-          typeof id === "string" &&
-          id.match(/^sensor\.kleenex_pollen_radar_.+_date$/),
-      );
-
-      const kleenexLocations = Array.from(
-        new Set(
-          kleenexDateSensors
-            .map((eid) => {
-              // sensor.kleenex_pollen_radar_<location>_date
-              const m = eid.match(/^sensor\.kleenex_pollen_radar_(.+)_date$/);
-              return m ? m[1] : null;
-            })
-            .filter(Boolean),
-        ),
-      );
-      cfg.location = kleenexLocations[0] || null;
-      if (this.debug)
-        console.debug(
-          "[Card][KLEENEX] Auto-set location:",
-          cfg.location,
-          kleenexLocations,
-        );
-    } else if (
-      integration === "atmo" &&
-      cfg.location !== "manual" &&
-      !cfg.location &&
-      atmoStates.length
-    ) {
-      const atmoLocations = Array.from(
-        new Set(
-          atmoStates
-            .map((eid) => {
-              const m = eid.match(
-                /^sensor\.niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)_(.+?)(?:_j_\d+)?$/,
-              );
-              return m ? m[1] : null;
-            })
-            .filter(Boolean),
-        ),
-      );
-      cfg.location = atmoLocations[0] || null;
-      if (this.debug)
-        console.debug(
-          "[Card][ATMO] Auto-set location:",
-          cfg.location,
-          atmoLocations,
-        );
-    } else if (
-      integration === "gpl" &&
-      cfg.location !== "manual" &&
-      !cfg.location &&
-      gplStates.length
-    ) {
-      const gplDiscovery = getGplDiscovery();
-      const firstLocId = gplDiscovery.locations.keys().next().value;
-      cfg.location = firstLocId || null;
-      if (this.debug)
-        console.debug(
-          "[Card][GPL] Auto-set location:",
-          cfg.location,
-          [...gplDiscovery.locations.keys()],
-        );
+        console.debug(`[Card] Auto-set ${autoLoc.key}:`, autoLoc.value);
     }
 
     // Only update reactive properties when values actually changed.

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -633,6 +633,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       userIntegration: this._userConfig.integration,
       skip: this._skipIntegrations,
     });
+    // Nothing detected and no prior choice: default to pp so the
+    // unknown-integration error below stays reserved for genuinely invalid ids
+    // (a user-typed bad value), not noisy on every no-sensors install.
+    if (!integration) integration = "pp";
 
     // Plocka rätt stub
     let baseStub = getStubConfig(integration);

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -15,10 +15,9 @@ import { PollenEditorBase, deepMerge } from "./editor/base.js";
 import { getStubConfig } from "./adapter-registry.js";
 import { stubConfigPP, discoverPpSensors, extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./adapters/pp.js";
 import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "./adapters/dwd.js";
-import { PEU_ALLERGENS, discoverPeuSensors, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
-import { PLU_ALIAS_MAP } from "./adapters/plu.js";
-import { discoverAtmoSensors, findAtmoLocationBySlug } from "./adapters/atmo.js";
-import { GPL_BASE_ALLERGENS, GPL_ATTRIBUTION, discoverGplSensors, discoverGplAllergens } from "./adapters/gpl/index.js";
+import { PEU_ALLERGENS, extractPeuLocationSlugFromEntityId } from "./adapters/peu.js";
+import { findAtmoLocationBySlug } from "./adapters/atmo.js";
+import { GPL_BASE_ALLERGENS, discoverGplSensors, discoverGplAllergens } from "./adapters/gpl/index.js";
 import { GP_BASE_ALLERGENS, discoverGpSensors, discoverGpAllergens } from "./adapters/gp/index.js";
 import { discoverMswSensors } from "./adapters/msw.js";
 import {
@@ -26,6 +25,11 @@ import {
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
 import { findLocationBySlug } from "./utils/adapter-helpers.js";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  detectedIntegrationIds,
+} from "./utils/autodetect.js";
 
 import {
   PP_POSSIBLE_CITIES,
@@ -261,100 +265,21 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       this._daysExplicit = this._userConfig.hasOwnProperty("days_to_show");
       this._localeExplicit = this._userConfig.hasOwnProperty("date_locale");
 
-      // 9. Bestäm integration (userConfig > tidigare config > autodetect)
+      // 9. Bestäm integration (userConfig > tidigare config > autodetect).
+      // Autodetect uses the shared module (src/utils/autodetect.js), so this
+      // path now matches the card and detects PLU + Kleenex too (it previously
+      // missed PLU).
       let integration =
         this._userConfig.integration !== undefined
           ? this._userConfig.integration
           : this._config.integration;
 
       if (!this._integrationExplicit && this._hass) {
-        const all = Object.keys(this._hass.states);
-        if (
-          all.some(
-            (id) =>
-              typeof id === "string" &&
-              id.startsWith("sensor.pollen_") &&
-              !id.includes("_level_at_"),
-          )
-        ) {
-          integration = "pp";
-        } else if (
-          all.some(
-            (id) =>
-              typeof id === "string" &&
-              id.startsWith("sensor.polleninformation_"),
-          )
-        ) {
-          integration = "peu";
-        } else if (
-          all.some(
-            (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
-          )
-        ) {
-          integration = "dwd";
-        } else if (
-          // Primary: hass.entities platform check
-          (this._hass?.entities && Object.values(this._hass.entities).some(
-            (e) => e.platform === "silam_pollen" && !e.entity_category
-          )) ||
-          // Fallback: regex
-          all.some(
-            (id) =>
-              typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-          )
-        ) {
-          integration = "silam";
-        } else if (
-          all.some(
-            (id) =>
-              typeof id === "string" &&
-              id.startsWith("sensor.kleenex_pollen_radar_"),
-          )
-        ) {
-          integration = "kleenex";
-        } else if (
-          // Discovery-based detection so prefixed multi-instance entity IDs
-          // (e.g. sensor.toulouse_niveau_bouleau_toulouse) are recognized.
-          discoverAtmoSensors(this._hass, false).locations.size > 0
-        ) {
-          integration = "atmo";
-        } else if (
-          this._hass && (
-            (this._hass.entities && Object.values(this._hass.entities).some(
-              (e) => e.platform === "google_pollen" && !e.entity_category
-            )) ||
-            all.some((id) => typeof id === "string" && id.startsWith("sensor.google_pollen_"))
-          )
-        ) {
-          integration = "gp";
-        } else if (
-          this._hass && (
-            // Primary: check hass.entities for pollenlevels platform
-            (this._hass.entities && Object.values(this._hass.entities).some(
-              (e) => e.platform === "pollenlevels" && !e.entity_category
-            )) ||
-            // Fallback: check attribution
-            all.some((id) => {
-              const s = this._hass.states[id];
-              return s?.attributes?.attribution === GPL_ATTRIBUTION
-                && s.attributes?.device_class !== "date"
-                && s.attributes?.device_class !== "timestamp";
-            })
-          )
-        ) {
-          integration = "gpl";
-        } else if (
-          (this._hass?.entities && Object.values(this._hass.entities).some(
-            (e) => e.platform === "swissweather" && !e.entity_category
-          )) ||
-          all.some(
-            (id) =>
-              typeof id === "string" &&
-              /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-          )
-        ) {
-          integration = "msw";
-        }
+        const detection = detectIntegrationStates(this._hass, {
+          debug: this.debug,
+        });
+        const picked = pickIntegration(detection, { explicit: false });
+        if (picked) integration = picked;
         this._userConfig.integration = integration;
         if (this.debug)
           console.debug("[Editor] auto-detected integration:", integration);
@@ -636,175 +561,49 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     this._hass = hass;
     const explicit = this._integrationExplicit;
 
-    // Hitta alla sensor-ID för PP, DWD, PEU, SILAM, PLU
-    // Build set of PLU allergen slugs for more specific detection
-    const pluAllergenSlugs = new Set(
-      Object.values(PLU_ALIAS_MAP).flat()
-    );
-
-    // Snapshot the state-key list once and reuse it for every prefix/regex
-    // filter below. Each call into `Object.keys(hass.states)` allocates a
-    // fresh array proportional to the entity count, and set hass() runs
-    // ~9 such scans per cycle; on large HA installs that is wasted work.
-    const stateIds = Object.keys(hass.states);
-
-    const ppStates = stateIds.filter(
-      (id) => {
-        if (typeof id !== "string") return false;
-        if (!id.startsWith("sensor.pollen_")) return false;
-        if (id.startsWith("sensor.pollenflug_")) return false;
-        // Exclude MSW (hass-swissweather) entities: sensor.pollen_<allergen>_level_at_<station>
-        if (id.includes("_level_at_")) return false;
-
-        // Match both manual mode (sensor.pollen_<allergen>) and city mode (sensor.pollen_<allergen>_<city>)
-        const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
-        if (!match) return false;
-
-        const allergenSlug = match[1];
-        // Exclude known PLU allergens to avoid misclassification
-        // PLU uses sensor.pollen_<allergen> pattern with specific allergen list
-        // PP manual mode also uses sensor.pollen_<allergen> but with different allergens
-        if (!match[2] && pluAllergenSlugs.has(allergenSlug)) {
-          // Single underscore AND known PLU allergen → likely PLU, not PP
-          return false;
-        }
-
-        return true;
+    // Shared autodetect (see src/utils/autodetect.js) — the same module the
+    // card element and badge use. Destructure local aliases the rest of
+    // set hass() already references; the lazy getters feed the installed-
+    // location lists below without re-scanning the registry.
+    const detection = detectIntegrationStates(hass, { debug: this.debug });
+    // ppStates/dwdStates feed the regex fallbacks for the PP/DWD location
+    // lists; the discovery objects/getters feed the installed-location lists.
+    // Other per-integration state lists are only needed for the pick, which is
+    // handled inside the shared module.
+    const {
+      states: { pp: ppStates, dwd: dwdStates },
+      discovery: {
+        silam: silamDiscovery,
+        atmo: atmoDiscovery,
+        gp: gpDiscovery,
       },
-    );
+      getPpDiscovery,
+      getDwdDiscovery,
+      getPeuDiscovery,
+      getGplDiscovery,
+      getMswDiscovery,
+    } = detection;
 
-    // DWD: lenient regex catches device-prefixed entity_ids too (#217).
-    const dwdStates = stateIds.filter(
-      (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
-    );
-
-    const peuStates = stateIds.filter(
-      (id) =>
-        typeof id === "string" && id.startsWith("sensor.polleninformation_"),
-    );
-
-    // SILAM: primary via hass.entities, fallback via regex
-    const silamDiscovery = discoverSilamSensors(hass, false);
-    let silamStates = [];
-    if (silamDiscovery.locations.size > 0) {
-      for (const [, loc] of silamDiscovery.locations) {
-        for (const eid of loc.sensors.values()) {
-          silamStates.push(eid);
-        }
-      }
-    }
-    if (!silamStates.length) {
-      silamStates = stateIds.filter(
-        (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-      );
-    }
-    const pluStates = stateIds.filter(
-      (id) => {
-        if (typeof id !== "string") return false;
-        const match = /^sensor\.pollen_([^_]+)$/.exec(id);
-        if (!match) return false;
-        const allergenSlug = match[1];
-        // Only match if it's a known PLU allergen
-        return pluAllergenSlugs.has(allergenSlug);
-      },
-    );
-    // Atmo France: discovery-based detection (same function used for location list)
-    const atmoDiscovery = discoverAtmoSensors(hass, false);
-    const atmoDetected = atmoDiscovery.locations.size > 0;
-    // GPL: use hass.entities (primary) or attribution (fallback)
-    let gplStates = [];
-    if (hass.entities) {
-      gplStates = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === "pollenlevels" && !entry.entity_category)
-        .map(([eid]) => eid);
-    }
-    if (!gplStates.length) {
-      gplStates = stateIds.filter((id) => {
-        const s = hass.states[id];
-        return s?.attributes?.attribution === GPL_ATTRIBUTION
-          && s.attributes.device_class !== "date"
-          && s.attributes.device_class !== "timestamp";
-      });
-    }
-    // GP (svenove/google_pollen): hass.entities (primary) or entity prefix (fallback)
-    let gpStates = [];
-    if (hass.entities) {
-      gpStates = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === "google_pollen" && !entry.entity_category)
-        .map(([eid]) => eid);
-    }
-    if (!gpStates.length) {
-      gpStates = stateIds.filter((id) =>
-        typeof id === "string" && id.startsWith("sensor.google_pollen_")
-      );
-    }
-    // MSW (MeteoSwiss / hass-swissweather). HA prefixes entity IDs with the
-    // device's friendly name slug, so primary detection uses hass.entities
-    // platform check (same as SILAM/GP); fallback regex handles older HA
-    // registries without entity metadata.
-    const mswLevelRe =
-      /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
-    let mswStates = [];
-    if (hass.entities) {
-      mswStates = Object.entries(hass.entities)
-        .filter(([eid, entry]) =>
-          entry.platform === "swissweather" &&
-          !entry.entity_category &&
-          mswLevelRe.test(eid),
-        )
-        .map(([eid]) => eid);
-    }
-    if (!mswStates.length) {
-      mswStates = stateIds.filter(
-        (id) =>
-          typeof id === "string" &&
-          /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-      );
-    }
-
-    // Kleenex prefix scan, computed locally for the dropdown sort. The editor's
-    // set hass() autodetect chain intentionally does not pick Kleenex (see
-    // 'known divergence' in test/card/autodetect.test.js), but for the
-    // dropdown's two-segment order we still want to mark it as installed
-    // whenever its sensors are present.
-    const kleenexStatesLocal = stateIds.filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
-    );
-
-    // Set of integrations that have at least one sensor in this hass.
-    // Drives the integration dropdown's two-segment sort order in render().
-    const detectedIntegrations = new Set();
-    if (ppStates.length) detectedIntegrations.add("pp");
-    if (pluStates.length) detectedIntegrations.add("plu");
-    if (peuStates.length) detectedIntegrations.add("peu");
-    if (dwdStates.length) detectedIntegrations.add("dwd");
-    if (silamStates.length) detectedIntegrations.add("silam");
-    if (kleenexStatesLocal.length) detectedIntegrations.add("kleenex");
-    if (atmoDetected) detectedIntegrations.add("atmo");
-    if (gpStates.length) detectedIntegrations.add("gp");
-    if (gplStates.length) detectedIntegrations.add("gpl");
-    if (mswStates.length) detectedIntegrations.add("msw");
-    this._detectedIntegrations = detectedIntegrations;
+    // Set of integrations that have at least one sensor in this hass. Drives
+    // the integration dropdown's two-segment sort order in render(). Now
+    // includes PLU and Kleenex — the editor previously diverged from the card
+    // and missed them; the shared module unifies every path.
+    this._detectedIntegrations = detectedIntegrationIds(detection);
 
     // 1) Autodetektera integration om användaren inte valt själv
-    let integration = this._userConfig.integration;
+    let integration = pickIntegration(detection, {
+      explicit,
+      userIntegration: this._userConfig.integration,
+    });
     if (!explicit) {
-      if (ppStates.length) integration = "pp";
-      else if (pluStates.length) integration = "plu";
-      else if (peuStates.length) integration = "peu";
-      else if (dwdStates.length) integration = "dwd";
-      else if (silamStates.length) integration = "silam";
-      else if (atmoDetected) integration = "atmo";
-      else if (gpStates.length) integration = "gp";
-      else if (gplStates.length) integration = "gpl";
-      else if (mswStates.length) integration = "msw";
       this._userConfig.integration = integration;
       if (this.debug)
-        console.debug("[Editor] autodetect:", { pp: ppStates.length, plu: pluStates.length, peu: peuStates.length, dwd: dwdStates.length, silam: silamStates.length, atmo: atmoDiscovery.locations.size, gp: gpStates.length, gpl: gplStates.length, msw: mswStates.length, chosen: integration });
+        console.debug("[Editor] autodetect chosen:", integration);
     }
 
     // 1.1) GPL discovery — always run so render() and auto-select have data
-    const gplDiscovery = discoverGplSensors(hass, false);
+    // (memoized via the shared detection result; no extra registry scan).
+    const gplDiscovery = getGplDiscovery();
     this.installedGplLocations = Array.from(gplDiscovery.locations.entries())
       .map(([configEntryId, loc]) => [configEntryId, loc.label]);
 
@@ -816,8 +615,8 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       this.installedGplPlants = [];
     }
 
-    // 1.2) GP discovery
-    const gpDiscovery = discoverGpSensors(hass, false);
+    // 1.2) GP discovery (gpDiscovery already resolved eagerly by the shared
+    // detection above and destructured into scope).
     this.installedGpLocations = Array.from(gpDiscovery.locations.entries())
       .map(([configEntryId, loc]) => [configEntryId, loc.label]);
 
@@ -831,7 +630,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
     // 1.3) MSW discovery (always run so the editor dropdown is populated even
     // when MSW is not the active integration, mirroring GPL/GP).
-    const mswDiscovery = discoverMswSensors(hass, false);
+    const mswDiscovery = getMswDiscovery();
     this.installedMswLocations = Array.from(mswDiscovery.locations.entries())
       .map(([configEntryId, loc]) => [configEntryId, loc.label]);
 
@@ -876,8 +675,8 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       this._config = merged;
       // 3) Fyll installerade regioner/städer via discovery helpers
 
-      // PP: device-based discovery with legacy slug fallback
-      const ppDiscovery = discoverPpSensors(hass, false);
+      // PP: device-based discovery with legacy slug fallback (memoized).
+      const ppDiscovery = getPpDiscovery();
       if (ppDiscovery.locations.size > 0) {
         this.installedPpLocations = Array.from(ppDiscovery.locations.entries())
           .map(([key, loc]) => [key, loc.label]);
@@ -921,8 +720,8 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         this.installedPpLocations = this.installedCities.map((city) => [city, city]);
       }
 
-      // DWD: device-based discovery with legacy region_id fallback
-      const dwdDiscovery = discoverDwdSensors(hass, false);
+      // DWD: device-based discovery with legacy region_id fallback (memoized).
+      const dwdDiscovery = getDwdDiscovery();
       if (dwdDiscovery.locations.size > 0) {
         this.installedDwdLocations = Array.from(dwdDiscovery.locations.entries())
           .map(([key, loc]) => [key, loc.label]);
@@ -963,8 +762,8 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       // PEU: device-based discovery with legacy location slug fallback.
-      // Sort by label so the dropdown stays stable across HA restarts.
-      const peuDiscovery = discoverPeuSensors(hass, false);
+      // Sort by label so the dropdown stays stable across HA restarts (memoized).
+      const peuDiscovery = getPeuDiscovery();
       if (peuDiscovery.locations.size > 0) {
         this.installedPeuLocations = Array.from(peuDiscovery.locations.entries())
           .map(([key, loc]) => [key, loc.label])

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -279,7 +279,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
           debug: this.debug,
         });
         const picked = pickIntegration(detection, { explicit: false });
-        if (picked) integration = picked;
+        // pickIntegration yields undefined when nothing is detected and no
+        // prior integration is set; fall back to "pp" so we never persist an
+        // undefined integration that could override the stub during merges.
+        integration = picked || integration || "pp";
         this._userConfig.integration = integration;
         if (this.debug)
           console.debug("[Editor] auto-detected integration:", integration);
@@ -590,11 +593,15 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     // and missed them; the shared module unifies every path.
     this._detectedIntegrations = detectedIntegrationIds(detection);
 
-    // 1) Autodetektera integration om användaren inte valt själv
-    let integration = pickIntegration(detection, {
-      explicit,
-      userIntegration: this._userConfig.integration,
-    });
+    // 1) Autodetektera integration om användaren inte valt själv.
+    // Fall back to "pp" so a no-sensors hass never yields an undefined
+    // integration (which would override the stub during merges and leave an
+    // invalid id).
+    let integration =
+      pickIntegration(detection, {
+        explicit,
+        userIntegration: this._userConfig.integration,
+      }) || "pp";
     if (!explicit) {
       this._userConfig.integration = integration;
       if (this.debug)

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -119,6 +119,10 @@ export function detectIntegrationStates(hass, { debug = false } = {}) {
   if (silamDiscovery.locations.size > 0) {
     for (const [, loc] of silamDiscovery.locations) {
       for (const eid of loc.sensors.values()) silamStates.push(eid);
+      // A SILAM install can enable only the weather entity (no allergen
+      // sensors) and still expose the allergy_risk index; count the weather
+      // entity as evidence so weather-only installs are detected too.
+      if (loc.weatherEntity) silamStates.push(loc.weatherEntity);
     }
   }
   if (!silamStates.length) {

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -390,14 +390,15 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
           .filter(Boolean),
       ),
     );
-    return { key: "location", value: peuLocations[0] || null };
+    const value = peuLocations[0];
+    return value ? { key: "location", value } : null;
   }
 
   if (integration === "silam" && states.silam?.length) {
     const silamDiscovery = detection.discovery.silam;
     if (silamDiscovery.locations.size > 0) {
       const firstLocId = silamDiscovery.locations.keys().next().value;
-      return { key: "location", value: firstLocId || null };
+      return firstLocId ? { key: "location", value: firstLocId } : null;
     }
     const silamLocations = Array.from(
       new Set(
@@ -409,7 +410,8 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
           .filter(Boolean),
       ),
     );
-    return { key: "location", value: silamLocations[0] || null };
+    const value = silamLocations[0];
+    return value ? { key: "location", value } : null;
   }
 
   if (integration === "kleenex" && states.kleenex?.length) {
@@ -428,7 +430,8 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
           .filter(Boolean),
       ),
     );
-    return { key: "location", value: kleenexLocations[0] || null };
+    const value = kleenexLocations[0];
+    return value ? { key: "location", value } : null;
   }
 
   if (integration === "atmo" && states.atmo?.length) {
@@ -444,13 +447,14 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
           .filter(Boolean),
       ),
     );
-    return { key: "location", value: atmoLocations[0] || null };
+    const value = atmoLocations[0];
+    return value ? { key: "location", value } : null;
   }
 
   if (integration === "gpl" && states.gpl?.length) {
     const gplDiscovery = detection.getGplDiscovery();
     const firstLocId = gplDiscovery.locations.keys().next().value;
-    return { key: "location", value: firstLocId || null };
+    return firstLocId ? { key: "location", value: firstLocId } : null;
   }
 
   if (integration === "gp" && states.gp?.length) {

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -20,7 +20,10 @@ import { discoverAtmoSensors } from "../adapters/atmo.js";
 import { GPL_ATTRIBUTION, discoverGplSensors } from "../adapters/gpl/index.js";
 import { discoverGpSensors } from "../adapters/gp/index.js";
 import { discoverMswSensors } from "../adapters/msw.js";
-import { discoverPpSensors } from "../adapters/pp.js";
+import {
+  discoverPpSensors,
+  extractCitySlugFromEntityId as extractPpCitySlugFromEntityId,
+} from "../adapters/pp.js";
 import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "../adapters/dwd.js";
 import { discoverPeuSensors } from "../adapters/peu.js";
 import { discoverSilamSensors } from "./silam.js";
@@ -364,10 +367,15 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
   }
 
   if (integration === "pp" && states.pp?.length) {
-    const value = states.pp[0]
-      .slice("sensor.pollen_".length)
-      .replace(/_[^_]+$/, "");
-    return { key: "city", value };
+    // Use the PP adapter's extractor (PP_ALLERGEN_SLUGS suffix whitelist) so
+    // allergens whose slug contains underscores (e.g. "salg_och_viden") and
+    // manual-mode sensors are handled correctly; a naive `_[^_]+$` split would
+    // mis-derive the city. Pick the first sensor that yields a real city slug.
+    for (const id of states.pp) {
+      const value = extractPpCitySlugFromEntityId(id);
+      if (value) return { key: "city", value };
+    }
+    return null;
   }
 
   if (integration === "peu" && states.peu?.length) {

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -1,0 +1,457 @@
+// src/utils/autodetect.js
+//
+// Shared Home Assistant integration autodetection. Extracted from the card
+// element and card editor (which previously each carried their own inline copy
+// with documented behaviour divergences) so the card, card editor, badge
+// element, and badge editor all detect integrations and auto-select a location
+// the same way. One source of truth; the divergences (editor setConfig missing
+// PLU, editor set hass missing Kleenex) are gone.
+//
+// Three layers, each pure and side-effect free:
+//   detectIntegrationStates(hass)  -> per-integration entity-id lists + cached
+//                                     discovery results
+//   pickIntegration(detection,..)  -> priority pick honouring explicit/skip
+//   autoSelectLocation(int,cfg,..) -> { key, value } | null for the location
+//
+// Plus normalizeIntegration() and detectedIntegrationIds() helpers.
+
+import { PLU_ALIAS_MAP } from "../adapters/plu.js";
+import { discoverAtmoSensors } from "../adapters/atmo.js";
+import { GPL_ATTRIBUTION, discoverGplSensors } from "../adapters/gpl/index.js";
+import { discoverGpSensors } from "../adapters/gp/index.js";
+import { discoverMswSensors } from "../adapters/msw.js";
+import { discoverPpSensors } from "../adapters/pp.js";
+import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "../adapters/dwd.js";
+import { discoverPeuSensors } from "../adapters/peu.js";
+import { discoverSilamSensors } from "./silam.js";
+
+// Canonical autodetect priority order. The first integration with detected
+// sensors (and not in `skip`) wins. Single source of truth for every consumer.
+export const INTEGRATION_PRIORITY = [
+  "pp",
+  "plu",
+  "peu",
+  "dwd",
+  "silam",
+  "kleenex",
+  "atmo",
+  "gp",
+  "gpl",
+  "msw",
+];
+
+/**
+ * Normalize an integration id from config: trim + lowercase when it's a string,
+ * pass through otherwise. Previously duplicated in the card, badge, and both
+ * editors.
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+export function normalizeIntegration(value) {
+  if (value && typeof value === "string") return value.trim().toLowerCase();
+  return value;
+}
+
+/**
+ * Scan hass for every supported integration's sensors and run the discovery
+ * helpers. Returns per-integration entity-id arrays plus discovery results so
+ * callers never re-scan hass.states or re-run discovery within a single update.
+ *
+ * Discovery cost is preserved from the card: silam/atmo/gp run eagerly (the card
+ * always did); pp/dwd/peu/gpl/msw stay behind memoized getters so large installs
+ * don't gain extra registry scans per HA tick.
+ *
+ * @param {object} hass
+ * @param {{debug?: boolean}} [opts]
+ * @returns {{
+ *   stateIds: string[],
+ *   states: Record<string, string[]>,
+ *   discovery: { silam: object, atmo: object, gp: object },
+ *   getPpDiscovery: () => object,
+ *   getDwdDiscovery: () => object,
+ *   getPeuDiscovery: () => object,
+ *   getGplDiscovery: () => object,
+ *   getMswDiscovery: () => object,
+ * }}
+ */
+export function detectIntegrationStates(hass, { debug = false } = {}) {
+  const stateIds = hass && hass.states ? Object.keys(hass.states) : [];
+
+  // PP allergen disambiguation against PLU (both can use sensor.pollen_<x>).
+  const pluAllergenSlugs = new Set(Object.values(PLU_ALIAS_MAP).flat());
+
+  const ppStates = stateIds.filter((id) => {
+    if (typeof id !== "string") return false;
+    if (!id.startsWith("sensor.pollen_")) return false;
+    if (id.startsWith("sensor.pollenflug_")) return false;
+    // Exclude MSW (hass-swissweather): sensor.pollen_<allergen>_level_at_<station>
+    if (id.includes("_level_at_")) return false;
+
+    // Match manual mode (sensor.pollen_<allergen>) and city mode
+    // (sensor.pollen_<allergen>_<city>).
+    const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
+    if (!match) return false;
+
+    const allergenSlug = match[1];
+    // Single underscore AND a known PLU allergen -> likely PLU, not PP.
+    if (!match[2] && pluAllergenSlugs.has(allergenSlug)) return false;
+
+    return true;
+  });
+
+  // DWD: match the pollenflug_<allergen>_<region> segment whether or not HA has
+  // prepended a device-name slug (#217).
+  const dwdStates = stateIds.filter(
+    (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
+  );
+
+  const peuStates = stateIds.filter(
+    (id) => typeof id === "string" && id.startsWith("sensor.polleninformation_"),
+  );
+
+  // SILAM: primary via discovery, fallback via regex.
+  const silamDiscovery = discoverSilamSensors(hass, debug);
+  let silamStates = [];
+  if (silamDiscovery.locations.size > 0) {
+    for (const [, loc] of silamDiscovery.locations) {
+      for (const eid of loc.sensors.values()) silamStates.push(eid);
+    }
+  }
+  if (!silamStates.length) {
+    silamStates = stateIds.filter(
+      (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
+    );
+  }
+
+  const kleenexStates = stateIds.filter(
+    (id) =>
+      typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
+  );
+
+  const pluStates = stateIds.filter((id) => {
+    if (typeof id !== "string") return false;
+    const match = /^sensor\.pollen_([^_]+)$/.exec(id);
+    if (!match) return false;
+    return pluAllergenSlugs.has(match[1]);
+  });
+
+  // ATMO: primary via discovery (prefixed entity IDs + device-based), fallback
+  // to regex for older HA registries.
+  const atmoDiscovery = discoverAtmoSensors(hass, debug);
+  let atmoStates = [];
+  if (atmoDiscovery.locations.size > 0) {
+    for (const [, loc] of atmoDiscovery.locations) {
+      for (const eid of loc.entities.values()) atmoStates.push(eid);
+    }
+  }
+  if (!atmoStates.length) {
+    // Legacy fallback. Matches current niveau_{slug} and legacy
+    // niveau_alerte_{slug}.
+    atmoStates = stateIds.filter(
+      (id) =>
+        typeof id === "string" &&
+        /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(
+          id,
+        ) &&
+        !/_j_\d+$/.test(id),
+    );
+  }
+
+  // GPL: hass.entities platform (primary) or attribution (fallback).
+  let gplStates = [];
+  if (hass && hass.entities) {
+    gplStates = Object.entries(hass.entities)
+      .filter(
+        ([, entry]) =>
+          entry.platform === "pollenlevels" && !entry.entity_category,
+      )
+      .map(([eid]) => eid);
+  }
+  if (!gplStates.length) {
+    gplStates = stateIds.filter((id) => {
+      const s = hass.states[id];
+      return (
+        s?.attributes?.attribution === GPL_ATTRIBUTION &&
+        s.attributes.device_class !== "date" &&
+        s.attributes.device_class !== "timestamp"
+      );
+    });
+  }
+
+  // GP (svenove/google_pollen): full discovery; state list derived from it.
+  const gpDiscovery = discoverGpSensors(hass, debug);
+  let gpStates = [];
+  if (gpDiscovery.locations.size > 0) {
+    for (const [, loc] of gpDiscovery.locations) {
+      for (const eid of loc.entities.values()) gpStates.push(eid);
+    }
+  }
+  if (!gpStates.length) {
+    if (hass && hass.entities) {
+      gpStates = Object.entries(hass.entities)
+        .filter(
+          ([, entry]) =>
+            entry.platform === "google_pollen" && !entry.entity_category,
+        )
+        .map(([eid]) => eid);
+    }
+    if (!gpStates.length) {
+      gpStates = stateIds.filter(
+        (id) => typeof id === "string" && id.startsWith("sensor.google_pollen_"),
+      );
+    }
+  }
+
+  // MSW (MeteoSwiss / hass-swissweather). Entity IDs follow
+  // sensor.<device-slug>_pollen_<allergen>_level_at_<station>; the device-slug
+  // prefix is added by HA and varies per install. Primary via hass.entities
+  // platform check; fallback regex for older registries.
+  const mswLevelRe =
+    /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
+  let mswStates = [];
+  if (hass && hass.entities) {
+    mswStates = Object.entries(hass.entities)
+      .filter(
+        ([eid, entry]) =>
+          entry.platform === "swissweather" &&
+          !entry.entity_category &&
+          mswLevelRe.test(eid),
+      )
+      .map(([eid]) => eid);
+  }
+  if (!mswStates.length) {
+    mswStates = stateIds.filter(
+      (id) =>
+        typeof id === "string" &&
+        /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(
+          id,
+        ),
+    );
+  }
+
+  // Lazy/memoized discoveries for adapters whose header label / location
+  // resolution would otherwise re-scan the registry. SILAM/Atmo/GP are already
+  // computed above; PP/DWD/PEU/GPL/MSW go behind getters so callers that only
+  // need the state lists don't pay for the scan.
+  let _ppDiscovery = null;
+  let _dwdDiscovery = null;
+  let _peuDiscovery = null;
+  let _gplDiscovery = null;
+  let _mswDiscovery = null;
+  const getPpDiscovery = () => {
+    if (_ppDiscovery === null) _ppDiscovery = discoverPpSensors(hass, debug);
+    return _ppDiscovery;
+  };
+  const getDwdDiscovery = () => {
+    if (_dwdDiscovery === null) _dwdDiscovery = discoverDwdSensors(hass, debug);
+    return _dwdDiscovery;
+  };
+  const getPeuDiscovery = () => {
+    if (_peuDiscovery === null) _peuDiscovery = discoverPeuSensors(hass, debug);
+    return _peuDiscovery;
+  };
+  const getGplDiscovery = () => {
+    if (_gplDiscovery === null) _gplDiscovery = discoverGplSensors(hass, debug);
+    return _gplDiscovery;
+  };
+  const getMswDiscovery = () => {
+    if (_mswDiscovery === null) _mswDiscovery = discoverMswSensors(hass, debug);
+    return _mswDiscovery;
+  };
+
+  if (debug) {
+    console.debug("Sensor states detected:");
+    console.debug("PP:", ppStates);
+    console.debug("DWD:", dwdStates);
+    console.debug("PEU:", peuStates);
+    console.debug("SILAM:", silamStates);
+    console.debug("KLEENEX:", kleenexStates);
+    console.debug("PLU:", pluStates);
+    console.debug("ATMO:", atmoStates);
+    console.debug("GPL:", gplStates);
+    console.debug("GP:", gpStates);
+    console.debug("MSW:", mswStates);
+  }
+
+  return {
+    stateIds,
+    states: {
+      pp: ppStates,
+      dwd: dwdStates,
+      peu: peuStates,
+      silam: silamStates,
+      kleenex: kleenexStates,
+      plu: pluStates,
+      atmo: atmoStates,
+      gpl: gplStates,
+      gp: gpStates,
+      msw: mswStates,
+    },
+    discovery: { silam: silamDiscovery, atmo: atmoDiscovery, gp: gpDiscovery },
+    getPpDiscovery,
+    getDwdDiscovery,
+    getPeuDiscovery,
+    getGplDiscovery,
+    getMswDiscovery,
+  };
+}
+
+/**
+ * Ordered Set of integration ids that have detected sensors, in canonical
+ * priority order. Powers the editor integration dropdown's "installed first"
+ * sort.
+ *
+ * @param {ReturnType<typeof detectIntegrationStates>} detection
+ * @returns {Set<string>}
+ */
+export function detectedIntegrationIds(detection) {
+  const out = new Set();
+  if (!detection || !detection.states) return out;
+  for (const id of INTEGRATION_PRIORITY) {
+    if (detection.states[id] && detection.states[id].length) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Pick the active integration. When `explicit` is set, the user's integration
+ * wins unchanged (autodetect never overrides an explicit choice). Otherwise the
+ * first integration in INTEGRATION_PRIORITY with detected sensors and not in
+ * `skip` is chosen.
+ *
+ * @param {ReturnType<typeof detectIntegrationStates>} detection
+ * @param {{explicit?: boolean, userIntegration?: *, skip?: Set<string>}} [opts]
+ * @returns {string|undefined}
+ */
+export function pickIntegration(
+  detection,
+  { explicit = false, userIntegration, skip } = {},
+) {
+  const normalized = normalizeIntegration(userIntegration);
+  if (explicit) return normalized;
+
+  const states = detection?.states || {};
+  const skipSet = skip || new Set();
+  for (const id of INTEGRATION_PRIORITY) {
+    if (states[id] && states[id].length && !skipSet.has(id)) return id;
+  }
+  // Nothing detected: keep whatever the user had (may be undefined).
+  return normalized;
+}
+
+/**
+ * Compute the location/city/region value to auto-select for an integration.
+ * Pure: returns { key, value } (e.g. {key:"city", value:"stockholm"}) or null.
+ * Callers apply the value under their own guards (typically
+ * cfg[key] !== "manual" && !cfg[key] && states.length) so "manual" mode and
+ * already-set values are honoured at the call site.
+ *
+ * @param {string} integration
+ * @param {object} cfg              current config (read-only here)
+ * @param {object} hass
+ * @param {ReturnType<typeof detectIntegrationStates>} detection
+ * @returns {{key: string, value: *}|null}
+ */
+export function autoSelectLocation(integration, cfg, hass, detection) {
+  const states = detection?.states || {};
+
+  if (integration === "dwd" && states.dwd?.length) {
+    const value = Array.from(
+      new Set(states.dwd.map((id) => id.split("_").pop())),
+    ).sort((a, b) => Number(a) - Number(b))[0];
+    return value != null ? { key: "region_id", value } : null;
+  }
+
+  if (integration === "pp" && states.pp?.length) {
+    const value = states.pp[0]
+      .slice("sensor.pollen_".length)
+      .replace(/_[^_]+$/, "");
+    return { key: "city", value };
+  }
+
+  if (integration === "peu" && states.peu?.length) {
+    const peuLocations = Array.from(
+      new Set(
+        states.peu
+          .map((eid) => hass.states[eid]?.attributes?.location_slug || null)
+          .filter(Boolean),
+      ),
+    );
+    return { key: "location", value: peuLocations[0] || null };
+  }
+
+  if (integration === "silam" && states.silam?.length) {
+    const silamDiscovery = detection.discovery.silam;
+    if (silamDiscovery.locations.size > 0) {
+      const firstLocId = silamDiscovery.locations.keys().next().value;
+      return { key: "location", value: firstLocId || null };
+    }
+    const silamLocations = Array.from(
+      new Set(
+        states.silam
+          .map((eid) => {
+            const m = eid.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
+            return m ? m[1] : null;
+          })
+          .filter(Boolean),
+      ),
+    );
+    return { key: "location", value: silamLocations[0] || null };
+  }
+
+  if (integration === "kleenex" && states.kleenex?.length) {
+    const kleenexDateSensors = detection.stateIds.filter(
+      (id) =>
+        typeof id === "string" &&
+        id.match(/^sensor\.kleenex_pollen_radar_.+_date$/),
+    );
+    const kleenexLocations = Array.from(
+      new Set(
+        kleenexDateSensors
+          .map((eid) => {
+            const m = eid.match(/^sensor\.kleenex_pollen_radar_(.+)_date$/);
+            return m ? m[1] : null;
+          })
+          .filter(Boolean),
+      ),
+    );
+    return { key: "location", value: kleenexLocations[0] || null };
+  }
+
+  if (integration === "atmo" && states.atmo?.length) {
+    const atmoLocations = Array.from(
+      new Set(
+        states.atmo
+          .map((eid) => {
+            const m = eid.match(
+              /^sensor\.niveau_(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)_(.+?)(?:_j_\d+)?$/,
+            );
+            return m ? m[1] : null;
+          })
+          .filter(Boolean),
+      ),
+    );
+    return { key: "location", value: atmoLocations[0] || null };
+  }
+
+  if (integration === "gpl" && states.gpl?.length) {
+    const gplDiscovery = detection.getGplDiscovery();
+    const firstLocId = gplDiscovery.locations.keys().next().value;
+    return { key: "location", value: firstLocId || null };
+  }
+
+  if (integration === "gp" && states.gp?.length) {
+    const gpDiscovery = detection.discovery.gp;
+    const firstLocId = gpDiscovery.locations.keys().next().value;
+    return firstLocId ? { key: "location", value: firstLocId } : null;
+  }
+
+  if (integration === "msw" && states.msw?.length) {
+    const mswDiscovery = detection.getMswDiscovery();
+    const firstLocId = mswDiscovery.locations.keys().next().value;
+    return firstLocId ? { key: "location", value: firstLocId } : null;
+  }
+
+  return null;
+}

--- a/test/card/autodetect.test.js
+++ b/test/card/autodetect.test.js
@@ -60,6 +60,8 @@ const FIXTURES = {
   kleenex: ["sensor.kleenex_pollen_radar_trees"],
   // ATMO needs to match the regex (pollen allergen, not a forecast day)
   atmo: ["sensor.niveau_bouleau_montpellier"],
+  // GP (svenove/google_pollen): prefix fallback when no registry entry
+  gp: ["sensor.google_pollen_grass"],
   // GPL uses entity registry platform check
   gpl: ["sensor.pollenlevels_grass"],
   // MSW: HA prefixes entity_id with the device name slug (e.g.
@@ -130,7 +132,9 @@ describe("shared autodetect", () => {
       ["silam", "silam"],
       ["kleenex", "kleenex"],
       ["atmo", "atmo"],
+      ["gp", "gp"],
       ["gpl", "gpl"],
+      ["msw", "msw"],
     ])("detects %s alone as %s", (fixture, expected) => {
       expect(detect(hassWithIntegrations(fixture))).toBe(expected);
     });
@@ -196,8 +200,18 @@ describe("shared autodetect", () => {
       );
     });
 
-    it("selects ATMO when only ATMO and GPL are present", () => {
-      expect(detect(hassWithIntegrations("atmo", "gpl"))).toBe("atmo");
+    it("selects ATMO when ATMO, GP, GPL, MSW are present", () => {
+      expect(detect(hassWithIntegrations("atmo", "gp", "gpl", "msw"))).toBe(
+        "atmo",
+      );
+    });
+
+    it("selects GP over GPL and MSW", () => {
+      expect(detect(hassWithIntegrations("gp", "gpl", "msw"))).toBe("gp");
+    });
+
+    it("selects GPL over MSW", () => {
+      expect(detect(hassWithIntegrations("gpl", "msw"))).toBe("gpl");
     });
 
     it("detects ATMO via discovery for prefixed entity IDs", () => {
@@ -229,7 +243,7 @@ describe("shared autodetect", () => {
     expect(detect(mkHass([]))).toBeUndefined();
   });
 
-  describe("full precedence order PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GPL", () => {
+  describe("full precedence order PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GP > GPL > MSW", () => {
     const order = [
       "pp",
       "plu",
@@ -238,7 +252,9 @@ describe("shared autodetect", () => {
       "silam",
       "kleenex",
       "atmo",
+      "gp",
       "gpl",
+      "msw",
     ];
 
     it("each integration wins over all that follow it", () => {

--- a/test/card/autodetect.test.js
+++ b/test/card/autodetect.test.js
@@ -443,6 +443,27 @@ describe("SILAM detection via entity registry vs prefix fallback", () => {
     expect(detect(hass)).toBe("silam");
   });
 
+  it("detects a weather-only SILAM install (no allergen sensors)", () => {
+    // SILAM can be configured with only the weather entity (allergy_risk
+    // index); the weather entity counts as evidence so it still autodetects.
+    const weatherId = "weather.silam_pollen_home_forecast";
+    const hass = mkHass([weatherId], {
+      stateObj: { [weatherId]: { state: "sunny", attributes: {} } },
+      entities: {
+        [weatherId]: {
+          entity_id: weatherId,
+          platform: "silam_pollen",
+          device_id: "dev_home",
+          translation_key: "forecast",
+        },
+      },
+    });
+    hass.devices = {
+      dev_home: { name: "Home", config_entries: ["entry_home"] },
+    };
+    expect(detect(hass)).toBe("silam");
+  });
+
   it("entity_category entries are excluded from SILAM entity detection", () => {
     const hass = mkHass([], {
       entities: {

--- a/test/card/autodetect.test.js
+++ b/test/card/autodetect.test.js
@@ -1,30 +1,37 @@
 /**
  * Autodetect precedence tests.
  *
- * The pollenprognos-card has THREE separate autodetect codepaths with
- * intentionally different precedence orders. This test file locks the
- * current behavior so accidental changes are caught.
+ * Integration autodetection now lives in ONE shared module
+ * (src/utils/autodetect.js) consumed by the card element, card editor, badge
+ * element and badge editor. This file exercises the REAL shared functions
+ * (no parallel reimplementation), so it catches drift in the actual code.
  *
- * Paths tested:
- *   1. Card set hass()          — PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GPL
- *   2. Editor setConfig()       — PP > PEU > DWD > SILAM > Kleenex > ATMO > GPL  (no PLU)
- *   3. Editor set hass()        — PP > PLU > PEU > DWD > SILAM > ATMO > GPL      (no Kleenex)
+ * Canonical precedence (single source of truth, INTEGRATION_PRIORITY):
+ *   PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GP > GPL > MSW
  *
- * Since we cannot easily instantiate LitElement components in vitest, we
- * replicate each detection path as a pure function and verify the logic
- * matches the source code exactly.
+ * Previously the card and the two editor codepaths had documented divergences
+ * (editor setConfig missed PLU; editor set hass missed Kleenex). The extraction
+ * unified them, so every path now agrees — the old divergence cases are flipped
+ * below to assert the unified behaviour.
  */
 
 import { describe, it, expect } from "vitest";
 import { PLU_ALIAS_MAP } from "../../src/adapters/plu.js";
 import { GPL_ATTRIBUTION } from "../../src/adapters/gpl/index.js";
-import { discoverAtmoSensors } from "../../src/adapters/atmo.js";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  detectedIntegrationIds,
+} from "../../src/utils/autodetect.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-const pluAllergenSlugs = new Set(Object.values(PLU_ALIAS_MAP).flat());
+/** Run the real shared autodetect and return the picked integration id. */
+function detect(hass) {
+  return pickIntegration(detectIntegrationStates(hass));
+}
 
 /** Minimal hass mock. */
 function mkHass(entityIds, opts = {}) {
@@ -36,341 +43,6 @@ function mkHass(entityIds, opts = {}) {
     states,
     entities: opts.entities || {},
   };
-}
-
-// ---------------------------------------------------------------------------
-// Path 1: Card set hass()
-// Order: PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GPL
-// ---------------------------------------------------------------------------
-
-function detectCardSetHass(hass) {
-  const all = Object.keys(hass.states);
-
-  const ppStates = all.filter((id) => {
-    if (typeof id !== "string") return false;
-    if (!id.startsWith("sensor.pollen_")) return false;
-    if (id.startsWith("sensor.pollenflug_")) return false;
-    if (id.includes("_level_at_")) return false;
-    const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
-    if (!match) return false;
-    const allergenSlug = match[1];
-    if (!match[2] && pluAllergenSlugs.has(allergenSlug)) return false;
-    return true;
-  });
-
-  const pluStates = all.filter((id) => {
-    if (typeof id !== "string") return false;
-    const match = /^sensor\.pollen_([^_]+)$/.exec(id);
-    if (!match) return false;
-    return pluAllergenSlugs.has(match[1]);
-  });
-
-  const peuStates = all.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.polleninformation_"),
-  );
-
-  const dwdStates = all.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.pollenflug_"),
-  );
-
-  // SILAM: primary via hass.entities platform check, fallback via prefix
-  let silamStates = [];
-  if (hass.entities) {
-    silamStates = Object.entries(hass.entities)
-      .filter(([, e]) => e.platform === "silam_pollen" && !e.entity_category)
-      .map(([eid]) => eid);
-  }
-  if (!silamStates.length) {
-    silamStates = all.filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-    );
-  }
-
-  const kleenexStates = all.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
-  );
-
-  // ATMO: primary via discovery (handles prefixed entity IDs), fallback to regex
-  const atmoDiscovery = discoverAtmoSensors(hass, false);
-  let atmoStates = [];
-  if (atmoDiscovery.locations.size > 0) {
-    for (const [, loc] of atmoDiscovery.locations) {
-      for (const eid of loc.entities.values()) {
-        atmoStates.push(eid);
-      }
-    }
-  }
-  if (!atmoStates.length) {
-    atmoStates = all.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
-        !/_j_\d+$/.test(id),
-    );
-  }
-
-  // GPL: primary via hass.entities, fallback via attribution
-  let gplStates = [];
-  if (hass.entities) {
-    gplStates = Object.entries(hass.entities)
-      .filter(([, entry]) => entry.platform === "pollenlevels" && !entry.entity_category)
-      .map(([eid]) => eid);
-  }
-  if (!gplStates.length) {
-    gplStates = all.filter((id) => {
-      const s = hass.states[id];
-      return (
-        s?.attributes?.attribution === GPL_ATTRIBUTION &&
-        s.attributes.device_class !== "date" &&
-        s.attributes.device_class !== "timestamp"
-      );
-    });
-  }
-
-  // MSW (MeteoSwiss / hass-swissweather). HA prefixes entity IDs with
-  // device-name slug, so use platform check primary + lenient regex fallback.
-  const mswLevelRe =
-    /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
-  let mswStates = [];
-  if (hass.entities) {
-    mswStates = Object.entries(hass.entities)
-      .filter(
-        ([eid, entry]) =>
-          entry.platform === "swissweather" &&
-          !entry.entity_category &&
-          mswLevelRe.test(eid),
-      )
-      .map(([eid]) => eid);
-  }
-  if (!mswStates.length) {
-    mswStates = all.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-    );
-  }
-
-  if (ppStates.length) return "pp";
-  if (pluStates.length) return "plu";
-  if (peuStates.length) return "peu";
-  if (dwdStates.length) return "dwd";
-  if (silamStates.length) return "silam";
-  if (kleenexStates.length) return "kleenex";
-  if (atmoStates.length) return "atmo";
-  if (gplStates.length) return "gpl";
-  if (mswStates.length) return "msw";
-  return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Path 2: Editor setConfig()
-// Order: PP > PEU > DWD > SILAM > Kleenex > ATMO > GPL
-// NOTE: No PLU detection; PP check is simpler (no PLU exclusion).
-// ---------------------------------------------------------------------------
-
-function detectEditorSetConfig(hass) {
-  const all = Object.keys(hass.states);
-
-  // Simple sensor.pollen_* startsWith check (no PLU filtering); MSW excluded.
-  if (
-    all.some(
-      (id) =>
-        typeof id === "string" &&
-        id.startsWith("sensor.pollen_") &&
-        !id.includes("_level_at_"),
-    )
-  ) {
-    return "pp";
-  }
-
-  if (all.some((id) => typeof id === "string" && id.startsWith("sensor.polleninformation_"))) {
-    return "peu";
-  }
-
-  if (all.some((id) => typeof id === "string" && id.startsWith("sensor.pollenflug_"))) {
-    return "dwd";
-  }
-
-  // SILAM: primary via hass.entities, fallback via prefix
-  if (
-    (hass.entities &&
-      Object.values(hass.entities).some(
-        (e) => e.platform === "silam_pollen" && !e.entity_category,
-      )) ||
-    all.some((id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"))
-  ) {
-    return "silam";
-  }
-
-  if (
-    all.some(
-      (id) =>
-        typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
-    )
-  ) {
-    return "kleenex";
-  }
-
-  // ATMO: discovery-based detection handles prefixed multi-instance entity IDs
-  if (discoverAtmoSensors(hass, false).locations.size > 0) {
-    return "atmo";
-  }
-
-  // GPL: primary via hass.entities, fallback via attribution
-  if (
-    (hass.entities &&
-      Object.values(hass.entities).some(
-        (e) => e.platform === "pollenlevels" && !e.entity_category,
-      )) ||
-    all.some((id) => {
-      const s = hass.states[id];
-      return (
-        s?.attributes?.attribution === GPL_ATTRIBUTION &&
-        s.attributes?.device_class !== "date" &&
-        s.attributes?.device_class !== "timestamp"
-      );
-    })
-  ) {
-    return "gpl";
-  }
-
-  // MSW (MeteoSwiss / hass-swissweather): platform check primary, regex fallback.
-  if (
-    (hass.entities &&
-      Object.values(hass.entities).some(
-        (e) => e.platform === "swissweather" && !e.entity_category,
-      )) ||
-    all.some(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-    )
-  ) {
-    return "msw";
-  }
-
-  return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Path 3: Editor set hass()
-// Order: PP > PLU > PEU > DWD > SILAM > ATMO > GPL
-// NOTE: No Kleenex detection; has PLU.
-// ---------------------------------------------------------------------------
-
-function detectEditorSetHass(hass) {
-  const all = Object.keys(hass.states);
-
-  const ppStates = all.filter((id) => {
-    if (typeof id !== "string") return false;
-    if (!id.startsWith("sensor.pollen_")) return false;
-    if (id.startsWith("sensor.pollenflug_")) return false;
-    if (id.includes("_level_at_")) return false;
-    const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
-    if (!match) return false;
-    const allergenSlug = match[1];
-    if (!match[2] && pluAllergenSlugs.has(allergenSlug)) return false;
-    return true;
-  });
-
-  const pluStates = all.filter((id) => {
-    if (typeof id !== "string") return false;
-    const match = /^sensor\.pollen_([^_]+)$/.exec(id);
-    if (!match) return false;
-    return pluAllergenSlugs.has(match[1]);
-  });
-
-  const peuStates = all.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.polleninformation_"),
-  );
-
-  const dwdStates = all.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.pollenflug_"),
-  );
-
-  // SILAM: primary via hass.entities, fallback via prefix
-  let silamStates = [];
-  if (hass.entities) {
-    silamStates = Object.entries(hass.entities)
-      .filter(([, e]) => e.platform === "silam_pollen" && !e.entity_category)
-      .map(([eid]) => eid);
-  }
-  if (!silamStates.length) {
-    silamStates = all.filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-    );
-  }
-
-  // No Kleenex detection in this path
-
-  // ATMO: primary via discovery (handles prefixed entity IDs), fallback to regex
-  const atmoDiscovery = discoverAtmoSensors(hass, false);
-  let atmoStates = [];
-  if (atmoDiscovery.locations.size > 0) {
-    for (const [, loc] of atmoDiscovery.locations) {
-      for (const eid of loc.entities.values()) {
-        atmoStates.push(eid);
-      }
-    }
-  }
-  if (!atmoStates.length) {
-    atmoStates = all.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(id) &&
-        !/_j_\d+$/.test(id),
-    );
-  }
-
-  // GPL: primary via hass.entities, fallback via attribution
-  let gplStates = [];
-  if (hass.entities) {
-    gplStates = Object.entries(hass.entities)
-      .filter(([, entry]) => entry.platform === "pollenlevels" && !entry.entity_category)
-      .map(([eid]) => eid);
-  }
-  if (!gplStates.length) {
-    gplStates = all.filter((id) => {
-      const s = hass.states[id];
-      return (
-        s?.attributes?.attribution === GPL_ATTRIBUTION &&
-        s.attributes.device_class !== "date" &&
-        s.attributes.device_class !== "timestamp"
-      );
-    });
-  }
-
-  // MSW (MeteoSwiss / hass-swissweather): platform check primary, regex fallback.
-  const mswLevelRe =
-    /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
-  let mswStates = [];
-  if (hass.entities) {
-    mswStates = Object.entries(hass.entities)
-      .filter(
-        ([eid, entry]) =>
-          entry.platform === "swissweather" &&
-          !entry.entity_category &&
-          mswLevelRe.test(eid),
-      )
-      .map(([eid]) => eid);
-  }
-  if (!mswStates.length) {
-    mswStates = all.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(id),
-    );
-  }
-
-  if (ppStates.length) return "pp";
-  if (pluStates.length) return "plu";
-  if (peuStates.length) return "peu";
-  if (dwdStates.length) return "dwd";
-  if (silamStates.length) return "silam";
-  if (atmoStates.length) return "atmo";
-  if (gplStates.length) return "gpl";
-  if (mswStates.length) return "msw";
-  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -392,8 +64,7 @@ const FIXTURES = {
   gpl: ["sensor.pollenlevels_grass"],
   // MSW: HA prefixes entity_id with the device name slug (e.g.
   // "meteoswiss_at_8000_klo"). Use a realistic prefixed shape so the
-  // detection regex is exercised for the real-world case, not just the
-  // bare-prefix case in the PR's original tests.
+  // detection regex is exercised for the real-world case.
   msw: ["sensor.meteoswiss_at_8000_klo_pollen_birch_level_at_8000_pzh"],
 };
 
@@ -446,12 +117,10 @@ function hassWithIntegrations(...keys) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Unified autodetect (shared module)
 // ---------------------------------------------------------------------------
 
-describe("Card set hass() autodetect", () => {
-  const detect = detectCardSetHass;
-
+describe("shared autodetect", () => {
   describe("single integration present", () => {
     it.each([
       ["pp", "pp"],
@@ -467,22 +136,45 @@ describe("Card set hass() autodetect", () => {
     });
   });
 
-  describe("precedence when all integrations present", () => {
-    it("selects PP when all 8 are present", () => {
+  describe("precedence when multiple integrations present", () => {
+    it("selects PP when all are present", () => {
       expect(
-        detect(hassWithIntegrations("pp", "plu", "peu", "dwd", "silam", "kleenex", "atmo", "gpl")),
+        detect(
+          hassWithIntegrations(
+            "pp",
+            "plu",
+            "peu",
+            "dwd",
+            "silam",
+            "kleenex",
+            "atmo",
+            "gpl",
+          ),
+        ),
       ).toBe("pp");
     });
 
     it("selects PLU when PP is absent", () => {
       expect(
-        detect(hassWithIntegrations("plu", "peu", "dwd", "silam", "kleenex", "atmo", "gpl")),
+        detect(
+          hassWithIntegrations(
+            "plu",
+            "peu",
+            "dwd",
+            "silam",
+            "kleenex",
+            "atmo",
+            "gpl",
+          ),
+        ),
       ).toBe("plu");
     });
 
     it("selects PEU when PP and PLU are absent", () => {
       expect(
-        detect(hassWithIntegrations("peu", "dwd", "silam", "kleenex", "atmo", "gpl")),
+        detect(
+          hassWithIntegrations("peu", "dwd", "silam", "kleenex", "atmo", "gpl"),
+        ),
       ).toBe("peu");
     });
 
@@ -493,11 +185,15 @@ describe("Card set hass() autodetect", () => {
     });
 
     it("selects SILAM when PP, PLU, PEU, DWD are absent", () => {
-      expect(detect(hassWithIntegrations("silam", "kleenex", "atmo", "gpl"))).toBe("silam");
+      expect(detect(hassWithIntegrations("silam", "kleenex", "atmo", "gpl"))).toBe(
+        "silam",
+      );
     });
 
     it("selects Kleenex when PP, PLU, PEU, DWD, SILAM are absent", () => {
-      expect(detect(hassWithIntegrations("kleenex", "atmo", "gpl"))).toBe("kleenex");
+      expect(detect(hassWithIntegrations("kleenex", "atmo", "gpl"))).toBe(
+        "kleenex",
+      );
     });
 
     it("selects ATMO when only ATMO and GPL are present", () => {
@@ -533,87 +229,17 @@ describe("Card set hass() autodetect", () => {
     expect(detect(mkHass([]))).toBeUndefined();
   });
 
-  describe("full precedence order is PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GPL", () => {
-    const order = ["pp", "plu", "peu", "dwd", "silam", "kleenex", "atmo", "gpl"];
-
-    it("each integration wins over all that follow it", () => {
-      for (let i = 0; i < order.length; i++) {
-        const remaining = order.slice(i);
-        expect(detect(hassWithIntegrations(...remaining))).toBe(order[i]);
-      }
-    });
-  });
-});
-
-describe("Editor setConfig() autodetect", () => {
-  const detect = detectEditorSetConfig;
-
-  describe("single integration present", () => {
-    it.each([
-      ["pp", "pp"],
-      ["peu", "peu"],
-      ["dwd", "dwd"],
-      ["silam", "silam"],
-      ["kleenex", "kleenex"],
-      ["atmo", "atmo"],
-      ["gpl", "gpl"],
-    ])("detects %s alone as %s", (fixture, expected) => {
-      expect(detect(hassWithIntegrations(fixture))).toBe(expected);
-    });
-  });
-
-  describe("precedence when multiple integrations present", () => {
-    it("selects PP when all 7 (no PLU path) are present", () => {
-      expect(
-        detect(hassWithIntegrations("pp", "peu", "dwd", "silam", "kleenex", "atmo", "gpl")),
-      ).toBe("pp");
-    });
-
-    it("selects PEU when PP is absent", () => {
-      expect(
-        detect(hassWithIntegrations("peu", "dwd", "silam", "kleenex", "atmo", "gpl")),
-      ).toBe("peu");
-    });
-
-    it("selects DWD when PP, PEU are absent", () => {
-      expect(
-        detect(hassWithIntegrations("dwd", "silam", "kleenex", "atmo", "gpl")),
-      ).toBe("dwd");
-    });
-
-    it("selects SILAM when PP, PEU, DWD are absent", () => {
-      expect(detect(hassWithIntegrations("silam", "kleenex", "atmo", "gpl"))).toBe("silam");
-    });
-
-    it("selects Kleenex when PP, PEU, DWD, SILAM are absent", () => {
-      expect(detect(hassWithIntegrations("kleenex", "atmo", "gpl"))).toBe("kleenex");
-    });
-
-    it("selects ATMO when only ATMO and GPL are present", () => {
-      expect(detect(hassWithIntegrations("atmo", "gpl"))).toBe("atmo");
-    });
-
-    it("selects GPL when only GPL is present", () => {
-      expect(detect(hassWithIntegrations("gpl"))).toBe("gpl");
-    });
-  });
-
-  describe("known divergence: no PLU detection", () => {
-    it("PLU-only sensors match PP (simpler sensor.pollen_* check)", () => {
-      // Editor setConfig() has no PLU-specific detection.
-      // sensor.pollen_bouleau starts with "sensor.pollen_", so it matches PP.
-      const hass = hassWithIntegrations("plu");
-      expect(detect(hass)).toBe("pp");
-    });
-
-    it("PLU sensors alongside PEU: PP wins (PLU sensors trigger PP check)", () => {
-      const hass = hassWithIntegrations("plu", "peu");
-      expect(detect(hass)).toBe("pp");
-    });
-  });
-
-  describe("full precedence order is PP > PEU > DWD > SILAM > Kleenex > ATMO > GPL", () => {
-    const order = ["pp", "peu", "dwd", "silam", "kleenex", "atmo", "gpl"];
+  describe("full precedence order PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GPL", () => {
+    const order = [
+      "pp",
+      "plu",
+      "peu",
+      "dwd",
+      "silam",
+      "kleenex",
+      "atmo",
+      "gpl",
+    ];
 
     it("each integration wins over all that follow it", () => {
       for (let i = 0; i < order.length; i++) {
@@ -623,94 +249,19 @@ describe("Editor setConfig() autodetect", () => {
     });
   });
 
-  it("returns undefined when no sensors present", () => {
-    expect(detect(mkHass([]))).toBeUndefined();
-  });
-});
-
-describe("Editor set hass() autodetect", () => {
-  const detect = detectEditorSetHass;
-
-  describe("single integration present", () => {
-    it.each([
-      ["pp", "pp"],
-      ["plu", "plu"],
-      ["peu", "peu"],
-      ["dwd", "dwd"],
-      ["silam", "silam"],
-      ["atmo", "atmo"],
-      ["gpl", "gpl"],
-    ])("detects %s alone as %s", (fixture, expected) => {
-      expect(detect(hassWithIntegrations(fixture))).toBe(expected);
-    });
-  });
-
-  describe("precedence when multiple integrations present", () => {
-    it("selects PP when all 7 (no Kleenex path) are present", () => {
-      expect(
-        detect(hassWithIntegrations("pp", "plu", "peu", "dwd", "silam", "atmo", "gpl")),
-      ).toBe("pp");
+  describe("unified behaviour (former divergences)", () => {
+    it("PLU is detected on every path (formerly missed by editor setConfig)", () => {
+      expect(detect(hassWithIntegrations("plu"))).toBe("plu");
+      // PLU alongside PEU still resolves to PLU (PLU outranks PEU).
+      expect(detect(hassWithIntegrations("plu", "peu"))).toBe("plu");
     });
 
-    it("selects PLU when PP is absent", () => {
-      expect(
-        detect(hassWithIntegrations("plu", "peu", "dwd", "silam", "atmo", "gpl")),
-      ).toBe("plu");
+    it("Kleenex is detected on every path (formerly missed by editor set hass)", () => {
+      expect(detect(hassWithIntegrations("kleenex"))).toBe("kleenex");
+      // Kleenex outranks ATMO and GPL.
+      expect(detect(hassWithIntegrations("kleenex", "atmo"))).toBe("kleenex");
+      expect(detect(hassWithIntegrations("kleenex", "gpl"))).toBe("kleenex");
     });
-
-    it("selects PEU when PP, PLU are absent", () => {
-      expect(
-        detect(hassWithIntegrations("peu", "dwd", "silam", "atmo", "gpl")),
-      ).toBe("peu");
-    });
-
-    it("selects DWD when PP, PLU, PEU are absent", () => {
-      expect(detect(hassWithIntegrations("dwd", "silam", "atmo", "gpl"))).toBe("dwd");
-    });
-
-    it("selects SILAM when PP, PLU, PEU, DWD are absent", () => {
-      expect(detect(hassWithIntegrations("silam", "atmo", "gpl"))).toBe("silam");
-    });
-
-    it("selects ATMO when only ATMO and GPL are present", () => {
-      expect(detect(hassWithIntegrations("atmo", "gpl"))).toBe("atmo");
-    });
-
-    it("selects GPL when only GPL is present", () => {
-      expect(detect(hassWithIntegrations("gpl"))).toBe("gpl");
-    });
-  });
-
-  describe("known divergence: no Kleenex detection", () => {
-    it("Kleenex-only sensors are not detected", () => {
-      const hass = hassWithIntegrations("kleenex");
-      expect(detect(hass)).toBeUndefined();
-    });
-
-    it("Kleenex sensors are ignored, ATMO wins when both present", () => {
-      const hass = hassWithIntegrations("kleenex", "atmo");
-      expect(detect(hass)).toBe("atmo");
-    });
-
-    it("Kleenex sensors are ignored, GPL wins when Kleenex + GPL present", () => {
-      const hass = hassWithIntegrations("kleenex", "gpl");
-      expect(detect(hass)).toBe("gpl");
-    });
-  });
-
-  describe("full precedence order is PP > PLU > PEU > DWD > SILAM > ATMO > GPL", () => {
-    const order = ["pp", "plu", "peu", "dwd", "silam", "atmo", "gpl"];
-
-    it("each integration wins over all that follow it", () => {
-      for (let i = 0; i < order.length; i++) {
-        const remaining = order.slice(i);
-        expect(detect(hassWithIntegrations(...remaining))).toBe(order[i]);
-      }
-    });
-  });
-
-  it("returns undefined when no sensors present", () => {
-    expect(detect(mkHass([]))).toBeUndefined();
   });
 });
 
@@ -719,114 +270,59 @@ describe("Editor set hass() autodetect", () => {
 // ---------------------------------------------------------------------------
 
 describe("PP / PLU disambiguation", () => {
-  describe("PLU-pattern sensors (sensor.pollen_{allergen}, no city suffix)", () => {
-    it("known PLU allergen slug goes to PLU in card set hass()", () => {
-      // "bouleau" is a PLU alias for "birch"
-      const hass = mkHass(["sensor.pollen_bouleau"]);
-      expect(detectCardSetHass(hass)).toBe("plu");
-    });
-
-    it("known PLU allergen slug goes to PLU in editor set hass()", () => {
-      const hass = mkHass(["sensor.pollen_bouleau"]);
-      expect(detectEditorSetHass(hass)).toBe("plu");
-    });
-
-    it("known PLU allergen slug goes to PP in editor setConfig() (no PLU path)", () => {
-      // Editor setConfig() has no PLU-specific detection
-      const hass = mkHass(["sensor.pollen_bouleau"]);
-      expect(detectEditorSetConfig(hass)).toBe("pp");
-    });
+  it("known PLU allergen slug (no city suffix) goes to PLU", () => {
+    // "bouleau" is a PLU alias for "birch"
+    const hass = mkHass(["sensor.pollen_bouleau"]);
+    expect(detect(hass)).toBe("plu");
   });
 
-  describe("PP-pattern sensors (sensor.pollen_{city}_{allergen})", () => {
-    it("city-mode sensor goes to PP in card set hass()", () => {
-      const hass = mkHass(["sensor.pollen_stockholm_bjork"]);
-      expect(detectCardSetHass(hass)).toBe("pp");
-    });
-
-    it("city-mode sensor goes to PP in editor set hass()", () => {
-      const hass = mkHass(["sensor.pollen_stockholm_bjork"]);
-      expect(detectEditorSetHass(hass)).toBe("pp");
-    });
-
-    it("city-mode sensor goes to PP in editor setConfig()", () => {
-      const hass = mkHass(["sensor.pollen_stockholm_bjork"]);
-      expect(detectEditorSetConfig(hass)).toBe("pp");
-    });
+  it("city-mode sensor goes to PP", () => {
+    const hass = mkHass(["sensor.pollen_stockholm_bjork"]);
+    expect(detect(hass)).toBe("pp");
   });
 
-  describe("mixed PP and PLU sensors", () => {
-    it("PP wins over PLU in card set hass() when both present", () => {
-      const hass = mkHass([
-        "sensor.pollen_stockholm_bjork",
-        "sensor.pollen_bouleau",
-      ]);
-      expect(detectCardSetHass(hass)).toBe("pp");
-    });
-
-    it("PP wins over PLU in editor set hass() when both present", () => {
-      const hass = mkHass([
-        "sensor.pollen_stockholm_bjork",
-        "sensor.pollen_bouleau",
-      ]);
-      expect(detectEditorSetHass(hass)).toBe("pp");
-    });
+  it("PP wins over PLU when both present", () => {
+    const hass = mkHass([
+      "sensor.pollen_stockholm_bjork",
+      "sensor.pollen_bouleau",
+    ]);
+    expect(detect(hass)).toBe("pp");
   });
 
   describe("PLU canonical slugs are correctly identified", () => {
-    // All canonical PLU allergens should be detected as PLU (not PP)
-    // in paths that have PLU detection
     const canonicalPluAllergens = Object.keys(PLU_ALIAS_MAP);
 
     it.each(canonicalPluAllergens)(
-      "sensor.pollen_%s detected as PLU in card set hass()",
+      "sensor.pollen_%s detected as PLU",
       (allergen) => {
         const hass = mkHass([`sensor.pollen_${allergen}`]);
-        expect(detectCardSetHass(hass)).toBe("plu");
-      },
-    );
-
-    it.each(canonicalPluAllergens)(
-      "sensor.pollen_%s detected as PLU in editor set hass()",
-      (allergen) => {
-        const hass = mkHass([`sensor.pollen_${allergen}`]);
-        expect(detectEditorSetHass(hass)).toBe("plu");
+        expect(detect(hass)).toBe("plu");
       },
     );
   });
 
   describe("PLU alias slugs are correctly identified", () => {
-    // Slugified aliases should also route to PLU
     const aliasSamples = [
-      "rumex",      // sorrel alias
-      "artemisia",  // mugwort alias
-      "betula",     // birch alias
-      "corylus",    // hazel alias
-      "fraxinus",   // ash alias
-      "quercus",    // oak alias
-      "poacea",     // poaceae alias (note: single 'a' variant)
-      "plantago",   // plantain alias
+      "rumex", // sorrel alias
+      "artemisia", // mugwort alias
+      "betula", // birch alias
+      "corylus", // hazel alias
+      "fraxinus", // ash alias
+      "quercus", // oak alias
+      "poacea", // poaceae alias (note: single 'a' variant)
+      "plantago", // plantain alias
     ];
 
-    it.each(aliasSamples)(
-      "sensor.pollen_%s detected as PLU in card set hass()",
-      (slug) => {
-        const hass = mkHass([`sensor.pollen_${slug}`]);
-        expect(detectCardSetHass(hass)).toBe("plu");
-      },
-    );
+    it.each(aliasSamples)("sensor.pollen_%s detected as PLU", (slug) => {
+      const hass = mkHass([`sensor.pollen_${slug}`]);
+      expect(detect(hass)).toBe("plu");
+    });
   });
 
   describe("unknown allergen with no city suffix goes to PP (not PLU)", () => {
-    it("sensor.pollen_unknownallergen is PP in card set hass()", () => {
-      // "unknownallergen" is not a PLU slug, so PP filter accepts it
+    it("sensor.pollen_unknownallergen is PP", () => {
       const hass = mkHass(["sensor.pollen_unknownallergen"]);
-      expect(detectCardSetHass(hass)).toBe("pp");
-    });
-
-    it("sensor.pollen_unknownallergen is PP in editor set hass()", () => {
-      const hass = mkHass(["sensor.pollen_unknownallergen"]);
-      expect(detectEditorSetHass(hass)).toBe("pp");
+      expect(detect(hass)).toBe("pp");
     });
   });
 });
@@ -836,76 +332,62 @@ describe("PP / PLU disambiguation", () => {
 // ---------------------------------------------------------------------------
 
 describe("MSW detection", () => {
-  it("device-prefixed entity is detected as MSW (card set hass)", () => {
-    // hass-swissweather entity_ids are prefixed with the device-name slug
-    // ("meteoswiss_at_8000_klo_" for default name; "bern_" for renamed device).
+  it("device-prefixed entity is detected as MSW", () => {
     const hass = mkHass([
       "sensor.meteoswiss_at_8000_klo_pollen_birch_level_at_8000_pzh",
       "sensor.meteoswiss_at_8000_klo_pollen_grasses_level_at_8000_pzh",
     ]);
-    expect(detectCardSetHass(hass)).toBe("msw");
+    expect(detect(hass)).toBe("msw");
   });
 
   it("renamed device prefix is also detected as MSW", () => {
     const hass = mkHass(["sensor.bern_pollen_birch_level_at_3000_pbe"]);
-    expect(detectCardSetHass(hass)).toBe("msw");
+    expect(detect(hass)).toBe("msw");
   });
 
   it("non-prefixed shape is also detected (legacy/no device-name path)", () => {
     const hass = mkHass(["sensor.pollen_birch_level_at_8000"]);
-    expect(detectCardSetHass(hass)).toBe("msw");
+    expect(detect(hass)).toBe("msw");
   });
 
   it("MSW pattern is excluded from PP detection (no false PP hit)", () => {
-    // Without the exclusion, PP regex would match these as
-    // sensor.pollen_<allergen>_<city> and route the card to PP.
     const hass = mkHass(["sensor.pollen_birch_level_at_8000"]);
-    expect(detectCardSetHass(hass)).not.toBe("pp");
+    expect(detect(hass)).not.toBe("pp");
   });
 
   it("entity-registry platform check detects MSW even without state", () => {
-    const hass = mkHass(
-      ["sensor.bern_pollen_birch_level_at_3000_pbe"],
-      {
-        entities: {
-          "sensor.bern_pollen_birch_level_at_3000_pbe": {
-            platform: "swissweather",
-          },
+    const hass = mkHass(["sensor.bern_pollen_birch_level_at_3000_pbe"], {
+      entities: {
+        "sensor.bern_pollen_birch_level_at_3000_pbe": {
+          platform: "swissweather",
         },
       },
-    );
-    expect(detectCardSetHass(hass)).toBe("msw");
+    });
+    expect(detect(hass)).toBe("msw");
   });
 
   it("PP wins when both PP and MSW sensors are present", () => {
-    // PP runs first in the autodetect chain; MSW only kicks in when no
-    // earlier integration matches.
     const hass = mkHass([
       "sensor.pollen_stockholm_bjork",
       "sensor.bern_pollen_birch_level_at_3000_pbe",
     ]);
-    expect(detectCardSetHass(hass)).toBe("pp");
+    expect(detect(hass)).toBe("pp");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Edge cases: pollenflug_ prefix exclusion
+// pollenflug_ prefix exclusion from PP
 // ---------------------------------------------------------------------------
 
 describe("pollenflug_ prefix exclusion from PP", () => {
   it("sensor.pollenflug_ is excluded from PP detection (goes to DWD)", () => {
     const hass = mkHass(["sensor.pollenflug_erle_11"]);
-    expect(detectCardSetHass(hass)).toBe("dwd");
-    expect(detectEditorSetHass(hass)).toBe("dwd");
-    expect(detectEditorSetConfig(hass)).toBe("dwd");
+    expect(detect(hass)).toBe("dwd");
   });
 
   it("sensor.pollenflug_ does not trigger PP even when only PP-like prefix matches", () => {
-    // "sensor.pollenflug_" starts with "sensor.pollen" but the explicit
-    // pollenflug exclusion should prevent it from matching PP
     const hass = mkHass(["sensor.pollenflug_hasel_11"]);
-    expect(detectCardSetHass(hass)).toBe("dwd");
-    expect(detectEditorSetHass(hass)).toBe("dwd");
+    expect(detect(hass)).toBe("dwd");
   });
 });
 
@@ -914,26 +396,35 @@ describe("pollenflug_ prefix exclusion from PP", () => {
 // ---------------------------------------------------------------------------
 
 describe("SILAM detection via entity registry vs prefix fallback", () => {
-  it("detects SILAM via hass.entities platform check", () => {
-    const hass = mkHass([], {
+  it("detects SILAM via registry discovery (device + platform)", () => {
+    // Realistic registry setup: discoverSilamSensors() walks hass.entities by
+    // platform and resolves the device. A bare registry entry with no device
+    // and no state is not a real SILAM install and is intentionally not
+    // detected (it only ever matched the old test shim).
+    const sensorId = "sensor.silam_pollen_birch_home";
+    const hass = mkHass([sensorId], {
+      stateObj: { [sensorId]: { state: "1", attributes: {} } },
       entities: {
-        "sensor.silam_pollen_birch_home": {
+        [sensorId]: {
+          entity_id: sensorId,
           platform: "silam_pollen",
+          device_id: "dev_home",
+          entity_category: null,
+          translation_key: "birch",
         },
       },
     });
-    // The entity is in hass.entities but NOT in hass.states,
-    // so only the entities path fires
-    expect(detectCardSetHass(hass)).toBe("silam");
-    expect(detectEditorSetHass(hass)).toBe("silam");
+    hass.devices = {
+      dev_home: { name: "Home", config_entries: ["entry_home"] },
+    };
+    expect(detect(hass)).toBe("silam");
   });
 
   it("detects SILAM via sensor prefix fallback when no entities", () => {
     const hass = mkHass(["sensor.silam_pollen_birch_home"], {
       entities: {},
     });
-    expect(detectCardSetHass(hass)).toBe("silam");
-    expect(detectEditorSetHass(hass)).toBe("silam");
+    expect(detect(hass)).toBe("silam");
   });
 
   it("entity_category entries are excluded from SILAM entity detection", () => {
@@ -945,7 +436,7 @@ describe("SILAM detection via entity registry vs prefix fallback", () => {
         },
       },
     });
-    expect(detectCardSetHass(hass)).toBeUndefined();
+    expect(detect(hass)).toBeUndefined();
   });
 });
 
@@ -962,9 +453,7 @@ describe("GPL detection via entity registry vs attribution fallback", () => {
         },
       },
     });
-    expect(detectCardSetHass(hass)).toBe("gpl");
-    expect(detectEditorSetHass(hass)).toBe("gpl");
-    expect(detectEditorSetConfig(hass)).toBe("gpl");
+    expect(detect(hass)).toBe("gpl");
   });
 
   it("detects GPL via attribution fallback when no entities", () => {
@@ -977,9 +466,7 @@ describe("GPL detection via entity registry vs attribution fallback", () => {
         },
       },
     });
-    expect(detectCardSetHass(hass)).toBe("gpl");
-    expect(detectEditorSetHass(hass)).toBe("gpl");
-    expect(detectEditorSetConfig(hass)).toBe("gpl");
+    expect(detect(hass)).toBe("gpl");
   });
 
   it("GPL date/timestamp sensors are excluded from attribution fallback", () => {
@@ -995,7 +482,7 @@ describe("GPL detection via entity registry vs attribution fallback", () => {
         },
       },
     });
-    expect(detectCardSetHass(hass)).toBeUndefined();
+    expect(detect(hass)).toBeUndefined();
   });
 
   it("entity_category entries are excluded from GPL entity detection", () => {
@@ -1007,7 +494,7 @@ describe("GPL detection via entity registry vs attribution fallback", () => {
         },
       },
     });
-    expect(detectCardSetHass(hass)).toBeUndefined();
+    expect(detect(hass)).toBeUndefined();
   });
 });
 
@@ -1018,31 +505,17 @@ describe("GPL detection via entity registry vs attribution fallback", () => {
 describe("ATMO detection", () => {
   it("detects ATMO via pollen sensor (niveau_bouleau)", () => {
     const hass = mkHass(["sensor.niveau_bouleau_montpellier"]);
-    expect(detectCardSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetConfig(hass)).toBe("atmo");
+    expect(detect(hass)).toBe("atmo");
   });
 
-  it("detects ATMO via pollution sensor (pm25) in card and editor set hass()", () => {
-    // pm25 sensors are in the broader ATMO regex used by card/editor set hass()
+  it("detects ATMO via pollution sensor (pm25)", () => {
     const hass = mkHass(["sensor.pm25_montpellier"]);
-    expect(detectCardSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetHass(hass)).toBe("atmo");
+    expect(detect(hass)).toBe("atmo");
   });
 
-  it("editor setConfig() matches ATMO pollution sensors via discovery fallback", () => {
-    // Editor setConfig() now uses discoverAtmoSensors(), whose tier 3 regex
-    // covers pollution (pm25/pm10/ozone/dioxyde_*/qualite_globale) as well
-    // as pollen. Previously this path was limited to the niveau_{slug} form.
-    const hass = mkHass(["sensor.pm25_montpellier"]);
-    expect(detectEditorSetConfig(hass)).toBe("atmo");
-  });
-
-  it("excludes forecast day entities (_j_N suffix) in card and editor set hass()", () => {
-    // Sensors ending with _j_1, _j_2 etc are forecast-day entities, excluded
+  it("excludes forecast day entities (_j_N suffix)", () => {
     const hass = mkHass(["sensor.niveau_bouleau_montpellier_j_1"]);
-    expect(detectCardSetHass(hass)).toBeUndefined();
-    expect(detectEditorSetHass(hass)).toBeUndefined();
+    expect(detect(hass)).toBeUndefined();
   });
 
   it.each([
@@ -1054,13 +527,10 @@ describe("ATMO detection", () => {
     "sensor.niveau_olivier_nice",
   ])("all six ATMO pollen allergens are detected: %s", (id) => {
     const hass = mkHass([id]);
-    expect(detectCardSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetConfig(hass)).toBe("atmo");
+    expect(detect(hass)).toBe("atmo");
   });
 
-  it("editor setConfig() detects ATMO via discovery for prefixed entity IDs", () => {
-    // Multi-instance prefixed entity IDs don't match the legacy regex, but
-    // tier 1 device-based discovery finds them via hass.devices/entities.
+  it("detects ATMO via discovery for prefixed entity IDs", () => {
     const eid = "sensor.toulouse_niveau_bouleau_toulouse";
     const hass = {
       states: { [eid]: { state: "2", attributes: {} } },
@@ -1075,35 +545,39 @@ describe("ATMO detection", () => {
         },
       },
     };
-    expect(detectEditorSetConfig(hass)).toBe("atmo");
+    expect(detect(hass)).toBe("atmo");
+  });
+
+  it("qualite_globale pollution sensor is detected as ATMO", () => {
+    const hass = mkHass(["sensor.qualite_globale_montpellier"]);
+    expect(detect(hass)).toBe("atmo");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Cross-path comparison: document the three divergences
+// Badge picker (getStubConfig) integration choice
+//
+// PollenPrognosBadge.getStubConfig(hass) is a LitElement static method we
+// cannot import in the node test environment (no customElements), so we assert
+// the exact expression it uses: pick the detected integration, fall back to
+// "pp" when nothing is detected. HA also calls getStubConfig with no hass, in
+// which case the badge defaults to "pp" without scanning.
 // ---------------------------------------------------------------------------
 
-describe("cross-path divergence documentation", () => {
-  it("editor setConfig() detects PLU sensors as PP (no PLU path)", () => {
-    const hass = hassWithIntegrations("plu");
-    expect(detectCardSetHass(hass)).toBe("plu");
-    expect(detectEditorSetConfig(hass)).toBe("pp"); // divergence
-    expect(detectEditorSetHass(hass)).toBe("plu");
+describe("badge picker integration choice (getStubConfig logic)", () => {
+  const pickStubIntegration = (hass) =>
+    pickIntegration(detectIntegrationStates(hass), { explicit: false }) || "pp";
+
+  it("uses the detected integration (e.g. DWD), not always pp", () => {
+    expect(pickStubIntegration(hassWithIntegrations("dwd"))).toBe("dwd");
   });
 
-  it("editor set hass() does not detect Kleenex (no Kleenex path)", () => {
-    const hass = hassWithIntegrations("kleenex");
-    expect(detectCardSetHass(hass)).toBe("kleenex");
-    expect(detectEditorSetConfig(hass)).toBe("kleenex");
-    expect(detectEditorSetHass(hass)).toBeUndefined(); // divergence
+  it("falls back to pp when nothing is installed", () => {
+    expect(pickStubIntegration(mkHass([]))).toBe("pp");
   });
 
-  it("ATMO pollution sensors detected consistently in all three paths", () => {
-    // All three paths now use discoverAtmoSensors() whose tier 3 regex covers
-    // pm25, pm10, ozone, dioxyde_*, qualite_globale alongside niveau_{slug}.
-    const hass = mkHass(["sensor.qualite_globale_montpellier"]);
-    expect(detectCardSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetHass(hass)).toBe("atmo");
-    expect(detectEditorSetConfig(hass)).toBe("atmo");
+  it("detectIntegrationStates tolerates an empty hass", () => {
+    const detection = detectIntegrationStates({ states: {}, entities: {} });
+    expect(detectedIntegrationIds(detection).size).toBe(0);
   });
 });

--- a/test/card/autodetect.test.js
+++ b/test/card/autodetect.test.js
@@ -575,21 +575,21 @@ describe("ATMO detection", () => {
 //
 // PollenPrognosBadge.getStubConfig(hass) is a LitElement static method we
 // cannot import in the node test environment (no customElements), so we assert
-// the exact expression it uses: pick the detected integration, fall back to
-// "pp" when nothing is detected. HA also calls getStubConfig with no hass, in
-// which case the badge defaults to "pp" without scanning.
+// the pick it relies on. The stub pins `integration` ONLY when one is detected;
+// when nothing is detected or hass is absent it omits the key (so the present-
+// integration => user-pin heuristic doesn't suppress autodetect later).
 // ---------------------------------------------------------------------------
 
 describe("badge picker integration choice (getStubConfig logic)", () => {
-  const pickStubIntegration = (hass) =>
-    pickIntegration(detectIntegrationStates(hass), { explicit: false }) || "pp";
+  const pickStub = (hass) =>
+    pickIntegration(detectIntegrationStates(hass), { explicit: false });
 
-  it("uses the detected integration (e.g. DWD), not always pp", () => {
-    expect(pickStubIntegration(hassWithIntegrations("dwd"))).toBe("dwd");
+  it("pins the detected integration (e.g. DWD), not always pp", () => {
+    expect(pickStub(hassWithIntegrations("dwd"))).toBe("dwd");
   });
 
-  it("falls back to pp when nothing is installed", () => {
-    expect(pickStubIntegration(mkHass([]))).toBe("pp");
+  it("omits integration when nothing is installed (autodetect later)", () => {
+    expect(pickStub(mkHass([]))).toBeUndefined();
   });
 
   it("detectIntegrationStates tolerates an empty hass", () => {


### PR DESCRIPTION
## What

Extracts the integration autodetection that the card and its editor do well into one shared module (`src/utils/autodetect.js`), and wires the new badge element + badge editor to it. Addresses the autodetect feedback in #235: a DWD (or any non-PollenPrognos) user adding a badge previously got an empty PollenPrognos badge and a badge editor that preselected the wrong integration with an empty location dropdown.

## Why

Detection logic was duplicated inline in the card element and the card editor (two copies, plus `setConfig` vs `set hass` variants), with documented behaviour divergences: the editor `setConfig` path missed PLU and the editor `set hass` path missed Kleenex. The badge had no detection at all (`getStubConfig` hardcoded `integration: "pp"`). Adding a third copy would entrench the drift, so this unifies all paths.

## Changes

- **`src/utils/autodetect.js`** (new): `normalizeIntegration`, `detectIntegrationStates` (per-integration state lists + cached eager/lazy discovery), `detectedIntegrationIds`, `pickIntegration`, and the pure `autoSelectLocation`. Canonical order `PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GP > GPL > MSW`.
- **Card element / card editor**: call the shared module; header label-resolution and the editor's installed-location dropdown lists are unchanged (they reuse the detection result's memoized discovery getters, so no extra registry scans).
- **Badge element**: `getStubConfig(hass)` autodetects the integration (falls back to `pp` with no hass); config build moved into `_buildConfig(config, hass)` which auto-selects integration + first location when not user-pinned; `set hass` re-resolves on hass change (deepEqual-guarded).
- **Badge editor**: runs the shared detection, marks installed integrations for the dropdown sort, populates the location lists, and prefills integration + first location (diff-before-dispatch to avoid an HA update loop).

## Behaviour changes (intended)

- The card editor now detects PLU and Kleenex (previously missed on those paths).
- The card element now auto-selects the first GP/MSW location (the editor already did).

## Tests

`test/card/autodetect.test.js` now imports the real shared functions instead of a parallel reimplementation (which had drifted). The former "known divergence" cases are flipped to the unified behaviour; a badge-picker case documents the `getStubConfig` choice. Full suite: 1078 passing. Build clean. Validated against the live hass-test states (all 8 integrations present): full set picks PP, per-integration subsets pick correctly and auto-select the right region/location.

## Not in this PR (separate, per plan)

Per-section reset buttons in the badge editor, and the `icon_only` icon-scale + `badge_scale` clamp.