### PR TITLE
Badge icon_only icon scale + badge_scale clamp (#235)

### DIFF
--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Měřítko ikony",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Ikonskala",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Symbolskalierung",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Κλίμακα εικονιδίου",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -119,6 +119,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Icon scale",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Escala del icono",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Kuvakkeen koko",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Échelle de l'icône",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Scala icona",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Pictogramschaal",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/no.json
+++ b/src/locales/no.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Ikonskala",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Skala ikony",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Масштаб значка",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Below",
   "editor.badge_label_position_right": "Right",
   "editor.badge_scale": "Badge size (scale)",
+  "editor.badge_icon_scale": "Mierka ikony",
   "editor.badge_show_label": "Show label",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Icon in ring",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -118,6 +118,7 @@
   "editor.badge_label_position_below": "Under",
   "editor.badge_label_position_right": "Höger",
   "editor.badge_scale": "Badgestorlek (skala)",
+  "editor.badge_icon_scale": "Ikonskala",
   "editor.badge_show_label": "Visa etikett",
   "editor.badge_single_allergen": "Allergen",
   "editor.badge_visual_icon_in_ring": "Ikon i ring",

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -561,38 +561,35 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         ></ha-textfield>
       </ha-formfield>
 
-      <!-- badge_icon_scale: shrink/grow ONLY the bare icon in icon_only mode.
-           Hidden in the other visual modes where the icon sits in the ring
-           (use icon_in_ring size ratio there instead). -->
-      ${c.badge_visual === "icon_only"
-        ? html`
-            <ha-formfield label="${this._t("badge_icon_scale")}">
-              <ha-slider
-                min="0.3"
-                max="3"
-                step="0.05"
-                .value=${typeof c.badge_icon_scale === "number"
-                  ? c.badge_icon_scale
-                  : 1}
-                @input=${(e) =>
-                  this._updateConfig("badge_icon_scale", Number(e.target.value))}
-                style="width: 120px;"
-              ></ha-slider>
-              <ha-textfield
-                type="number"
-                min="0.3"
-                max="3"
-                step="0.05"
-                .value=${typeof c.badge_icon_scale === "number"
-                  ? c.badge_icon_scale
-                  : 1}
-                @input=${(e) =>
-                  this._updateConfig("badge_icon_scale", Number(e.target.value))}
-                style="width: 80px;"
-              ></ha-textfield>
-            </ha-formfield>
-          `
-        : ""}
+      <!-- badge_icon_scale: scale the allergen visual as a whole — the ring
+           (and whatever it centres) in the ring modes, the bare icon in
+           icon_only — without touching the label text or the pill box. Shown
+           in every visual mode. -->
+      <ha-formfield label="${this._t("badge_icon_scale")}">
+        <ha-slider
+          min="0.3"
+          max="3"
+          step="0.05"
+          .value=${typeof c.badge_icon_scale === "number"
+            ? c.badge_icon_scale
+            : 1}
+          @input=${(e) =>
+            this._updateConfig("badge_icon_scale", Number(e.target.value))}
+          style="width: 120px;"
+        ></ha-slider>
+        <ha-textfield
+          type="number"
+          min="0.3"
+          max="3"
+          step="0.05"
+          .value=${typeof c.badge_icon_scale === "number"
+            ? c.badge_icon_scale
+            : 1}
+          @input=${(e) =>
+            this._updateConfig("badge_icon_scale", Number(e.target.value))}
+          style="width: 80px;"
+        ></ha-textfield>
+      </ha-formfield>
 
       <!-- badge_show_label / badge_label_position -->
       <ha-formfield label="${this._t("badge_show_label")}">

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -561,6 +561,39 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         ></ha-textfield>
       </ha-formfield>
 
+      <!-- badge_icon_scale: shrink/grow ONLY the bare icon in icon_only mode.
+           Hidden in the other visual modes where the icon sits in the ring
+           (use icon_in_ring size ratio there instead). -->
+      ${c.badge_visual === "icon_only"
+        ? html`
+            <ha-formfield label="${this._t("badge_icon_scale")}">
+              <ha-slider
+                min="0.3"
+                max="2"
+                step="0.05"
+                .value=${typeof c.badge_icon_scale === "number"
+                  ? c.badge_icon_scale
+                  : 1}
+                @input=${(e) =>
+                  this._updateConfig("badge_icon_scale", Number(e.target.value))}
+                style="width: 120px;"
+              ></ha-slider>
+              <ha-textfield
+                type="number"
+                min="0.3"
+                max="3"
+                step="0.05"
+                .value=${typeof c.badge_icon_scale === "number"
+                  ? c.badge_icon_scale
+                  : 1}
+                @input=${(e) =>
+                  this._updateConfig("badge_icon_scale", Number(e.target.value))}
+                style="width: 80px;"
+              ></ha-textfield>
+            </ha-formfield>
+          `
+        : ""}
+
       <!-- badge_show_label / badge_label_position -->
       <ha-formfield label="${this._t("badge_show_label")}">
         <ha-switch

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -569,7 +569,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             <ha-formfield label="${this._t("badge_icon_scale")}">
               <ha-slider
                 min="0.3"
-                max="2"
+                max="3"
                 step="0.05"
                 .value=${typeof c.badge_icon_scale === "number"
                   ? c.badge_icon_scale

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -176,9 +176,22 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       ? config.badge_visual
       : "icon_in_ring";
     // Scale: whole-badge multiplier; default 1 = standard HA badge size.
+    // Clamp to a sane ceiling so a typo (e.g. 100 typed into the editor field)
+    // can't render an editor-breaking giant pill (#235).
+    const BADGE_SCALE_MAX = 10;
     const badgeScaleRaw = Number(config.badge_scale);
     const badgeScale =
-      Number.isFinite(badgeScaleRaw) && badgeScaleRaw > 0 ? badgeScaleRaw : 1;
+      Number.isFinite(badgeScaleRaw) && badgeScaleRaw > 0
+        ? Math.min(badgeScaleRaw, BADGE_SCALE_MAX)
+        : 1;
+    // Icon scale: multiplies ONLY the bare icon in icon_only mode (the whole
+    // pill keeps badge_scale). Default 1 = no change. Lets users shrink the
+    // glyph without shrinking the badge (#235). Same clamp guards a typo.
+    const badgeIconScaleRaw = Number(config.badge_icon_scale);
+    const badgeIconScale =
+      Number.isFinite(badgeIconScaleRaw) && badgeIconScaleRaw > 0
+        ? Math.min(badgeIconScaleRaw, BADGE_SCALE_MAX)
+        : 1;
     // Label position: right (community convention, default) | below.
     const badgeLabelPosition =
       config.badge_label_position === "below" ? "below" : "right";
@@ -225,6 +238,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       badge_show_label: badgeShowLabel,
       badge_visual: badgeVisual,
       badge_scale: badgeScale,
+      badge_icon_scale: badgeIconScale,
       badge_label_position: badgeLabelPosition,
       icon_in_ring: iconInRing,
       show_value_numeric_in_circle: showValueInCircle,
@@ -348,12 +362,18 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     const ring = Math.round(height * 0.78);
     // --ppb-size drives the proportional pill CSS (padding/gap/radius/label);
     // --pollen-icon-size sizes the bare icon used by the icon_only mode.
+    // badge_icon_scale multiplies ONLY that bare icon, so users can shrink the
+    // glyph without shrinking the whole badge (#235). It is consumed only by the
+    // .pp-icon rule (icon_only path); the in-ring icon uses iconSizeRatio, so
+    // applying it here has no effect on the other visual modes.
+    const iconScale = Number(this.config?.badge_icon_scale) || 1;
+    const bareIcon = Math.round(ring * iconScale);
     // A configured background_color sets --ppb-bg (consumed by the .ppb rule,
     // which otherwise falls back to the themed background). Same ?.trim?.()
     // guard the card uses, so non-string YAML values can't throw.
     const bg = this.config?.background_color?.trim?.();
     const hostStyle =
-      `--ppb-size: ${height}px; --pollen-icon-size: ${ring}px;` +
+      `--ppb-size: ${height}px; --pollen-icon-size: ${bareIcon}px;` +
       (bg ? ` --ppb-bg: ${bg};` : "");
 
     // Not yet loaded: render an empty pill placeholder so the badge slot

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -367,7 +367,11 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // both the ring `base` passed to _renderBadgeVisual below and the bare
     // icon's --pollen-icon-size. badge_scale still governs the overall badge.
     const iconScale = Number(this.config?.badge_icon_scale) || 1;
-    const visualSize = Math.round(ring * iconScale);
+    // Cap the scaled visual at the pill height so scaling UP can grow the image
+    // to fill the badge but never overflow it (the ring base is already
+    // 0.78*height, so scales above ~1.28 would otherwise spill out of the pill).
+    // Scaling DOWN is unbounded within the slider range.
+    const visualSize = Math.min(Math.round(ring * iconScale), height);
     // A configured background_color sets --ppb-bg (consumed by the .ppb rule,
     // which otherwise falls back to the themed background). Same ?.trim?.()
     // guard the card uses, so non-string YAML values can't throw.

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -184,9 +184,10 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       Number.isFinite(badgeScaleRaw) && badgeScaleRaw > 0
         ? Math.min(badgeScaleRaw, BADGE_SCALE_MAX)
         : 1;
-    // Icon scale: multiplies ONLY the bare icon in icon_only mode (the whole
-    // pill keeps badge_scale). Default 1 = no change. Lets users shrink the
-    // glyph without shrinking the badge (#235). Same clamp guards a typo.
+    // Icon scale: scales the allergen visual as a whole (the ring in the ring
+    // modes, the bare icon in icon_only) while the pill keeps badge_scale.
+    // Default 1 = no change. Lets users shrink the image without shrinking the
+    // badge (#235). Same clamp guards a typo.
     const badgeIconScaleRaw = Number(config.badge_icon_scale);
     const badgeIconScale =
       Number.isFinite(badgeIconScaleRaw) && badgeIconScaleRaw > 0

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -360,20 +360,20 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // Pill height follows the HA badge convention; the ring sits inside it.
     const height = this._badgeBaseSize();
     const ring = Math.round(height * 0.78);
-    // --ppb-size drives the proportional pill CSS (padding/gap/radius/label);
-    // --pollen-icon-size sizes the bare icon used by the icon_only mode.
-    // badge_icon_scale multiplies ONLY that bare icon, so users can shrink the
-    // glyph without shrinking the whole badge (#235). It is consumed only by the
-    // .pp-icon rule (icon_only path); the in-ring icon uses iconSizeRatio, so
-    // applying it here has no effect on the other visual modes.
+    // --ppb-size drives the proportional pill CSS (padding/gap/radius/label).
+    // badge_icon_scale scales the allergen VISUAL as a whole — the ring (with
+    // whatever it centres: icon or value) in the ring modes, and the bare icon
+    // in icon_only — but NOT the label text or the pill box (#235). So it sizes
+    // both the ring `base` passed to _renderBadgeVisual below and the bare
+    // icon's --pollen-icon-size. badge_scale still governs the overall badge.
     const iconScale = Number(this.config?.badge_icon_scale) || 1;
-    const bareIcon = Math.round(ring * iconScale);
+    const visualSize = Math.round(ring * iconScale);
     // A configured background_color sets --ppb-bg (consumed by the .ppb rule,
     // which otherwise falls back to the themed background). Same ?.trim?.()
     // guard the card uses, so non-string YAML values can't throw.
     const bg = this.config?.background_color?.trim?.();
     const hostStyle =
-      `--ppb-size: ${height}px; --pollen-icon-size: ${bareIcon}px;` +
+      `--ppb-size: ${height}px; --pollen-icon-size: ${visualSize}px;` +
       (bg ? ` --ppb-bg: ${bg};` : "");
 
     // Not yet loaded: render an empty pill placeholder so the badge slot
@@ -415,7 +415,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
           const visual = this._renderBadgeVisual(
             visualMode,
             sensor,
-            { ringConfig, base: ring, ringIconRatio, ringLevel, svgKey, displayLevel, clickable },
+            { ringConfig, base: visualSize, ringIconRatio, ringLevel, svgKey, displayLevel, clickable },
           );
 
           return html`


### PR DESCRIPTION
## What

Two small badge fixes from #235:

1. **`badge_icon_scale`** (additive, default `1`): scales the allergen **visual as a whole** — the ring (with its centred icon/value) in the ring modes, and the bare icon in `icon_only` — without touching the label text or the pill box. So `badge_scale` sets the overall badge size and `badge_icon_scale` sets how big the image is *within* it. Shown in the editor in every visual mode. The scaled visual is capped at the pill height so scaling up fills the badge but never overflows it; scaling down is the primary use (LinqLover's "shrink the icons, not the whole badge").
2. **`badge_scale` clamp**: clamp the stored scale to a ceiling of `10` so a typo (e.g. `100` in the editor field) can't render an editor-breaking giant pill.

## Changes

- **`src/pollenprognos-badge.js`**: coerce + clamp `badge_icon_scale` and `badge_scale` in `_buildConfig`; size both the ring `base` and the bare icon's `--pollen-icon-size` from the scaled visual, capped at the pill height.
- **`src/pollenprognos-badge-editor.js`**: a `badge_icon_scale` slider/number in the Card appearance section (shown in all visual modes).
- **Locales**: `badge_icon_scale` label in all 15 files.

## Tests

Full suite green. Build clean.

## Note

Stacked on #246 (autodetect) because both touch `badge.js` `_buildConfig`; base is `feature/badge-autodetect` for a clean diff. Retarget to `dev` once #246 merges. The per-section reset PR (#247) already lists `badge_icon_scale` in the appearance reset.