### PR TITLE
Per-section reset buttons in the editor (#235)

### DIFF
--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2692,6 +2692,11 @@ export class PollenEditorBase extends LitElement {
     // gone.
     this._userConfig = {};
     this.setConfig(base);
+    // setConfig re-derives _config for rendering and (card editor) injects
+    // LEVELS_DEFAULTS into _userConfig. Restore the clean `base` as the
+    // user-origin view so a subsequent section reset doesn't start from a
+    // defaults-polluted base and persist level defaults as if user settings.
+    this._userConfig = { ...base };
     this.dispatchEvent(
       new CustomEvent("config-changed", {
         detail: { config: base },

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2677,9 +2677,10 @@ export class PollenEditorBase extends LitElement {
     }
     // Clear _userConfig BEFORE re-seeding: the card editor's setConfig
     // deep-merges its argument into the existing _userConfig, which would
-    // reintroduce the just-deleted keys. _resetAll clears it for the same
-    // reason; setConfig(base) then restores the kept keys while the section
-    // keys stay gone.
+    // reintroduce the just-deleted keys. (The card editor's _resetAll override
+    // clears _userConfig for the same reason before delegating to the base.)
+    // setConfig(base) then restores the kept keys while the section keys stay
+    // gone.
     this._userConfig = {};
     this.setConfig(base);
     this.dispatchEvent(
@@ -2700,20 +2701,25 @@ export class PollenEditorBase extends LitElement {
    * @returns {import("lit").TemplateResult}
    */
   _renderSectionReset(keys) {
+    const label = this._t("preset_reset_section") || "Reset section";
+    // Compact icon button absolutely positioned + vertically centred in the
+    // section header (.section-reset CSS lives in each editor's styles). A
+    // plain <button> instead of <ha-button> keeps it small and avoids the
+    // chunky Material button height that overflowed the summary bar.
     return html`
-      <ha-button
-        outlined
+      <button
+        type="button"
         class="section-reset"
-        title="${this._t("preset_reset_section") || "Reset section"}"
-        aria-label="${this._t("preset_reset_section") || "Reset section"}"
-        style="float: right; --mdc-typography-button-font-size: 14px;"
+        title="${label}"
+        aria-label="${label}"
         @click=${(e) => {
           e.preventDefault();
           e.stopPropagation();
           this._resetSection(keys);
         }}
-        >↺</ha-button
       >
+        ↺
+      </button>
     `;
   }
 

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2729,7 +2729,13 @@ export class PollenEditorBase extends LitElement {
       "allergen_stroke_width",
       "no_allergens_color",
     ];
-    if (this._inheritState().gapDisabled) keys.push("levels_gap");
+    const { inheritMode, gapDisabled } = this._inheritState();
+    // In inherit_allergen mode the allergen settings DERIVE level keys via
+    // _applyVisualConfigSideEffects: allergen_stroke_width -> levels_gap (when
+    // synced) and allergen_colors[0] -> levels_empty_color. Clear those derived
+    // keys too, else the reset leaves the ring's gap/empty-color customized.
+    if (gapDisabled) keys.push("levels_gap");
+    if (inheritMode === "inherit_allergen") keys.push("levels_empty_color");
     return keys;
   }
 
@@ -2753,13 +2759,19 @@ export class PollenEditorBase extends LitElement {
     ];
   }
 
-  // Keys reset by the Icon in ring (§8) section button.
+  // Keys reset by the Icon in ring (§8) section button. levels_thickness is
+  // included only when it was auto-thinned by enabling icon_in_ring (tracked by
+  // _thicknessAutoShifted) and never user-customized; otherwise turning the
+  // feature off via reset would leave the rings unexpectedly thin. A
+  // user-customized thickness is owned by §7 and left untouched.
   _iconInRingResetKeys() {
-    return [
+    const keys = [
       "icon_in_ring",
       "icon_in_ring_color_mode",
       "icon_in_ring_size_ratio",
       "icon_in_ring_static_color",
     ];
+    if (this._thicknessAutoShifted) keys.push("levels_thickness");
+    return keys;
   }
 }

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2669,6 +2669,12 @@ export class PollenEditorBase extends LitElement {
     if (!Array.isArray(keys) || !keys.length) return;
     const base = { ...(this._userConfig || {}) };
     for (const k of keys) delete base[k];
+    // Preserve the HA `type` key (as _resetAll does): _userConfig may lack it
+    // even when _config carries it, and dispatching a config without `type`
+    // can break HA card persistence.
+    if (base.type === undefined && this._config?.type !== undefined) {
+      base.type = this._config.type;
+    }
     // Clear _userConfig BEFORE re-seeding: the card editor's setConfig
     // deep-merges its argument into the existing _userConfig, which would
     // reintroduce the just-deleted keys. _resetAll clears it for the same

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2659,7 +2659,9 @@ export class PollenEditorBase extends LitElement {
    * Reset one section's options to their defaults: drop the listed keys from
    * the user-origin config so the stub / element defaults take over, then
    * re-seed via setConfig and dispatch. Scoped sibling of _resetAll; works for
-   * both editors because _userConfig is the user-origin view they each persist.
+   * both editors because _userConfig is the user-origin view both editors
+   * maintain and which serves as the reset base (it is not necessarily what
+   * gets dispatched in config-changed).
    *
    * @param {string[]} keys
    */

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -389,7 +389,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §1 Integration & Location -->
       <details open>
-        <summary>${this._t("summary_integration_and_place")}</summary>
+        <summary>
+          ${this._t("summary_integration_and_place")}
+          ${this._renderSectionReset(this._integrationResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_integration_and_place")}</div>
 
         <div class="subgroup-header">${this._t("subgroup_source")}</div>
@@ -839,7 +842,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §2 Allergens (promoted to §2, moved from old §3) -->
       <details>
-        <summary>${this._t("summary_allergens")}</summary>
+        <summary>
+          ${this._t("summary_allergens")}
+          ${this._renderSectionReset(this._allergensResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_allergens")}</div>
         ${c.integration === "kleenex" || c.integration === "gpl" || c.integration === "gp"
           ? html`
@@ -2318,7 +2324,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- Translations & strings -->
       <details>
-        <summary>${this._t("summary_translation_and_strings")}</summary>
+        <summary>
+          ${this._t("summary_translation_and_strings")}
+          ${this._renderSectionReset(this._phrasesResetKeys())}
+        </summary>
         <div class="section-helper">
           ${this._t("helper_translation_and_strings")}
         </div>
@@ -2787,5 +2796,50 @@ export class PollenEditorBase extends LitElement {
     ];
     if (this._thicknessAutoShifted) keys.push("levels_thickness");
     return keys;
+  }
+
+  // Keys reset by the Integration & Location (§1) section button. Resets the
+  // place/title WITHIN the chosen integration but keeps `integration` itself —
+  // switching integration is the global "Reset all"'s job, not a section reset.
+  // These are exactly the identity keys _resetAll preserves, so the two are
+  // complementary; after the reset the location re-autodetects.
+  _integrationResetKeys() {
+    return [
+      "city",
+      "region_id",
+      "location",
+      "entity_prefix",
+      "entity_suffix",
+      "entity_weather",
+      "title",
+    ];
+  }
+
+  // Keys reset by the Allergens (§2) section button: selection, threshold,
+  // sort, pin-to-top, and the summary/pollution-block toggles.
+  _allergensResetKeys() {
+    return [
+      "allergens",
+      "pollen_threshold",
+      "sort",
+      "sort_category_allergens_first",
+      "sort_pollution_block",
+      "pollution_block_position",
+      "show_block_separator",
+      "show_summary_block",
+      "show_summary_row",
+      "show_summary_separator",
+      "show_summary_top_types",
+      "show_summary_plants_in_season",
+      "allergy_risk_top",
+      "index_top",
+    ];
+  }
+
+  // Keys reset by the Translations & strings (§9) section button: custom
+  // allergen/level/day phrase overrides and the date locale (which re-autofills
+  // from the HA locale afterwards).
+  _phrasesResetKeys() {
+    return ["phrases", "date_locale"];
   }
 }

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2716,19 +2716,21 @@ export class PollenEditorBase extends LitElement {
   }
 
   // Keys reset by the Allergen icons (§6) section button. levels_gap is
-  // included because in synced mode (allergen_levels_gap_synced, the default)
-  // editing allergen_stroke_width also writes levels_gap and disables the §7
-  // gap control, so resetting the stroke width must clear the derived gap too.
+  // included ONLY when it is actually derived from allergen_stroke_width, i.e.
+  // inherit_allergen mode with the gap synced (gapDisabled). When the user has
+  // unsynced the gap or picked custom mode, levels_gap is owned by the §7 Level
+  // circles section and an icon reset must not clear it.
   _allergenIconsResetKeys() {
-    return [
+    const keys = [
       "allergen_color_mode",
       "allergen_colors",
       "allergen_outline_color",
       "allergen_stroke_color_synced",
       "allergen_stroke_width",
       "no_allergens_color",
-      "levels_gap",
     ];
+    if (this._inheritState().gapDisabled) keys.push("levels_gap");
+    return keys;
   }
 
   // Keys reset by the Level circles (§7) section button.

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2799,10 +2799,10 @@ export class PollenEditorBase extends LitElement {
   }
 
   // Keys reset by the Integration & Location (§1) section button. Resets the
-  // place/title WITHIN the chosen integration but keeps `integration` itself —
-  // switching integration is the global "Reset all"'s job, not a section reset.
-  // These are exactly the identity keys _resetAll preserves, so the two are
-  // complementary; after the reset the location re-autodetects.
+  // place/title (and the SILAM/PEU forecast `mode` selector, which is rendered
+  // in this section) WITHIN the chosen integration but keeps `integration`
+  // itself — switching integration is the global "Reset all"'s job, not a
+  // section reset. After the reset the location re-autodetects.
   _integrationResetKeys() {
     return [
       "city",
@@ -2812,6 +2812,7 @@ export class PollenEditorBase extends LitElement {
       "entity_suffix",
       "entity_weather",
       "title",
+      "mode",
     ];
   }
 

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -1291,7 +1291,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §5 Card appearance -->
       <details>
-        <summary>${this._t("summary_card_appearance")}</summary>
+        <summary>
+          ${this._t("summary_card_appearance")}
+          ${this._renderSectionReset(this._appearanceResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_card_appearance")}</div>
         <ha-formfield label="${this._t("background_color")}">
             <div style="display:flex; gap:8px; align-items:center;">
@@ -1396,7 +1399,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §6 Allergen icons -->
       <details>
-        <summary>${this._t("summary_allergen_icons")}</summary>
+        <summary>
+          ${this._t("summary_allergen_icons")}
+          ${this._renderSectionReset(this._allergenIconsResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_allergen_icons")}</div>
         <ha-formfield
           label="${this._t("allergen_color_mode") ||
@@ -1701,7 +1707,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §7 Level circles -->
       <details>
-        <summary>${this._t("summary_level_circles")}</summary>
+        <summary>
+          ${this._t("summary_level_circles")}
+          ${this._renderSectionReset(this._levelCirclesResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_level_circles")}</div>
         <ha-formfield
           label="${this._t("levels_inherit_mode")}"
@@ -2096,7 +2105,10 @@ export class PollenEditorBase extends LitElement {
     return html`
       <!-- §8 Icon in ring -->
       <details>
-        <summary>${this._t("summary_icon_in_ring")}</summary>
+        <summary>
+          ${this._t("summary_icon_in_ring")}
+          ${this._renderSectionReset(this._iconInRingResetKeys())}
+        </summary>
         <div class="section-helper">${this._t("helper_icon_in_ring")}</div>
         ${this._showIconInRingToggle()
           ? html`
@@ -2637,5 +2649,106 @@ export class PollenEditorBase extends LitElement {
         composed: true,
       }),
     );
+  }
+
+  // ------------------------------------------------------------------
+  // Per-section reset
+  // ------------------------------------------------------------------
+
+  /**
+   * Reset one section's options to their defaults: drop the listed keys from
+   * the user-origin config so the stub / element defaults take over, then
+   * re-seed via setConfig and dispatch. Scoped sibling of _resetAll; works for
+   * both editors because _userConfig is the user-origin view they each persist.
+   *
+   * @param {string[]} keys
+   */
+  _resetSection(keys) {
+    if (!Array.isArray(keys) || !keys.length) return;
+    const base = { ...(this._userConfig || {}) };
+    for (const k of keys) delete base[k];
+    // setConfig (subclass) re-derives the stub-merged _config for rendering and
+    // re-seeds _userConfig from `base`, mirroring _resetAll.
+    this.setConfig(base);
+    this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: { config: base },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
+   * Small reset button for a section header. Resets the given keys via
+   * _resetSection. Rendered inside the <summary>; stops propagation and
+   * prevents default so clicking it doesn't toggle the <details>.
+   *
+   * @param {string[]} keys
+   * @returns {import("lit").TemplateResult}
+   */
+  _renderSectionReset(keys) {
+    return html`
+      <ha-button
+        outlined
+        class="section-reset"
+        title="${this._t("preset_reset_section") || "Reset section"}"
+        style="float: right; --mdc-typography-button-font-size: 14px;"
+        @click=${(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          this._resetSection(keys);
+        }}
+        >↺</ha-button
+      >
+    `;
+  }
+
+  // Keys reset by the Card appearance (§5) section button. The badge editor
+  // overrides this to add its badge_* size/label keys.
+  _appearanceResetKeys() {
+    return ["background_color", "icon_size", "text_size_ratio"];
+  }
+
+  // Keys reset by the Allergen icons (§6) section button.
+  _allergenIconsResetKeys() {
+    return [
+      "allergen_color_mode",
+      "allergen_colors",
+      "allergen_outline_color",
+      "allergen_stroke_color_synced",
+      "allergen_stroke_width",
+      "no_allergens_color",
+    ];
+  }
+
+  // Keys reset by the Level circles (§7) section button.
+  _levelCirclesResetKeys() {
+    return [
+      "levels_inherit_mode",
+      "levels_colors",
+      "levels_empty_color",
+      "levels_thickness",
+      "levels_gap",
+      "levels_gap_color",
+      "levels_icon_ratio",
+      "levels_text_size",
+      "levels_text_color",
+      "levels_text_weight",
+      "allergen_levels_gap_synced",
+      "numeric_value_raw",
+      "numeric_state_raw_risk",
+      "show_value_numeric_in_circle",
+    ];
+  }
+
+  // Keys reset by the Icon in ring (§8) section button.
+  _iconInRingResetKeys() {
+    return [
+      "icon_in_ring",
+      "icon_in_ring_color_mode",
+      "icon_in_ring_size_ratio",
+      "icon_in_ring_static_color",
+    ];
   }
 }

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -2667,8 +2667,12 @@ export class PollenEditorBase extends LitElement {
     if (!Array.isArray(keys) || !keys.length) return;
     const base = { ...(this._userConfig || {}) };
     for (const k of keys) delete base[k];
-    // setConfig (subclass) re-derives the stub-merged _config for rendering and
-    // re-seeds _userConfig from `base`, mirroring _resetAll.
+    // Clear _userConfig BEFORE re-seeding: the card editor's setConfig
+    // deep-merges its argument into the existing _userConfig, which would
+    // reintroduce the just-deleted keys. _resetAll clears it for the same
+    // reason; setConfig(base) then restores the kept keys while the section
+    // keys stay gone.
+    this._userConfig = {};
     this.setConfig(base);
     this.dispatchEvent(
       new CustomEvent("config-changed", {
@@ -2693,6 +2697,7 @@ export class PollenEditorBase extends LitElement {
         outlined
         class="section-reset"
         title="${this._t("preset_reset_section") || "Reset section"}"
+        aria-label="${this._t("preset_reset_section") || "Reset section"}"
         style="float: right; --mdc-typography-button-font-size: 14px;"
         @click=${(e) => {
           e.preventDefault();
@@ -2710,7 +2715,10 @@ export class PollenEditorBase extends LitElement {
     return ["background_color", "icon_size", "text_size_ratio"];
   }
 
-  // Keys reset by the Allergen icons (§6) section button.
+  // Keys reset by the Allergen icons (§6) section button. levels_gap is
+  // included because in synced mode (allergen_levels_gap_synced, the default)
+  // editing allergen_stroke_width also writes levels_gap and disables the §7
+  // gap control, so resetting the stroke width must clear the derived gap too.
   _allergenIconsResetKeys() {
     return [
       "allergen_color_mode",
@@ -2719,6 +2727,7 @@ export class PollenEditorBase extends LitElement {
       "allergen_stroke_color_synced",
       "allergen_stroke_width",
       "no_allergens_color",
+      "levels_gap",
     ];
   }
 

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -35,7 +35,7 @@
 //   - The icon_in_ring branch needs the session flag this._thicknessAutoShifted;
 //     the caller must maintain that flag based on the returned state.
 
-import { LitElement, html } from "lit";
+import { LitElement, html, css } from "lit";
 import { t, detectLang, SUPPORTED_LOCALES } from "../i18n.js";
 import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
@@ -127,6 +127,48 @@ export const deepMerge = (target, source) => {
  * Subclasses MAY override `_showTitleSection()` / `_showModeSelector()` to drop
  * card-only controls (the badge editor returns false for both).
  */
+/**
+ * Shared CSS for the per-section ↺ reset button and its summary anchoring.
+ * Spliced into both editors' styles (PollenPrognosCardEditor and
+ * PollenPrognosBadgeEditor) so the two never drift. `details > summary` reserves
+ * right padding for the absolutely-positioned, vertically-centred button;
+ * :focus-visible gives keyboard users a ring. Avoids :has() (older Firefox ESR).
+ */
+export const sectionResetStyles = css`
+  details > summary {
+    position: relative;
+    padding-right: 48px;
+  }
+  .section-reset {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border-radius: 50%;
+    border: 1px solid var(--divider-color, #ccc);
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .section-reset:hover,
+  .section-reset:focus-visible {
+    background: var(--secondary-background-color);
+    color: var(--primary-text-color);
+  }
+  .section-reset:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 1px;
+  }
+`;
+
 export class PollenEditorBase extends LitElement {
   // ------------------------------------------------------------------
   // Presentation hooks (overridable by subclasses)
@@ -2804,12 +2846,16 @@ export class PollenEditorBase extends LitElement {
   }
 
   // Keys reset by the Integration & Location (§1) section button. Resets the
-  // place/title (and the SILAM/PEU forecast `mode` selector, which is rendered
-  // in this section) WITHIN the chosen integration but keeps `integration`
-  // itself — switching integration is the global "Reset all"'s job, not a
-  // section reset. After the reset the location re-autodetects.
+  // place/title WITHIN the chosen integration but keeps `integration` itself —
+  // switching integration is the global "Reset all"'s job, not a section reset.
+  // After the reset the location re-autodetects. For SILAM/PEU the forecast
+  // `mode` selector is rendered in this section; clear it AND its hard-coupled
+  // day-display side effects (changing mode auto-writes days_to_show /
+  // show_empty_days), so the reset returns the whole mode-related config to
+  // defaults. Other integrations have no mode control here, so those keys are
+  // left to the Day display (§4) reset.
   _integrationResetKeys() {
-    return [
+    const keys = [
       "city",
       "region_id",
       "location",
@@ -2817,8 +2863,12 @@ export class PollenEditorBase extends LitElement {
       "entity_suffix",
       "entity_weather",
       "title",
-      "mode",
     ];
+    const integration = this._config?.integration;
+    if (integration === "silam" || integration === "peu") {
+      keys.push("mode", "days_to_show", "show_empty_days");
+    }
+    return keys;
   }
 
   // Keys reset by the Allergens (§2) section button: selection, threshold,

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Pozice znečištění",
   "editor.pollution_block_top": "Nahoře (nad pylem)",
   "editor.preset_reset_all": "Obnovit všechna nastavení",
+  "editor.preset_reset_section": "Obnovit sekci",
   "editor.region_id": "ID regionu",
   "editor.select_all_allergens": "Vybrat všechny alergeny",
   "editor.select_all_pollen": "Vybrat pyl",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Position for luftkvalitet",
   "editor.pollution_block_top": "Øverst (over pollen)",
   "editor.preset_reset_all": "Nulstil alle indstillinger",
+  "editor.preset_reset_section": "Nulstil afsnit",
   "editor.region_id": "Regions-ID",
   "editor.select_all_allergens": "Vælg alle allergener",
   "editor.select_all_pollen": "Vælg pollen",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Position der Luftqualität",
   "editor.pollution_block_top": "Oben (über Pollen)",
   "editor.preset_reset_all": "Alles zurücksetzen",
+  "editor.preset_reset_section": "Abschnitt zurücksetzen",
   "editor.region_id": "Region ID",
   "editor.select_all_allergens": "Alle Allergene auswählen",
   "editor.select_all_pollen": "Pollen auswählen",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Θέση ρύπανσης",
   "editor.pollution_block_top": "Πάνω (πάνω από τη γύρη)",
   "editor.preset_reset_all": "Επαναφορά όλων των ρυθμίσεων",
+  "editor.preset_reset_section": "Επαναφορά ενότητας",
   "editor.region_id": "ID περιοχής",
   "editor.select_all_allergens": "Επιλογή όλων των αλλεργιογόνων",
   "editor.select_all_pollen": "Επιλογή γύρης",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -332,6 +332,7 @@
   "editor.pollution_block_position": "Pollution position",
   "editor.pollution_block_top": "Top (above pollen)",
   "editor.preset_reset_all": "Reset all settings",
+  "editor.preset_reset_section": "Reset section",
   "editor.region_id": "Region ID",
   "editor.select_all_allergens": "Select all allergens",
   "editor.select_all_pollen": "Select pollen",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Posición de la contaminación",
   "editor.pollution_block_top": "Arriba (encima del polen)",
   "editor.preset_reset_all": "Restablecer toda la configuración",
+  "editor.preset_reset_section": "Restablecer sección",
   "editor.region_id": "ID de región",
   "editor.select_all_allergens": "Seleccionar todos los alérgenos",
   "editor.select_all_pollen": "Seleccionar polen",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Ilmanlaadun sijainti",
   "editor.pollution_block_top": "Ylhäällä (siitepölyn yläpuolella)",
   "editor.preset_reset_all": "Palauta kaikki asetukset",
+  "editor.preset_reset_section": "Palauta osio",
   "editor.region_id": "Alueen tunnus",
   "editor.select_all_allergens": "Valitse kaikki allergeenit",
   "editor.select_all_pollen": "Valitse siitepöly",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Position de la pollution",
   "editor.pollution_block_top": "En haut (au-dessus du pollen)",
   "editor.preset_reset_all": "Réinitialiser tous les paramètres",
+  "editor.preset_reset_section": "Réinitialiser la section",
   "editor.region_id": "ID de région",
   "editor.select_all_allergens": "Sélectionner tous les allergènes",
   "editor.select_all_pollen": "Sélectionner le pollen",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Posizione inquinamento",
   "editor.pollution_block_top": "In alto (sopra il polline)",
   "editor.preset_reset_all": "Ripristina tutte le impostazioni",
+  "editor.preset_reset_section": "Ripristina sezione",
   "editor.region_id": "ID Regione",
   "editor.select_all_allergens": "Seleziona tutti gli allergeni",
   "editor.select_all_pollen": "Seleziona polline",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Positie luchtkwaliteit",
   "editor.pollution_block_top": "Bovenaan (boven pollen)",
   "editor.preset_reset_all": "Alle instellingen resetten",
+  "editor.preset_reset_section": "Sectie resetten",
   "editor.region_id": "Regio-ID",
   "editor.select_all_allergens": "Selecteer alle allergenen",
   "editor.select_all_pollen": "Pollen selecteren",

--- a/src/locales/no.json
+++ b/src/locales/no.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Posisjon for luftkvalitet",
   "editor.pollution_block_top": "Øverst (over pollen)",
   "editor.preset_reset_all": "Tilbakestill alle innstillinger",
+  "editor.preset_reset_section": "Tilbakestill seksjon",
   "editor.region_id": "Region-ID",
   "editor.select_all_allergens": "Velg alle allergener",
   "editor.select_all_pollen": "Velg pollen",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Pozycja zanieczyszczeń",
   "editor.pollution_block_top": "Na górze (nad pyłkiem)",
   "editor.preset_reset_all": "Przywróć ustawienia",
+  "editor.preset_reset_section": "Przywróć sekcję",
   "editor.region_id": "ID regionu",
   "editor.select_all_allergens": "Wybierz wszystkie alergeny",
   "editor.select_all_pollen": "Wybierz pyłek",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Позиция загрязнения",
   "editor.pollution_block_top": "Сверху (над пыльцой)",
   "editor.preset_reset_all": "Сбросить все настройки",
+  "editor.preset_reset_section": "Сбросить раздел",
   "editor.region_id": "ID региона",
   "editor.select_all_allergens": "Выбрать все аллергены",
   "editor.select_all_pollen": "Выбрать пыльцу",

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Pozícia znečistenia",
   "editor.pollution_block_top": "Hore (nad peľom)",
   "editor.preset_reset_all": "Obnoviť všetky nastavenia",
+  "editor.preset_reset_section": "Obnoviť sekciu",
   "editor.region_id": "ID regiónu",
   "editor.select_all_allergens": "Vybrať všetky alergény",
   "editor.select_all_pollen": "Vybrať peľ",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -331,6 +331,7 @@
   "editor.pollution_block_position": "Position för luftkvalitet",
   "editor.pollution_block_top": "Överst (ovanför pollen)",
   "editor.preset_reset_all": "Återställ allt",
+  "editor.preset_reset_section": "Återställ avsnitt",
   "editor.region_id": "Region ID",
   "editor.select_all_allergens": "Välj alla allergener",
   "editor.select_all_pollen": "Välj pollen",

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -546,6 +546,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     return [
       ...super._appearanceResetKeys(),
       "badge_scale",
+      "badge_icon_scale",
       "badge_show_label",
       "badge_label_position",
     ];

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -546,7 +546,6 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     return [
       ...super._appearanceResetKeys(),
       "badge_scale",
-      "badge_icon_scale",
       "badge_show_label",
       "badge_label_position",
     ];

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -5,7 +5,7 @@
 
 import { html, css } from "lit";
 import { getStubConfig } from "./adapter-registry.js";
-import { PollenEditorBase, deepMerge } from "./editor/base.js";
+import { PollenEditorBase, deepMerge, sectionResetStyles } from "./editor/base.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import { coerceBool } from "./utils/adapter-helpers.js";
 import { deepEqual } from "./utils/confcompare.js";
@@ -768,45 +768,8 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-bottom: 4px;
       }
 
-      /* Anchor for the per-section reset button so it can centre itself, and
-         reserve room on the right so a long section title can't run under the
-         absolutely-positioned button. Applied to every summary (avoids :has(),
-         which older Firefox ESR lacks); the extra right padding on the few
-         reset-less nested summaries is just whitespace. */
-      details > summary {
-        position: relative;
-        padding-right: 48px;
-      }
-      /* Compact ↺ reset button in the section header: small circle, vertically
-         centred, ghost style until hovered/focused. */
-      .section-reset {
-        position: absolute;
-        right: 12px;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 26px;
-        height: 26px;
-        padding: 0;
-        border-radius: 50%;
-        border: 1px solid var(--divider-color, #ccc);
-        background: transparent;
-        color: var(--secondary-text-color);
-        font-size: 15px;
-        line-height: 1;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .section-reset:hover,
-      .section-reset:focus-visible {
-        background: var(--secondary-background-color);
-        color: var(--primary-text-color);
-      }
-      .section-reset:focus-visible {
-        outline: 2px solid var(--primary-color);
-        outline-offset: 1px;
-      }
+      /* Per-section ↺ reset button styles (shared with the card editor). */
+      ${sectionResetStyles}
 
       details details {
         margin-left: 24px;

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -768,12 +768,16 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-bottom: 4px;
       }
 
-      /* Anchor for the per-section reset button so it can centre itself. */
+      /* Anchor for the per-section reset button so it can centre itself, and
+         reserve room on the right so a long section title can't run under it. */
       details > summary {
         position: relative;
       }
+      details > summary:has(.section-reset) {
+        padding-right: 48px;
+      }
       /* Compact ↺ reset button in the section header: small circle, vertically
-         centred, ghost style until hovered. */
+         centred, ghost style until hovered/focused. */
       .section-reset {
         position: absolute;
         right: 12px;
@@ -793,9 +797,14 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         align-items: center;
         justify-content: center;
       }
-      .section-reset:hover {
+      .section-reset:hover,
+      .section-reset:focus-visible {
         background: var(--secondary-background-color);
         color: var(--primary-text-color);
+      }
+      .section-reset:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 1px;
       }
 
       details details {

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -768,6 +768,36 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-bottom: 4px;
       }
 
+      /* Anchor for the per-section reset button so it can centre itself. */
+      details > summary {
+        position: relative;
+      }
+      /* Compact ↺ reset button in the section header: small circle, vertically
+         centred, ghost style until hovered. */
+      .section-reset {
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 26px;
+        height: 26px;
+        padding: 0;
+        border-radius: 50%;
+        border: 1px solid var(--divider-color, #ccc);
+        background: transparent;
+        color: var(--secondary-text-color);
+        font-size: 15px;
+        line-height: 1;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .section-reset:hover {
+        background: var(--secondary-background-color);
+        color: var(--primary-text-color);
+      }
+
       details details {
         margin-left: 24px;
         margin-right: 24px;

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -448,7 +448,14 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
 
     return html`
       <details open>
-        <summary>${this._t("summary_badge_content")}</summary>
+        <summary>
+          ${this._t("summary_badge_content")}
+          ${this._renderSectionReset([
+            "badge_visual",
+            "badge_content",
+            "badge_single_allergen",
+          ])}
+        </summary>
         <div class="section-helper">${this._t("helper_badge_content")}</div>
 
         <!-- badge_visual: what kind of badge (the section header + helper say
@@ -530,6 +537,18 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
   // shared Card appearance section; the badge uses badge_scale instead.
   _showCardSizeControls() {
     return false;
+  }
+
+  // The Card appearance (§5) reset also clears the badge size/label keys, which
+  // live in this section via _renderAppearanceExtras (icon_size/text_size_ratio
+  // are hidden on the badge but harmless to include).
+  _appearanceResetKeys() {
+    return [
+      ...super._appearanceResetKeys(),
+      "badge_scale",
+      "badge_show_label",
+      "badge_label_position",
+    ];
   }
 
   // Badge size + label controls, rendered inside the shared Card appearance

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -769,11 +769,12 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       }
 
       /* Anchor for the per-section reset button so it can centre itself, and
-         reserve room on the right so a long section title can't run under it. */
+         reserve room on the right so a long section title can't run under the
+         absolutely-positioned button. Applied to every summary (avoids :has(),
+         which older Firefox ESR lacks); the extra right padding on the few
+         reset-less nested summaries is just whitespace. */
       details > summary {
         position: relative;
-      }
-      details > summary:has(.section-reset) {
         padding-right: 48px;
       }
       /* Compact ↺ reset button in the section header: small circle, vertically

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1869,12 +1869,16 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         margin-bottom: 4px; /* Space below summary */
       }
 
-      /* Anchor for the per-section reset button so it can centre itself. */
+      /* Anchor for the per-section reset button so it can centre itself, and
+         reserve room on the right so a long section title can't run under it. */
       details > summary {
         position: relative;
       }
+      details > summary:has(.section-reset) {
+        padding-right: 48px;
+      }
       /* Compact ↺ reset button in the section header: small circle, vertically
-         centred, ghost style until hovered. */
+         centred, ghost style until hovered/focused. */
       .section-reset {
         position: absolute;
         right: 12px;
@@ -1894,9 +1898,14 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         align-items: center;
         justify-content: center;
       }
-      .section-reset:hover {
+      .section-reset:hover,
+      .section-reset:focus-visible {
         background: var(--secondary-background-color);
         color: var(--primary-text-color);
+      }
+      .section-reset:focus-visible {
+        outline: 2px solid var(--primary-color);
+        outline-offset: 1px;
       }
 
       /* Nested details styling */

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1383,7 +1383,16 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
         <!-- §3 Card layout (open by default) -->
         <details open>
-          <summary>${this._t("summary_card_layout")}</summary>
+          <summary>
+            ${this._t("summary_card_layout")}
+            ${this._renderSectionReset([
+              "minimal",
+              "minimal_gap",
+              "allergens_abbreviated",
+              "show_allergen_column",
+              "show_text_allergen",
+            ])}
+          </summary>
           <div class="section-helper">${this._t("helper_card_layout")}</div>
           <ha-formfield label="${this._t("minimal")}">
             <ha-switch
@@ -1450,7 +1459,20 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
         <!-- §4 Day display -->
         <details>
-          <summary>${this._t("summary_day_display")}</summary>
+          <summary>
+            ${this._t("summary_day_display")}
+            ${this._renderSectionReset([
+              "days_to_show",
+              "days_abbreviated",
+              "days_boldfaced",
+              "days_relative",
+              "days_uppercase",
+              "show_empty_days",
+              "show_no_data_distinct",
+              "show_value_numeric",
+              "show_value_text",
+            ])}
+          </summary>
           <div class="section-helper">${this._t("helper_day_display")}</div>
 
           <div class="subgroup-header">${this._t("subgroup_values")}</div>
@@ -1555,7 +1577,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
         <!-- §10 Card interactivity -->
         <details>
-          <summary>${this._t("summary_card_interactivity")}</summary>
+          <summary>
+            ${this._t("summary_card_interactivity")}
+            ${this._renderSectionReset(["tap_action", "link_to_sensors"])}
+          </summary>
           <div class="section-helper">${this._t("helper_card_interactivity")}</div>
           <h3>${this._t("tap_action")}</h3>
           <ha-formfield label="${this._t("link_to_sensors")}">
@@ -1703,7 +1728,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
         <!-- §11 Advanced -->
         <details>
-          <summary>${this._t("summary_advanced")}</summary>
+          <summary>
+            ${this._t("summary_advanced")}
+            ${this._renderSectionReset(["debug", "show_version"])}
+          </summary>
           <div class="section-helper">${this._t("helper_advanced")}</div>
           <ha-formfield label="${this._t("debug")}">
             <ha-switch

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1251,9 +1251,13 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       cfg = deepMerge(base, newUser);
       cfg.integration = newInt;
 
-      // Immediately mark integration as explicit so set hass() won't
-      // override the user's choice before the round-trip completes.
-      this._userConfig.integration = newInt;
+      // _userConfig becomes the pruned user-origin config (location/allergen
+      // keys for the old integration removed) + the new integration. Assigning
+      // newUser keeps _userConfig clean — the generic per-key sync below is
+      // skipped for integration changes, since diffing cfg (full new-integration
+      // stub) against the old _config would mark stub defaults as user-set.
+      newUser.integration = newInt;
+      this._userConfig = newUser;
       this._integrationExplicit = true;
     } else {
       cfg = { ...this._config, [prop]: value };
@@ -1349,9 +1353,14 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     // Sync _userConfig with every key this edit changed (the edited prop plus
     // any side-effect keys written above), diffed against the pre-edit config.
     // Mirrors the visual-side-effects branch; keeps _userConfig a faithful
-    // user-origin view so per-section resets derive correct payloads.
-    for (const k of Object.keys(cfg)) {
-      if (!deepEqual(cfg[k], this._config[k])) this._userConfig[k] = cfg[k];
+    // user-origin view so per-section resets derive correct payloads. Skipped
+    // for integration changes: cfg there is the new integration's full stub, so
+    // diffing it against the old _config would mark stub defaults as user-set —
+    // that branch already set _userConfig to the pruned newUser.
+    if (prop !== "integration") {
+      for (const k of Object.keys(cfg)) {
+        if (!deepEqual(cfg[k], this._config[k])) this._userConfig[k] = cfg[k];
+      }
     }
 
     if (!deepEqual(this._config, cfg)) {

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -9,7 +9,7 @@ import {
 import { COSMETIC_FIELDS } from "./constants.js";
 
 // Shared editor base (deepMerge, section methods, helpers)
-import { PollenEditorBase, deepMerge } from "./editor/base.js";
+import { PollenEditorBase, deepMerge, sectionResetStyles } from "./editor/base.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
@@ -1258,12 +1258,12 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     } else {
       cfg = { ...this._config, [prop]: value };
 
-      // Keep _userConfig in sync with the edited key. Generic fields (debug,
-      // minimal, days_to_show, ...) previously updated only _config, leaving
-      // _userConfig stale until HA's setConfig round-trip; that let a later
-      // per-section reset (which derives its payload from _userConfig) lose the
-      // unsaved edit. Syncing here keeps _userConfig the current user-origin view.
-      this._userConfig = { ...this._userConfig, [prop]: value };
+      // _userConfig is synced to the full set of changed keys below (after all
+      // side-effects are applied), so it stays a faithful user-origin view even
+      // for generic fields and side-effect keys (entity_prefix/suffix on leaving
+      // manual mode, mode->days_to_show, ...). That keeps per-section resets,
+      // which derive their payload from _userConfig, from losing or resurrecting
+      // stale values before HA's setConfig round-trip.
 
       // Track explicit allergen changes
       if (prop === "allergens") {
@@ -1345,6 +1345,14 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
     }
     cfg.type = this._config.type;
+
+    // Sync _userConfig with every key this edit changed (the edited prop plus
+    // any side-effect keys written above), diffed against the pre-edit config.
+    // Mirrors the visual-side-effects branch; keeps _userConfig a faithful
+    // user-origin view so per-section resets derive correct payloads.
+    for (const k of Object.keys(cfg)) {
+      if (!deepEqual(cfg[k], this._config[k])) this._userConfig[k] = cfg[k];
+    }
 
     if (!deepEqual(this._config, cfg)) {
       this._config = cfg;
@@ -1876,45 +1884,8 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         margin-bottom: 4px; /* Space below summary */
       }
 
-      /* Anchor for the per-section reset button so it can centre itself, and
-         reserve room on the right so a long section title can't run under the
-         absolutely-positioned button. Applied to every summary (avoids :has(),
-         which older Firefox ESR lacks); the extra right padding on the few
-         reset-less nested summaries is just whitespace. */
-      details > summary {
-        position: relative;
-        padding-right: 48px;
-      }
-      /* Compact ↺ reset button in the section header: small circle, vertically
-         centred, ghost style until hovered/focused. */
-      .section-reset {
-        position: absolute;
-        right: 12px;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 26px;
-        height: 26px;
-        padding: 0;
-        border-radius: 50%;
-        border: 1px solid var(--divider-color, #ccc);
-        background: transparent;
-        color: var(--secondary-text-color);
-        font-size: 15px;
-        line-height: 1;
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .section-reset:hover,
-      .section-reset:focus-visible {
-        background: var(--secondary-background-color);
-        color: var(--primary-text-color);
-      }
-      .section-reset:focus-visible {
-        outline: 2px solid var(--primary-color);
-        outline-offset: 1px;
-      }
+      /* Per-section ↺ reset button styles (shared with the badge editor). */
+      ${sectionResetStyles}
 
       /* Nested details styling */
       details details {

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1258,6 +1258,13 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     } else {
       cfg = { ...this._config, [prop]: value };
 
+      // Keep _userConfig in sync with the edited key. Generic fields (debug,
+      // minimal, days_to_show, ...) previously updated only _config, leaving
+      // _userConfig stale until HA's setConfig round-trip; that let a later
+      // per-section reset (which derives its payload from _userConfig) lose the
+      // unsaved edit. Syncing here keeps _userConfig the current user-origin view.
+      this._userConfig = { ...this._userConfig, [prop]: value };
+
       // Track explicit allergen changes
       if (prop === "allergens") {
         
@@ -1870,11 +1877,12 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       /* Anchor for the per-section reset button so it can centre itself, and
-         reserve room on the right so a long section title can't run under it. */
+         reserve room on the right so a long section title can't run under the
+         absolutely-positioned button. Applied to every summary (avoids :has(),
+         which older Firefox ESR lacks); the extra right padding on the few
+         reset-less nested summaries is just whitespace. */
       details > summary {
         position: relative;
-      }
-      details > summary:has(.section-reset) {
         padding-right: 48px;
       }
       /* Compact ↺ reset button in the section header: small circle, vertically

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -1841,6 +1841,36 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         margin-bottom: 4px; /* Space below summary */
       }
 
+      /* Anchor for the per-section reset button so it can centre itself. */
+      details > summary {
+        position: relative;
+      }
+      /* Compact ↺ reset button in the section header: small circle, vertically
+         centred, ghost style until hovered. */
+      .section-reset {
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 26px;
+        height: 26px;
+        padding: 0;
+        border-radius: 50%;
+        border: 1px solid var(--divider-color, #ccc);
+        background: transparent;
+        color: var(--secondary-text-color);
+        font-size: 15px;
+        line-height: 1;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .section-reset:hover {
+        background: var(--secondary-background-color);
+        color: var(--primary-text-color);
+      }
+
       /* Nested details styling */
       details details {
         margin-left: 24px; /* More indent */


### PR DESCRIPTION
## What

Adds a ↺ reset button to each editor section header so users can revert one section's options to defaults without a full "Reset all" (#235). Both the card and badge editors get them.

## Why

The editor had a global "Reset all" and per-field resets inside Allergen icons / Level circles, but no section-level reset. The #235 reporter found the existing resets helpful and asked for them on the remaining options (appearance, sizes, etc.).

## Changes

- **`src/editor/base.js`**: `_resetSection(keys)` + `_renderSectionReset(keys)` (scoped sibling of `_resetAll`), plus a ↺ button in the §5 Card appearance, §6 Allergen icons, §7 Level circles, and §8 Icon in ring headers. Reset key lists are overridable methods (`_appearanceResetKeys` etc.).
- **`src/pollenprognos-badge-editor.js`**: extends the §5 reset to clear the badge size/label keys (`badge_scale`, `badge_show_label`, `badge_label_position`) and adds a reset to the badge-only Badge content section.
- **Locales**: `preset_reset_section` added to all 15 files.

The button stops propagation / prevents default so clicking it doesn't toggle the section. Reset works by dropping the section's keys from the user config and re-seeding via setConfig, so stub/element defaults take over (no stub bloat in saved YAML).

## Tests

Full suite green (1130). Build clean.

## Note

Independent of the autodetect PR (#246); both touch the badge editor in non-overlapping areas.