### PR TITLE
(badge) Fix single mode silently showing the wrong allergen

### DIFF
--- a/src/adapters/pp.js
+++ b/src/adapters/pp.js
@@ -401,11 +401,16 @@ export async function fetchForecast(hass, config) {
           dict[`day${idx}`] = dayObj;
           dict.days.push(dayObj);
         } else if (pollen_threshold === 0) {
-          // When threshold is 0, show all allergens even with no data
+          // When threshold is 0, show all allergens even with no data. Emit the
+          // no-data sentinel (state -1), not 0: a missing reading is "no info",
+          // not a real level 0. The render path then shows the no-data pattern
+          // (LevelCircleMixin level < 0) so the ring matches the no-info label,
+          // instead of a green no-pollen ring. Matters for badge single mode,
+          // which forces threshold 0 to keep a named allergen.
           const dayObj = {
             name: dict.allergenCapitalized,
             day: label,
-            state: 0,
+            state: -1,
             state_text: noInfoLabel,
           };
           dict[`day${idx}`] = dayObj;

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -503,7 +503,19 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             .value=${c.badge_content || "worst"}
             @value-changed=${(e) => {
               const v = e.detail?.value;
-              if (v !== undefined) this._updateConfig("badge_content", v);
+              if (v === undefined) return;
+              // Switching to "single" commits the default allergen the dropdown
+              // already shows (allergens[0]) when the user hasn't picked one, so
+              // the preview renders that allergen immediately instead of an
+              // unnamed single badge (which falls back to no-pollen/worst).
+              if (
+                v === "single" &&
+                !this._userConfig?.badge_single_allergen &&
+                allergens.length
+              ) {
+                this._updateConfig("badge_single_allergen", allergens[0]);
+              }
+              this._updateConfig("badge_content", v);
             }}
           ></ha-selector>
         </ha-formfield>

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -325,6 +325,20 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       this._userConfig.integration = value;
       const stub = getStubConfig(value) || getStubConfig("pp");
       this._config = deepMerge(stub, this._userConfig);
+      // In single mode the cleared badge_single_allergen would leave the badge
+      // with no named allergen on the new integration, so the preview falls back
+      // to "worst" while the picker shows the new integration's first allergen.
+      // Re-default it to that first allergen (what the picker displays) so the
+      // preview and picker stay in sync, mirroring the switch-to-single default.
+      if (this._config.badge_content === "single") {
+        const first = this._currentAllergens()[0];
+        if (first) {
+          this._userConfig.badge_single_allergen = first;
+          this._config = deepMerge(this._config, {
+            badge_single_allergen: first,
+          });
+        }
+      }
       this.dispatchEvent(
         new CustomEvent("config-changed", {
           detail: { config: this._userConfig },

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -291,7 +291,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       }
     }
 
-    return pinBadgeSingleAllergen(built);
+    return pinBadgeSingleAllergen(built, stub.allergens);
   }
 
   // ---------------------------------------------------------------------- //
@@ -430,11 +430,11 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     const picks = selectBadgeSensor(this.sensors, this.config);
     if (!picks.length) {
       // No pollen (entities exist, nothing above threshold): mirror the card's
-      // breezy no_allergens image instead of a blank pill, for the aggregate/
-      // selection modes. Reuse _renderAllergenSvg("no_allergens", 0) so the
-      // level-0 colour is applied identically to the card. single mode pins one
-      // named allergen and must not collapse to breezy (a missing named entity
-      // stays a blank pill); aggregate keeps its own summary ring elsewhere.
+      // breezy no_allergens image instead of a blank pill, for the worst and row
+      // modes only. Reuse _renderAllergenSvg("no_allergens", 0) so the level-0
+      // colour is applied identically to the card. single mode pins one named
+      // allergen and must not collapse to breezy (a missing named entity stays a
+      // blank pill); aggregate keeps its own summary ring (so it is excluded).
       const contentMode = this.config?.badge_content || "worst";
       if (
         this._noPollen &&

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -431,10 +431,17 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       `--ppb-size: ${height}px; --pollen-icon-size: ${visualSize}px;` +
       (bg ? ` --ppb-bg: ${bg};` : "");
 
+    // Pill layout class, shared by every render path (placeholder, no-data,
+    // no-pollen, empty, and the normal data render) so the pill keeps the same
+    // height/padding across states instead of jumping between ppb--right and
+    // ppb--below when data appears or disappears.
+    const wrapClass =
+      this.config?.badge_label_position === "below" ? "ppb--below" : "ppb--right";
+
     // Not yet loaded: render an empty pill placeholder so the badge slot
     // doesn't jump when data arrives. It carries the same size base.
     if (!this._isLoaded) {
-      return html`<div class="ppb ppb--right" style="${hostStyle}"><div class="ppb-empty"></div></div>`;
+      return html`<div class="ppb ${wrapClass}" style="${hostStyle}"><div class="ppb-empty"></div></div>`;
     }
 
     // Error or no sensors: render a tiny empty pill; do NOT render a big
@@ -446,7 +453,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       // pattern via level -1), not a blank pill or a false no-pollen image. The
       // badge stays text-free; the card adds the "(No information)" label.
       if (this._noData) {
-        return html`<div class="ppb ppb--right" style="${hostStyle}">
+        return html`<div class="ppb ${wrapClass}" style="${hostStyle}">
           <div class="ppb-item">
             ${this._renderAllergenSvg("no_allergens", -1, {})}
           </div>
@@ -463,13 +470,13 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         this._noPollen &&
         (contentMode === "worst" || contentMode === "row")
       ) {
-        return html`<div class="ppb ppb--right" style="${hostStyle}">
+        return html`<div class="ppb ${wrapClass}" style="${hostStyle}">
           <div class="ppb-item">
             ${this._renderAllergenSvg("no_allergens", 0, {})}
           </div>
         </div>`;
       }
-      return html`<div class="ppb ppb--right" style="${hostStyle}"><div class="ppb-empty"></div></div>`;
+      return html`<div class="ppb ${wrapClass}" style="${hostStyle}"><div class="ppb-empty"></div></div>`;
     }
 
     const ringConfig = this._buildLevelRingConfig();
@@ -478,7 +485,6 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       LEVELS_DEFAULTS.icon_in_ring_size_ratio;
 
     const visualMode = this.config?.badge_visual || "icon_in_ring";
-    const labelBelow = this.config?.badge_label_position === "below";
     const showLabel = this.config.badge_show_label === true;
 
     // Badge-level tap_action (shared with the card). Bind only when the action
@@ -490,7 +496,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
     return html`
       <div
-        class="ppb ${labelBelow ? "ppb--below" : "ppb--right"}"
+        class="ppb ${wrapClass}"
         style="${hostStyle}${hasTap ? " cursor: pointer;" : ""}"
         @click=${hasTap ? this._handleTapAction : null}
       >

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -333,6 +333,16 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
     const adapter = getAdapter(cfg.integration) || getAdapter("pp");
 
+    // Monotonic token: the editor preview reuses one badge element and refetches
+    // on every config + hass change, so several fetches can be in flight. Each
+    // fetch is async (and emptyWithEntities triggers a second await), so an
+    // OLDER fetch can resolve after a NEWER one. Without this guard the stale
+    // result overwrites this.sensors with the previous allergen's data, and the
+    // render then finds nothing for the new allergen and goes blank until a save
+    // (the bug behind "changing the allergen blanks the preview"). Only the
+    // latest fetch is allowed to apply its result.
+    const fetchId = (this._fetchSeq = (this._fetchSeq || 0) + 1);
+
     adapter
       .fetchForecast(hass, cfg)
       .then(async (sensors) => {
@@ -352,8 +362,6 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
           isSilamDaily ? silamAllergenMap.mapping : {},
         );
 
-        this.sensors = filtered;
-        this._isLoaded = true;
         // Classify an empty result. With entities available, an empty fetch has
         // two causes: genuine no-pollen (data exists, all below threshold) or no
         // usable data (entities exist but no valid forecast). A threshold-0
@@ -365,6 +373,14 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         const hasData = emptyWithEntities
           ? await hasValidPollenData(adapter, hass, cfg)
           : false;
+
+        // Drop a superseded (out-of-order) fetch: a newer config/hass change
+        // already started a later fetch, so applying this one would clobber the
+        // current allergen with stale data.
+        if (fetchId !== this._fetchSeq) return;
+
+        this.sensors = filtered;
+        this._isLoaded = true;
         this._noPollen = emptyWithEntities && hasData;
         this._noData = emptyWithEntities && !hasData;
         this._error =
@@ -373,6 +389,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
             : null;
       })
       .catch((err) => {
+        if (fetchId !== this._fetchSeq) return;
         console.error("[Badge] fetch error:", err);
         this._isLoaded = true;
         // Clear the previous fetch's data and no-pollen/no-data state so an

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -462,17 +462,16 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         </div>`;
       }
       // No pollen (entities exist, nothing above threshold): mirror the card's
-      // breezy no_allergens image instead of a blank pill, for every aggregate/
-      // selection mode. Reuse _renderAllergenSvg("no_allergens", 0) so the
-      // level-0 colour is applied identically to the card. single mode is the
-      // only exception: it is pinned to one named allergen and renders that
-      // allergen's own ring (or its no-data ring above), never breezy. This
-      // empty branch is reached only when the filtered set is empty, so an
-      // aggregate badge whose summary survived is already handled below; when
-      // the adapter has no summary (e.g. pp/plu) aggregate falls back to worst,
-      // and no pollen should look the same as worst -- breezy, not a blank pill.
-      const contentMode = this.config?.badge_content || "worst";
-      if (this._noPollen && contentMode !== "single") {
+      // breezy no_allergens image instead of a blank pill. Reuse
+      // _renderAllergenSvg("no_allergens", 0) so the level-0 colour matches the
+      // card. This applies to every mode, keyed only on _noPollen: a single
+      // badge WITH a named allergen never reaches here with _noPollen set,
+      // because the pin forces pollen_threshold 0 so its sensor is kept (it
+      // renders its own ring / no-data visual). A single badge with NO named
+      // allergen is effectively "worst" and must show breezy here too, not a
+      // blank pill. aggregate with a surviving summary is non-empty and rendered
+      // below; with no summary it falls back to worst, so breezy is right.
+      if (this._noPollen) {
         return html`<div class="ppb ${wrapClass}" style="${hostStyle}">
           <div class="ppb-item">
             ${this._renderAllergenSvg("no_allergens", 0, {})}

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -375,9 +375,11 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       .catch((err) => {
         console.error("[Badge] fetch error:", err);
         this._isLoaded = true;
-        // Clear the no-pollen/no-data state from a previous successful fetch so
-        // a later error does not keep rendering a stale no_allergens / no-info
-        // image.
+        // Clear the previous fetch's data and no-pollen/no-data state so an
+        // error renders the empty pill instead of stale rings: render() only
+        // consults selectBadgeSensor(this.sensors), never _error, so leaving the
+        // old sensors in place would keep showing outdated readings as current.
+        this.sensors = [];
         this._noPollen = false;
         this._noData = false;
         this._error = "card.error_entity_unavailable";

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -365,6 +365,9 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       .catch((err) => {
         console.error("[Badge] fetch error:", err);
         this._isLoaded = true;
+        // Clear any "no pollen" state from a previous successful fetch so a
+        // later error does not keep rendering the breezy no_allergens image.
+        this._noPollen = false;
         this._error = "card.error_entity_unavailable";
         this.requestUpdate();
       });

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -24,6 +24,7 @@ import {
   coerceBool,
   scaleRingLevel,
   resolveNumericValue,
+  badgeRingLevel,
 } from "./utils/adapter-helpers.js";
 import {
   LEVELS_DEFAULTS,
@@ -50,6 +51,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
   _userConfig = null;
   sensors = [];
   _versionLogged = false;
+  _noPollen = false;
 
   // ---------------------------------------------------------------------- //
   // Lit reactive properties                                                  //
@@ -62,6 +64,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       sensors: { state: true },
       _error: { type: String, state: true },
       _isLoaded: { type: Boolean, state: true },
+      _noPollen: { state: true },
     };
   }
 
@@ -348,7 +351,16 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
         this.sensors = filtered;
         this._isLoaded = true;
-        this._error = filtered.length ? null : "card.error_no_sensors";
+        // Distinguish "no pollen" (entities exist but everything is below the
+        // threshold, so the filtered set is empty) from "no sensors at all".
+        // The former mirrors the card's no_allergens breezy state; only the
+        // latter is a real error. availableSensors comes from findAvailableSensors
+        // above (already in scope in this block).
+        this._noPollen = filtered.length === 0 && availableSensors.length > 0;
+        this._error =
+          filtered.length === 0 && availableSensors.length === 0
+            ? "card.error_no_sensors"
+            : null;
       })
       .catch((err) => {
         console.error("[Badge] fetch error:", err);
@@ -414,6 +426,23 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // error card — the badge slot is not the right place for verbose errors.
     const picks = selectBadgeSensor(this.sensors, this.config);
     if (!picks.length) {
+      // No pollen (entities exist, nothing above threshold): mirror the card's
+      // breezy no_allergens image instead of a blank pill, for the aggregate/
+      // selection modes. Reuse _renderAllergenSvg("no_allergens", 0) so the
+      // level-0 colour is applied identically to the card. single mode pins one
+      // named allergen and must not collapse to breezy (a missing named entity
+      // stays a blank pill); aggregate keeps its own summary ring elsewhere.
+      const contentMode = this.config?.badge_content || "worst";
+      if (
+        this._noPollen &&
+        (contentMode === "worst" || contentMode === "row")
+      ) {
+        return html`<div class="ppb ppb--right" style="${hostStyle}">
+          <div class="ppb-item">
+            ${this._renderAllergenSvg("no_allergens", 0, {})}
+          </div>
+        </div>`;
+      }
       return html`<div class="ppb ppb--right" style="${hostStyle}"><div class="ppb-empty"></div></div>`;
     }
 
@@ -440,7 +469,12 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         @click=${hasTap ? this._handleTapAction : null}
       >
         ${picks.map((sensor) => {
-          const normalizedLevel = Number(sensor.day0?.state) || 0;
+          // Preserve a no-data sensor (missing / NaN / negative day0) as a
+          // negative level so the ring + icon render the no-data noise pattern
+          // instead of collapsing to a green level-0 ring. This matters for a
+          // single pinned allergen whose entity is unavailable (e.g. DWD/PEU
+          // emit no day0 for no data), which would otherwise look like level 0.
+          const normalizedLevel = badgeRingLevel(sensor.day0);
           const ringLevel = scaleRingLevel(
             this.config.integration,
             normalizedLevel,

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -387,6 +387,14 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
           filtered.length === 0 && availableSensors.length === 0
             ? "card.error_no_sensors"
             : null;
+        // Force a re-render: sensors / _noPollen / _noData are reactive
+        // properties that are also class-field-initialised, which shadows Lit's
+        // accessor (useDefineForClassFields), so assigning them does not by
+        // itself schedule an update. Without this, only the FIRST fetch repaints
+        // (via _isLoaded flipping); later fetches change only sensors and the
+        // view keeps showing the previous allergen -- the bug behind the editor
+        // preview going blank when the allergen is changed.
+        this.requestUpdate();
       })
       .catch((err) => {
         if (fetchId !== this._fetchSeq) return;

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -19,6 +19,7 @@ import { getAdapter, getStubConfig } from "./adapter-registry.js";
 import { findAvailableSensors } from "./utils/sensors.js";
 import {
   filterSensorsPostFetch,
+  pinBadgeSingleAllergen,
   selectBadgeSensor,
   coerceBool,
   scaleRingLevel,
@@ -287,7 +288,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       }
     }
 
-    return built;
+    return pinBadgeSingleAllergen(built);
   }
 
   // ---------------------------------------------------------------------- //

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -462,16 +462,17 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
         </div>`;
       }
       // No pollen (entities exist, nothing above threshold): mirror the card's
-      // breezy no_allergens image instead of a blank pill, for the worst and row
-      // modes only. Reuse _renderAllergenSvg("no_allergens", 0) so the level-0
-      // colour is applied identically to the card. single mode pins one named
-      // allergen (its own no-data ring is rendered above when present); aggregate
-      // keeps its own summary ring (so both are excluded here).
+      // breezy no_allergens image instead of a blank pill, for every aggregate/
+      // selection mode. Reuse _renderAllergenSvg("no_allergens", 0) so the
+      // level-0 colour is applied identically to the card. single mode is the
+      // only exception: it is pinned to one named allergen and renders that
+      // allergen's own ring (or its no-data ring above), never breezy. This
+      // empty branch is reached only when the filtered set is empty, so an
+      // aggregate badge whose summary survived is already handled below; when
+      // the adapter has no summary (e.g. pp/plu) aggregate falls back to worst,
+      // and no pollen should look the same as worst -- breezy, not a blank pill.
       const contentMode = this.config?.badge_content || "worst";
-      if (
-        this._noPollen &&
-        (contentMode === "worst" || contentMode === "row")
-      ) {
+      if (this._noPollen && contentMode !== "single") {
         return html`<div class="ppb ${wrapClass}" style="${hostStyle}">
           <div class="ppb-item">
             ${this._renderAllergenSvg("no_allergens", 0, {})}

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -25,6 +25,7 @@ import {
   scaleRingLevel,
   resolveNumericValue,
   badgeRingLevel,
+  hasValidPollenData,
 } from "./utils/adapter-helpers.js";
 import {
   LEVELS_DEFAULTS,
@@ -52,6 +53,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
   sensors = [];
   _versionLogged = false;
   _noPollen = false;
+  _noData = false;
 
   // ---------------------------------------------------------------------- //
   // Lit reactive properties                                                  //
@@ -65,6 +67,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       _error: { type: String, state: true },
       _isLoaded: { type: Boolean, state: true },
       _noPollen: { state: true },
+      _noData: { state: true },
     };
   }
 
@@ -332,7 +335,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
     adapter
       .fetchForecast(hass, cfg)
-      .then((sensors) => {
+      .then(async (sensors) => {
         const availableSensors = findAvailableSensors(cfg, hass, this.debug);
 
         // For silam daily, pass the full state-key list + allergen map so
@@ -351,12 +354,19 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
         this.sensors = filtered;
         this._isLoaded = true;
-        // Distinguish "no pollen" (entities exist but everything is below the
-        // threshold, so the filtered set is empty) from "no sensors at all".
-        // The former mirrors the card's no_allergens breezy state; only the
-        // latter is a real error. availableSensors comes from findAvailableSensors
-        // above (already in scope in this block).
-        this._noPollen = filtered.length === 0 && availableSensors.length > 0;
+        // Classify an empty result. With entities available, an empty fetch has
+        // two causes: genuine no-pollen (data exists, all below threshold) or no
+        // usable data (entities exist but no valid forecast). A threshold-0
+        // confirmation tells them apart so render shows the breezy no_allergens
+        // image only for the former and the no-info (noise) visual for the
+        // latter, never a false no-pollen image for a data problem.
+        const emptyWithEntities =
+          filtered.length === 0 && availableSensors.length > 0;
+        const hasData = emptyWithEntities
+          ? await hasValidPollenData(adapter, hass, cfg)
+          : false;
+        this._noPollen = emptyWithEntities && hasData;
+        this._noData = emptyWithEntities && !hasData;
         this._error =
           filtered.length === 0 && availableSensors.length === 0
             ? "card.error_no_sensors"
@@ -365,9 +375,11 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       .catch((err) => {
         console.error("[Badge] fetch error:", err);
         this._isLoaded = true;
-        // Clear any "no pollen" state from a previous successful fetch so a
-        // later error does not keep rendering the breezy no_allergens image.
+        // Clear the no-pollen/no-data state from a previous successful fetch so
+        // a later error does not keep rendering a stale no_allergens / no-info
+        // image.
         this._noPollen = false;
+        this._noData = false;
         this._error = "card.error_entity_unavailable";
         this.requestUpdate();
       });
@@ -429,12 +441,23 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // error card — the badge slot is not the right place for verbose errors.
     const picks = selectBadgeSensor(this.sensors, this.config);
     if (!picks.length) {
+      // Entities exist but none have usable forecast data: show the no-info
+      // visual (the no_allergens silhouette filled with the no-data noise
+      // pattern via level -1), not a blank pill or a false no-pollen image. The
+      // badge stays text-free; the card adds the "(No information)" label.
+      if (this._noData) {
+        return html`<div class="ppb ppb--right" style="${hostStyle}">
+          <div class="ppb-item">
+            ${this._renderAllergenSvg("no_allergens", -1, {})}
+          </div>
+        </div>`;
+      }
       // No pollen (entities exist, nothing above threshold): mirror the card's
       // breezy no_allergens image instead of a blank pill, for the worst and row
       // modes only. Reuse _renderAllergenSvg("no_allergens", 0) so the level-0
       // colour is applied identically to the card. single mode pins one named
-      // allergen and must not collapse to breezy (a missing named entity stays a
-      // blank pill); aggregate keeps its own summary ring (so it is excluded).
+      // allergen (its own no-data ring is rendered above when present); aggregate
+      // keeps its own summary ring (so both are excluded here).
       const contentMode = this.config?.badge_content || "worst";
       if (
         this._noPollen &&

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -1910,6 +1910,19 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       `;
     }
 
+    // Every remaining sensor is no-data (e.g. a threshold-0 config where each
+    // configured allergen has a missing/invalid reading): computeDisplayDays
+    // yields zero forecast columns, so the normal layout would render blank.
+    // Surface the no-information state instead. Mixed data/no-data keeps
+    // rendering normally (the no-data rows show the noise pattern).
+    if (this.sensors.length && this.days_to_show === 0) {
+      return html`
+        <ha-card>
+          ${this._renderNoInformationHtml()}
+        </ha-card>
+      `;
+    }
+
     const cardContent = this.config.minimal
       ? this._renderMinimalHtml()
       : this._renderNormalHtml();

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -434,6 +434,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       this._forecastEvent
     ) {
       const adapter = getAdapter(this.config.integration) || getAdapter("pp");
+      // Out-of-order guard shared with the main fetch (see set hass): only the
+      // latest fetch may apply, so a slow SILAM event fetch cannot clobber a
+      // newer result with stale sensors.
+      const fetchId = (this._fetchSeq = (this._fetchSeq || 0) + 1);
       adapter
         .fetchForecast(this._hass, this.config, this._forecastEvent)
         .then(async (sensors) => {
@@ -450,7 +454,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           // SILAM forecast event refetches without going through set hass, so a
           // stale _noPollenData would otherwise pick the wrong empty-state
           // branch (no-information vs no-allergens) until the next full fetch.
-          this._noPollenData =
+          const noPollenData =
             filtered.length === 0 && availableSensors.length > 0
               ? await hasValidPollenData(
                   adapter,
@@ -459,6 +463,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                   this._forecastEvent,
                 )
               : false;
+          if (fetchId !== this._fetchSeq) return;
+          this._noPollenData = noPollenData;
           this._updateSensorsAndColumns(filtered, availableSensors, this.config);
           // this.sensors = sensors;
           // this.requestUpdate();
@@ -1134,6 +1140,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
 
     // Hämta prognos via rätt adapter
     const adapter = getAdapter(cfg.integration) || getAdapter("pp");
+    // Out-of-order guard (shared with the SILAM forecast-event fetch): only the
+    // latest fetch may apply its result, so a slower earlier fetch cannot
+    // overwrite newer sensors with stale data on rapid config/hass changes.
+    const fetchId = (this._fetchSeq = (this._fetchSeq || 0) + 1);
     let fetchPromise = null;
     if (cfg.integration === "silam") {
       // Pass forecastEvent when available; fetchForecast falls back to
@@ -1206,10 +1216,14 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           // distinguish genuine no-pollen (data exists, all below threshold)
           // from a data problem (entities exist but no usable forecast), so the
           // breezy no_allergens image is shown only for the former.
-          this._noPollenData =
+          const noPollenData =
             filtered.length === 0 && availableSensorCount > 0
               ? await hasValidPollenData(adapter, hass, cfg, this._forecastEvent)
               : false;
+
+          // Drop a superseded fetch before mutating any state.
+          if (fetchId !== this._fetchSeq) return;
+          this._noPollenData = noPollenData;
 
           const explicitLocation = this._integrationExplicit && !!cfg.location;
           const noAvailableSensors = availableSensorCount === 0;

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -15,6 +15,7 @@ import {
   computeDisplayDays,
   scaleRingLevel,
   resolveNumericValue,
+  hasValidPollenData,
 } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 // Sensor detection / integration pick / location auto-select are shared with
@@ -487,6 +488,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       tapAction: {},
       _isLoaded: { type: Boolean, state: true },
       _error: { type: String, state: true },
+      _noPollenData: { type: Boolean, state: true },
     };
   }
 
@@ -507,6 +509,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     this.tapAction = null;
     this._forecastSubEntity = null;
     this._forecastSubType = null;
+    this._noPollenData = false;
   }
 
   static async getConfigElement() {
@@ -1129,7 +1132,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     }
     if (fetchPromise) {
       return fetchPromise
-        .then((sensors) => {
+        .then(async (sensors) => {
           if (this.debug) {
             console.debug("[Card][Debug] Sensors before filtering:", sensors);
             console.debug(
@@ -1186,6 +1189,15 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             );
           }
 
+          // When the filtered set is empty but entities are available,
+          // distinguish genuine no-pollen (data exists, all below threshold)
+          // from a data problem (entities exist but no usable forecast), so the
+          // breezy no_allergens image is shown only for the former.
+          this._noPollenData =
+            filtered.length === 0 && availableSensorCount > 0
+              ? await hasValidPollenData(adapter, hass, cfg, this._forecastEvent)
+              : false;
+
           const explicitLocation = this._integrationExplicit && !!cfg.location;
           const noAvailableSensors = availableSensorCount === 0;
 
@@ -1225,6 +1237,22 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         <div class="no-allergens-container">
           ${this._renderAllergenSvg("no_allergens", 0)}
           <span class="no-allergens-text">${this._t("card.no_allergens")}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderNoInformationHtml() {
+    // Entities exist but carry no usable forecast data. Reuse the no_allergens
+    // silhouette, but rendered through the no-data path (level -1) so it shows
+    // the noise pattern rather than the level-0 "no pollen" colour, paired with
+    // the "(No information)" label. Distinct from the breezy no-pollen state.
+    return html`
+      ${this.header ? html`<div class="card-header">${this.header}</div>` : ""}
+      <div class="card-content">
+        <div class="no-allergens-container">
+          ${this._renderAllergenSvg("no_allergens", -1)}
+          <span class="no-allergens-text">${this._t("card.no_information")}</span>
         </div>
       </div>
     `;
@@ -1850,14 +1878,24 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             <div class="card-error">${errorMsg} (${name})</div>
           </ha-card>
         `;
-      } else {
-        const filteredMsg = this._t("card.error_filtered_sensors");
-        if (this.debug) {
-          console.debug(`[PollenPrognosCard] ${filteredMsg} (${name})`);
-        }
+      } else if (this._noPollenData) {
+        // Entities exist and at least one has a real reading, all below
+        // threshold: genuine no pollen.
         return html`
           <ha-card>
             ${this._renderNoAllergensHtml()}
+          </ha-card>
+        `;
+      } else {
+        // Entities exist but none have usable forecast data: a data problem,
+        // not "no pollen". Show the no-info visual (the no_allergens silhouette
+        // filled with the no-data noise pattern) instead of the breezy image.
+        if (this.debug) {
+          console.debug(`[PollenPrognosCard] no usable forecast data (${name})`);
+        }
+        return html`
+          <ha-card>
+            ${this._renderNoInformationHtml()}
           </ha-card>
         `;
       }

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -436,7 +436,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       const adapter = getAdapter(this.config.integration) || getAdapter("pp");
       adapter
         .fetchForecast(this._hass, this.config, this._forecastEvent)
-        .then((sensors) => {
+        .then(async (sensors) => {
           const availableSensors = findAvailableSensors(
             this.config,
             this._hass,
@@ -446,6 +446,19 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             sensors, this.config, availableSensors,
             Object.keys(this._hass.states), silamAllergenMap.mapping,
           );
+          // Recompute the no-pollen-vs-no-data classification here too: a live
+          // SILAM forecast event refetches without going through set hass, so a
+          // stale _noPollenData would otherwise pick the wrong empty-state
+          // branch (no-information vs no-allergens) until the next full fetch.
+          this._noPollenData =
+            filtered.length === 0 && availableSensors.length > 0
+              ? await hasValidPollenData(
+                  adapter,
+                  this._hass,
+                  this.config,
+                  this._forecastEvent,
+                )
+              : false;
           this._updateSensorsAndColumns(filtered, availableSensors, this.config);
           // this.sensors = sensors;
           // this.requestUpdate();

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -187,14 +187,20 @@ export function selectBadgeSensor(sensors, config) {
 }
 
 /**
- * Single-mode badge pinning. When a badge names one allergen, restrict the
- * fetch to it and disable the threshold so a no-data / level-0 named allergen
- * still renders its ring instead of being dropped before selectBadgeSensor can
- * resolve it (filtered out by the stub allergens for gpl, or below threshold
- * for pp). With the fetch pinned to the one named allergen, an unresolved name
- * surfaces as a no-data badge rather than the wrong allergen. Pure: returns the
- * input unchanged for any non-single / unnamed config, else a shallow-merged
- * copy.
+ * Single-mode badge pinning. When a badge names one allergen, make sure it is
+ * fetched and survives the post-fetch filter: ADD the named key to the config's
+ * allergens (deduped) and disable the threshold, so a no-data / level-0 named
+ * allergen still reaches selectBadgeSensor instead of being dropped (filtered
+ * out by the stub allergens for gpl, or below the threshold for pp).
+ *
+ * The key is ADDED, not substituted, so an adapter whose fetch is keyed by
+ * native names (e.g. pp "Björk") still fetches its own sensors even when the
+ * user names a canonical key. selectBadgeSensor then resolves the named
+ * allergen canonically (a canonical "birch" still matches a fetched "bjork"),
+ * and a genuine miss surfaces as no-data rather than the wrong allergen.
+ * Substituting [key] would narrow pp's fetch to an unadapted canonical key and
+ * return nothing. Pure: returns the input unchanged for any non-single /
+ * unnamed config, else a shallow-merged copy.
  *
  * @param {object} config - badge config (already typeguarded by _buildConfig).
  * @returns {object} the config, or a shallow copy with allergens/threshold pinned.
@@ -203,7 +209,9 @@ export function pinBadgeSingleAllergen(config) {
   if (config?.badge_content !== "single") return config;
   const key = config.badge_single_allergen;
   if (typeof key !== "string" || !key) return config;
-  return { ...config, allergens: [key], pollen_threshold: 0 };
+  const existing = Array.isArray(config.allergens) ? config.allergens : [];
+  const allergens = existing.includes(key) ? existing : [...existing, key];
+  return { ...config, allergens, pollen_threshold: 0 };
 }
 
 /**
@@ -216,7 +224,9 @@ export function pinBadgeSingleAllergen(config) {
  * reading as a real level 0. Pure.
  *
  * @param {object|undefined} day0 - sensor.day0, may be undefined.
- * @returns {number} the level (>= 0), or -1 for no data.
+ * @returns {number} the finite state unchanged (a level >= 0, or a negative
+ *   no-data sentinel such as -1, or -2 once DWD-scaled downstream), or -1 when
+ *   there is no usable reading.
  */
 export function badgeRingLevel(day0) {
   if (day0?.state == null) return -1;

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -188,29 +188,48 @@ export function selectBadgeSensor(sensors, config) {
 
 /**
  * Single-mode badge pinning. When a badge names one allergen, make sure it is
- * fetched and survives the post-fetch filter: ADD the named key to the config's
- * allergens (deduped) and disable the threshold, so a no-data / level-0 named
- * allergen still reaches selectBadgeSensor instead of being dropped (filtered
- * out by the stub allergens for gpl, or below the threshold for pp).
+ * fetched and survives the post-fetch filter, then disable the threshold so a
+ * no-data / level-0 named allergen still reaches selectBadgeSensor instead of
+ * being dropped.
  *
- * The key is ADDED, not substituted, so an adapter whose fetch is keyed by
- * native names (e.g. pp "Björk") still fetches its own sensors even when the
- * user names a canonical key. selectBadgeSensor then resolves the named
- * allergen canonically (a canonical "birch" still matches a fetched "bjork"),
- * and a genuine miss surfaces as no-data rather than the wrong allergen.
- * Substituting [key] would narrow pp's fetch to an unadapted canonical key and
- * return nothing. Pure: returns the input unchanged for any non-single /
- * unnamed config, else a shallow-merged copy.
+ * The fetch is based on the adapter's STUB allergen set (passed in), not the
+ * possibly-custom configured list. The stub holds each adapter's native slugs
+ * (pp "Björk", dwd "Birke"), so the named sensor is fetched even when the user
+ * named a canonical key ("birch") or trimmed the allergens list: an adapter
+ * keyed by localized slugs would never resolve a bare canonical key on its own.
+ * The named key is appended only when no stub allergen is canonically
+ * equivalent to it, so a canonical name the stub omits but the adapter resolves
+ * directly (e.g. gpl "birch") is still fetched, without duplicating a localized
+ * stub key that already covers it (which would double-fetch the same entity).
+ * selectBadgeSensor then resolves the named allergen canonically and a genuine
+ * miss surfaces as no-data rather than the wrong allergen. Pure: returns the
+ * input unchanged for any non-single / unnamed config, else a shallow-merged
+ * copy.
  *
  * @param {object} config - badge config (already typeguarded by _buildConfig).
+ * @param {string[]} stubAllergens - the adapter's stub allergens (native slugs).
  * @returns {object} the config, or a shallow copy with allergens/threshold pinned.
  */
-export function pinBadgeSingleAllergen(config) {
+export function pinBadgeSingleAllergen(config, stubAllergens = []) {
   if (config?.badge_content !== "single") return config;
   const key = config.badge_single_allergen;
   if (typeof key !== "string" || !key) return config;
-  const existing = Array.isArray(config.allergens) ? config.allergens : [];
-  const allergens = existing.includes(key) ? existing : [...existing, key];
+  const base = Array.isArray(stubAllergens) ? stubAllergens.slice() : [];
+  // Canonical forms of the named key, via both normalizers, mirroring how
+  // matchSensorByAllergenKey later resolves it (so "covered" agrees with the
+  // eventual lookup, and dwd umlaut/ß keys are matched too).
+  const wanted = new Set([
+    toCanonicalAllergenKey(normalize(key)),
+    toCanonicalAllergenKey(normalizeDWD(key)),
+  ]);
+  const covered = base.some((a) => {
+    const s = String(a);
+    return (
+      wanted.has(toCanonicalAllergenKey(normalize(s))) ||
+      wanted.has(toCanonicalAllergenKey(normalizeDWD(s)))
+    );
+  });
+  const allergens = covered ? base : [...base, key];
   return { ...config, allergens, pollen_threshold: 0 };
 }
 

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -192,19 +192,20 @@ export function selectBadgeSensor(sensors, config) {
  * no-data / level-0 named allergen still reaches selectBadgeSensor instead of
  * being dropped.
  *
- * The fetch is based on the adapter's STUB allergen set (passed in), not the
- * possibly-custom configured list. The stub holds each adapter's native slugs
- * (pp "Björk", dwd "Birke"), so the named sensor is fetched even when the user
- * named a canonical key ("birch") or trimmed the allergens list: an adapter
- * keyed by localized slugs would never resolve a bare canonical key on its own.
- * The named key is appended only when no stub allergen is canonically
- * equivalent to it, so a canonical name the stub omits but the adapter resolves
- * directly (e.g. gpl "birch") is still fetched, without duplicating a localized
- * stub key that already covers it (which would double-fetch the same entity).
- * selectBadgeSensor then resolves the named allergen canonically and a genuine
- * miss surfaces as no-data rather than the wrong allergen. Pure: returns the
- * input unchanged for any non-single / unnamed config, else a shallow-merged
- * copy.
+ * The fetch is narrowed to the one named allergen, resolved through the
+ * adapter's STUB allergen set (passed in): pick the stub key(s) whose canonical
+ * form matches the named key, so an adapter keyed by localized slugs fetches its
+ * native sensor (pp "Björk" / dwd "Birke" for a canonical "birch") rather than a
+ * bare canonical key it cannot resolve. Fall back to [key] when the stub has no
+ * canonical match but the adapter resolves the key directly (e.g. gpl "birch",
+ * which its stub omits). Resolving against the stub (not the possibly-custom
+ * configured list) means a trimmed allergens list cannot hide the named
+ * allergen, and matching canonically (not by exact string) avoids double-
+ * fetching the same entity from a casing/diacritic variant. The threshold is set
+ * to 0 so a level-0 / no-data named allergen still reaches selectBadgeSensor,
+ * which resolves the name canonically; a genuine miss then surfaces as no-data
+ * rather than the wrong allergen. Pure: returns the input unchanged for any
+ * non-single / unnamed config, else a shallow-merged copy.
  *
  * @param {object} config - badge config (already typeguarded by _buildConfig).
  * @param {string[]} stubAllergens - the adapter's stub allergens (native slugs).
@@ -214,22 +215,22 @@ export function pinBadgeSingleAllergen(config, stubAllergens = []) {
   if (config?.badge_content !== "single") return config;
   const key = config.badge_single_allergen;
   if (typeof key !== "string" || !key) return config;
-  const base = Array.isArray(stubAllergens) ? stubAllergens.slice() : [];
+  const base = Array.isArray(stubAllergens) ? stubAllergens : [];
   // Canonical forms of the named key, via both normalizers, mirroring how
-  // matchSensorByAllergenKey later resolves it (so "covered" agrees with the
+  // matchSensorByAllergenKey later resolves it (so the match agrees with the
   // eventual lookup, and dwd umlaut/ß keys are matched too).
   const wanted = new Set([
     toCanonicalAllergenKey(normalize(key)),
     toCanonicalAllergenKey(normalizeDWD(key)),
   ]);
-  const covered = base.some((a) => {
+  const matches = base.filter((a) => {
     const s = String(a);
     return (
       wanted.has(toCanonicalAllergenKey(normalize(s))) ||
       wanted.has(toCanonicalAllergenKey(normalizeDWD(s)))
     );
   });
-  const allergens = covered ? base : [...base, key];
+  const allergens = matches.length ? matches : [key];
   return { ...config, allergens, pollen_threshold: 0 };
 }
 

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -189,9 +189,12 @@ export function selectBadgeSensor(sensors, config) {
 /**
  * Single-mode badge pinning. When a badge names one allergen, restrict the
  * fetch to it and disable the threshold so a no-data / level-0 named allergen
- * still renders its ring instead of being dropped -- which would silently fall
- * back to the worst other allergen. Pure: returns the input unchanged for any
- * non-single / unnamed config, else a shallow-merged copy.
+ * still renders its ring instead of being dropped before selectBadgeSensor can
+ * resolve it (filtered out by the stub allergens for gpl, or below threshold
+ * for pp). With the fetch pinned to the one named allergen, an unresolved name
+ * surfaces as a no-data badge rather than the wrong allergen. Pure: returns the
+ * input unchanged for any non-single / unnamed config, else a shallow-merged
+ * copy.
  *
  * @param {object} config - badge config (already typeguarded by _buildConfig).
  * @returns {object} the config, or a shallow copy with allergens/threshold pinned.
@@ -201,6 +204,24 @@ export function pinBadgeSingleAllergen(config) {
   const key = config.badge_single_allergen;
   if (typeof key !== "string" || !key) return config;
   return { ...config, allergens: [key], pollen_threshold: 0 };
+}
+
+/**
+ * Ring level for a badge sensor's current day, preserving the no-data sentinel.
+ * A finite numeric state (including 0) is returned as-is; a missing / null /
+ * NaN / non-numeric day0.state becomes -1 so the render path treats it as
+ * no-data (the noise pattern) rather than a level-0 ring. Negative states pass
+ * through unchanged (already a no-data marker). The null/undefined guard is
+ * explicit because Number(null) is 0, which would otherwise mask a no-data
+ * reading as a real level 0. Pure.
+ *
+ * @param {object|undefined} day0 - sensor.day0, may be undefined.
+ * @returns {number} the level (>= 0), or -1 for no data.
+ */
+export function badgeRingLevel(day0) {
+  if (day0?.state == null) return -1;
+  const n = Number(day0.state);
+  return Number.isFinite(n) ? n : -1;
 }
 
 /**

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -236,20 +236,28 @@ export function pinBadgeSingleAllergen(config, stubAllergens = []) {
 
 /**
  * Ring level for a badge sensor's current day, preserving the no-data sentinel.
- * A finite numeric state (including 0) is returned as-is; a missing / null /
- * NaN / non-numeric day0.state becomes -1 so the render path treats it as
- * no-data (the noise pattern) rather than a level-0 ring. Negative states pass
- * through unchanged (already a no-data marker). The null/undefined guard is
- * explicit because Number(null) is 0, which would otherwise mask a no-data
- * reading as a real level 0. Pure.
+ * Returns the canonical `state` (a level >= 0) so the caller can scale it with
+ * scaleRingLevel (DWD doubles it); a missing / null / NaN / non-numeric state
+ * becomes -1 so the render path shows the no-data noise pattern instead of a
+ * level-0 ring. The null/undefined guard is explicit because Number(null) is 0,
+ * which would otherwise mask a no-data reading as a real level 0.
+ *
+ * `display_state` is consulted only as a no-data OVERRIDE: some adapters keep a
+ * non-negative `state` but flag "no information" via `display_state: -1` (atmo
+ * "Indisponible" maps raw 0 to state 0 / display_state -1; plu/gp/gpl do the
+ * same for missing readings). A negative display_state therefore forces -1. It
+ * is NOT used as the level itself, because for DWD `display_state` is already
+ * the SCALED value and scaleRingLevel would double it again. Pure.
  *
  * @param {object|undefined} day0 - sensor.day0, may be undefined.
- * @returns {number} the finite state unchanged (a level >= 0, or a negative
- *   no-data sentinel such as -1, or -2 once DWD-scaled downstream), or -1 when
- *   there is no usable reading.
+ * @returns {number} the level (>= 0), or -1 when there is no usable reading.
  */
 export function badgeRingLevel(day0) {
-  if (day0?.state == null) return -1;
+  if (day0 == null) return -1;
+  // No-data override: a negative display_state means "no information" even when
+  // state is a non-negative placeholder (atmo unavailable = state 0).
+  if (day0.display_state != null && Number(day0.display_state) < 0) return -1;
+  if (day0.state == null) return -1;
   const n = Number(day0.state);
   return Number.isFinite(n) ? n : -1;
 }
@@ -257,11 +265,14 @@ export function badgeRingLevel(day0) {
 /**
  * True when at least one configured allergen has a valid current reading,
  * ignoring the threshold. Re-fetches at pollen_threshold 0 and checks for any
- * day0.state >= 0, so a caller can tell genuine "no pollen" (data exists, all
- * below threshold) from "no usable data" (entities exist but no valid forecast)
- * and show the no_allergens image only for the former. Defensive: returns false
- * on any fetch error. forecastEvent is forwarded for silam; other adapters
- * ignore it.
+ * sensor whose day0 resolves to a real level via badgeRingLevel (>= 0), so a
+ * caller can tell genuine "no pollen" (data exists, all below threshold) from
+ * "no usable data" (entities exist but no valid forecast) and show the
+ * no_allergens image only for the former. Reusing badgeRingLevel keeps the
+ * no-data rule identical to the render path: null/NaN state and the atmo-style
+ * `display_state: -1` placeholder both count as no-data, not as level 0.
+ * Defensive: returns false on any fetch error. forecastEvent is forwarded for
+ * silam; other adapters ignore it.
  *
  * @param {object} adapter - the integration adapter (has fetchForecast).
  * @param {object} hass
@@ -276,7 +287,7 @@ export async function hasValidPollenData(adapter, hass, cfg, forecastEvent = nul
       { ...cfg, pollen_threshold: 0 },
       forecastEvent,
     );
-    return Array.isArray(sensors) && sensors.some((s) => Number(s?.day0?.state) >= 0);
+    return Array.isArray(sensors) && sensors.some((s) => badgeRingLevel(s?.day0) >= 0);
   } catch {
     return false;
   }

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -255,6 +255,34 @@ export function badgeRingLevel(day0) {
 }
 
 /**
+ * True when at least one configured allergen has a valid current reading,
+ * ignoring the threshold. Re-fetches at pollen_threshold 0 and checks for any
+ * day0.state >= 0, so a caller can tell genuine "no pollen" (data exists, all
+ * below threshold) from "no usable data" (entities exist but no valid forecast)
+ * and show the no_allergens image only for the former. Defensive: returns false
+ * on any fetch error. forecastEvent is forwarded for silam; other adapters
+ * ignore it.
+ *
+ * @param {object} adapter - the integration adapter (has fetchForecast).
+ * @param {object} hass
+ * @param {object} cfg - badge/card config.
+ * @param {object|null} forecastEvent - silam forecast event, or null.
+ * @returns {Promise<boolean>}
+ */
+export async function hasValidPollenData(adapter, hass, cfg, forecastEvent = null) {
+  try {
+    const sensors = await adapter.fetchForecast(
+      hass,
+      { ...cfg, pollen_threshold: 0 },
+      forecastEvent,
+    );
+    return Array.isArray(sensors) && sensors.some((s) => Number(s?.day0?.state) >= 0);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Compute the number of day columns to render for a given sensor list and
  * config. Extracted from _updateSensorsAndColumns so that _renderNormalHtml
  * can recompute columns from the *displayed* row set rather than the full

--- a/src/utils/adapter-helpers.js
+++ b/src/utils/adapter-helpers.js
@@ -129,7 +129,9 @@ export function matchSensorByAllergenKey(sensors, configKey) {
  *                 allergy_risk). Falls back to "worst" for adapters that expose
  *                 no aggregate (PP/DWD/SILAM/PEU/MSW).
  * - "single"    — the one allergen named in config.badge_single_allergen.
- *                 Falls back to "worst" if the named allergen is not present.
+ *                 Returns empty (no-data) if a named allergen is not present, so
+ *                 the miss is visible; only falls back to "worst" when no
+ *                 allergen was named.
  * - "row"       — all sensors, in their existing order, for a compact multi-ring
  *                 badge.
  *
@@ -168,11 +170,13 @@ export function selectBadgeSensor(sensors, config) {
     case "aggregate":
       return summary ? [summary] : worst();
     case "single": {
-      const found = matchSensorByAllergenKey(
-        sensors,
-        config?.badge_single_allergen,
-      );
-      return found ? [found] : worst();
+      const key = config?.badge_single_allergen;
+      const found = matchSensorByAllergenKey(sensors, key);
+      if (found) return [found];
+      // Explicitly named but absent: surface a visible miss (no-data) instead
+      // of silently swapping in the worst other allergen. Fall back to worst()
+      // only when no allergen was named (misconfigured single mode).
+      return typeof key === "string" && key ? [] : worst();
     }
     case "row":
       return sensors;
@@ -180,6 +184,23 @@ export function selectBadgeSensor(sensors, config) {
     default:
       return worst();
   }
+}
+
+/**
+ * Single-mode badge pinning. When a badge names one allergen, restrict the
+ * fetch to it and disable the threshold so a no-data / level-0 named allergen
+ * still renders its ring instead of being dropped -- which would silently fall
+ * back to the worst other allergen. Pure: returns the input unchanged for any
+ * non-single / unnamed config, else a shallow-merged copy.
+ *
+ * @param {object} config - badge config (already typeguarded by _buildConfig).
+ * @returns {object} the config, or a shallow copy with allergens/threshold pinned.
+ */
+export function pinBadgeSingleAllergen(config) {
+  if (config?.badge_content !== "single") return config;
+  const key = config.badge_single_allergen;
+  if (typeof key !== "string" || !key) return config;
+  return { ...config, allergens: [key], pollen_threshold: 0 };
 }
 
 /**

--- a/test/adapters/pp.test.js
+++ b/test/adapters/pp.test.js
@@ -94,10 +94,11 @@ describe("PP adapter: fetchForecast", () => {
 
     // Level 8 should be clamped to 6
     expect(result[0].day0.state).toBe(6);
-    // -1 and NaN produce null via clampLevel; with pollen_threshold 0
-    // these days still appear but with state: 0
-    expect(result[0].day1.state).toBe(0);
-    expect(result[0].day2.state).toBe(0);
+    // -1 and NaN produce null via clampLevel; with pollen_threshold 0 these
+    // days still appear but carry the no-data sentinel state -1 (no info, not a
+    // real level 0), so the render path shows the no-data pattern.
+    expect(result[0].day1.state).toBe(-1);
+    expect(result[0].day2.state).toBe(-1);
     // Valid level passes through
     expect(result[0].day3.state).toBe(3);
   });

--- a/test/utils/badge-ring-level.test.js
+++ b/test/utils/badge-ring-level.test.js
@@ -42,4 +42,19 @@ describe("badgeRingLevel", () => {
   it("coerces a numeric string to the corresponding number", () => {
     expect(badgeRingLevel({ state: "2" })).toBe(2);
   });
+
+  it("treats a negative display_state as no-data even when state is 0 (atmo unavailable)", () => {
+    // Atmo maps an unavailable reading (raw 0) to state 0 / display_state -1.
+    expect(badgeRingLevel({ state: 0, display_state: -1 })).toBe(-1);
+  });
+
+  it("returns state, not display_state, when display_state is non-negative", () => {
+    // DWD display_state is the already-scaled value; the ring level must stay
+    // the canonical state so scaleRingLevel does not double-scale it.
+    expect(badgeRingLevel({ state: 3, display_state: 6 })).toBe(3);
+  });
+
+  it("ignores a non-negative display_state and keeps a real level 0", () => {
+    expect(badgeRingLevel({ state: 0, display_state: 0 })).toBe(0);
+  });
 });

--- a/test/utils/badge-ring-level.test.js
+++ b/test/utils/badge-ring-level.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { badgeRingLevel } from "../../src/utils/adapter-helpers.js";
+
+// badgeRingLevel normalises the day0 sensor object into a single integer that
+// the badge ring renderer consumes. Level 0 is a real pollen level and must
+// not be collapsed into the no-data sentinel (-1). Only genuinely missing or
+// non-numeric states produce -1.
+
+describe("badgeRingLevel", () => {
+  it("preserves level 0 (real zero is not no-data)", () => {
+    expect(badgeRingLevel({ state: 0 })).toBe(0);
+  });
+
+  it("returns the state as a number for positive integer levels", () => {
+    expect(badgeRingLevel({ state: 3 })).toBe(3);
+  });
+
+  it("passes through -1 (existing no-data marker)", () => {
+    expect(badgeRingLevel({ state: -1 })).toBe(-1);
+  });
+
+  it("passes through -2 (DWD-scaled no-data marker)", () => {
+    expect(badgeRingLevel({ state: -2 })).toBe(-2);
+  });
+
+  it("returns -1 when day0 is undefined", () => {
+    expect(badgeRingLevel(undefined)).toBe(-1);
+  });
+
+  it("returns -1 when state is absent from day0", () => {
+    expect(badgeRingLevel({})).toBe(-1);
+  });
+
+  it("returns -1 when state is null", () => {
+    expect(badgeRingLevel({ state: null })).toBe(-1);
+  });
+
+  it("returns -1 when state is a non-numeric string", () => {
+    expect(badgeRingLevel({ state: "foo" })).toBe(-1);
+  });
+
+  it("coerces a numeric string to the corresponding number", () => {
+    expect(badgeRingLevel({ state: "2" })).toBe(2);
+  });
+});

--- a/test/utils/has-valid-pollen-data.test.js
+++ b/test/utils/has-valid-pollen-data.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { hasValidPollenData } from "../../src/utils/adapter-helpers.js";
+
+// hasValidPollenData re-fetches at pollen_threshold 0 so the caller can
+// distinguish "no pollen data at all" (returns false) from "pollen data
+// exists, all below threshold" (returns true), and can choose whether to
+// show the no_allergens image accordingly.
+
+describe("hasValidPollenData", () => {
+  it("returns true when a sensor has state 0 (level-0 is valid data)", async () => {
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([{ day0: { state: 0 } }]) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(true);
+  });
+
+  it("returns true when a sensor has state 3", async () => {
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([{ day0: { state: 3 } }]) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(true);
+  });
+
+  it("returns false when all sensors have state -1 (no-data sentinels)", async () => {
+    const adapter = {
+      fetchForecast: vi.fn().mockResolvedValue([
+        { day0: { state: -1 } },
+        { day0: { state: -1 } },
+      ]),
+    };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("returns false when the sensor array is empty", async () => {
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([]) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("returns false when day0.state is missing (Number(undefined) is NaN)", async () => {
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([{ day0: {} }]) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("returns false when fetchForecast throws (defensive catch)", async () => {
+    const adapter = { fetchForecast: vi.fn().mockRejectedValue(new Error("network error")) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("calls fetchForecast with pollen_threshold coerced to 0 while preserving the rest of cfg", async () => {
+    const cfg = { pollen_threshold: 5, allergens: ["x"], integration: "pp" };
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([]) };
+
+    await hasValidPollenData(adapter, {}, cfg);
+
+    expect(adapter.fetchForecast).toHaveBeenCalledOnce();
+    const receivedCfg = adapter.fetchForecast.mock.calls[0][1];
+    expect(receivedCfg.pollen_threshold).toBe(0);
+    expect(receivedCfg.allergens).toEqual(["x"]);
+    expect(receivedCfg.integration).toBe("pp");
+    // Third argument defaults to null when forecastEvent is not supplied.
+    expect(adapter.fetchForecast.mock.calls[0][2]).toBeNull();
+  });
+
+  it("forwards forecastEvent as the third argument to fetchForecast", async () => {
+    const forecastEvent = { ev: 1 };
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([]) };
+
+    await hasValidPollenData(adapter, {}, {}, forecastEvent);
+
+    expect(adapter.fetchForecast.mock.calls[0][2]).toBe(forecastEvent);
+  });
+});

--- a/test/utils/has-valid-pollen-data.test.js
+++ b/test/utils/has-valid-pollen-data.test.js
@@ -37,6 +37,31 @@ describe("hasValidPollenData", () => {
     expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
   });
 
+  it("returns false when day0.state is null (Number(null) is 0, must not count as data)", async () => {
+    const adapter = { fetchForecast: vi.fn().mockResolvedValue([{ day0: { state: null } }]) };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("returns false when all sensors are atmo-unavailable (state 0 / display_state -1)", async () => {
+    const adapter = {
+      fetchForecast: vi.fn().mockResolvedValue([
+        { day0: { state: 0, display_state: -1 } },
+        { day0: { state: 0, display_state: -1 } },
+      ]),
+    };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(false);
+  });
+
+  it("returns true when at least one sensor has real data among unavailable ones", async () => {
+    const adapter = {
+      fetchForecast: vi.fn().mockResolvedValue([
+        { day0: { state: 0, display_state: -1 } },
+        { day0: { state: 2, display_state: 2 } },
+      ]),
+    };
+    expect(await hasValidPollenData(adapter, {}, {})).toBe(true);
+  });
+
   it("returns false when fetchForecast throws (defensive catch)", async () => {
     const adapter = { fetchForecast: vi.fn().mockRejectedValue(new Error("network error")) };
     expect(await hasValidPollenData(adapter, {}, {})).toBe(false);

--- a/test/utils/match-sensor-by-allergen-key.test.js
+++ b/test/utils/match-sensor-by-allergen-key.test.js
@@ -66,4 +66,19 @@ describe("matchSensorByAllergenKey", () => {
       english,
     );
   });
+
+  it("matches PP short config keys (capital initial) against lowercase allergenReplaced slugs", () => {
+    // PP sensors store normalize(configKey) as lowercase slugs. The badge config
+    // holds the original PP key as the user/editor wrote it (e.g. "Al", "Hassel",
+    // "Ek"). The matcher must bridge the case difference via normalization so
+    // single mode works for PP without requiring the user to know the slug.
+    const al = { allergenReplaced: "al", day0: { state: 2 } };
+    const hassel = { allergenReplaced: "hassel", day0: { state: 1 } };
+    const ek = { allergenReplaced: "ek", day0: { state: 4 } };
+    const sensors = [al, hassel, ek];
+
+    expect(matchSensorByAllergenKey(sensors, "Al")).toBe(al);
+    expect(matchSensorByAllergenKey(sensors, "Hassel")).toBe(hassel);
+    expect(matchSensorByAllergenKey(sensors, "Ek")).toBe(ek);
+  });
 });

--- a/test/utils/pin-badge-single-allergen.test.js
+++ b/test/utils/pin-badge-single-allergen.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { pinBadgeSingleAllergen } from "../../src/utils/adapter-helpers.js";
 
 // pinBadgeSingleAllergen rewrites the config so that when badge_content is
-// "single" and badge_single_allergen names a specific allergen, the card's
+// "single" and badge_single_allergen names a specific allergen, the badge's
 // fetch/filter pipeline is scoped down to that allergen only (allergens:
 // [named] + pollen_threshold: 0). This avoids leaking unrelated allergens
 // into the fetch path. Non-single modes and unconfigured single modes get the

--- a/test/utils/pin-badge-single-allergen.test.js
+++ b/test/utils/pin-badge-single-allergen.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { pinBadgeSingleAllergen } from "../../src/utils/adapter-helpers.js";
+
+// pinBadgeSingleAllergen rewrites the config so that when badge_content is
+// "single" and badge_single_allergen names a specific allergen, the card's
+// fetch/filter pipeline is scoped down to that allergen only (allergens:
+// [named] + pollen_threshold: 0). This avoids leaking unrelated allergens
+// into the fetch path. Non-single modes and unconfigured single modes get the
+// original config back unchanged (same reference).
+
+describe("pinBadgeSingleAllergen", () => {
+  it("returns a new object with allergens and threshold overridden for a named single allergen", () => {
+    const input = {
+      integration: "pp",
+      badge_content: "single",
+      badge_single_allergen: "birch",
+      allergens: ["grass_cat"],
+      pollen_threshold: 3,
+    };
+
+    const result = pinBadgeSingleAllergen(input);
+
+    // Must be a NEW object, not the same reference.
+    expect(result).not.toBe(input);
+
+    // Core rewrite: allergens narrows to the named allergen, threshold drops.
+    expect(result.allergens).toEqual(["birch"]);
+    expect(result.pollen_threshold).toBe(0);
+
+    // Other keys must be preserved unchanged.
+    expect(result.integration).toBe("pp");
+    expect(result.badge_content).toBe("single");
+    expect(result.badge_single_allergen).toBe("birch");
+
+    // Input must NOT be mutated.
+    expect(input.allergens).toEqual(["grass_cat"]);
+    expect(input.pollen_threshold).toBe(3);
+  });
+
+  it("returns the same reference when badge_content is 'single' but badge_single_allergen is absent", () => {
+    const input = {
+      badge_content: "single",
+      allergens: ["grass"],
+      pollen_threshold: 2,
+    };
+    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  });
+
+  it("returns the same reference when badge_content is 'single' but badge_single_allergen is an empty string", () => {
+    const input = {
+      badge_content: "single",
+      badge_single_allergen: "",
+      allergens: ["grass"],
+    };
+    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  });
+
+  it("returns the same reference when badge_content is not 'single', even if badge_single_allergen is set", () => {
+    const input = {
+      badge_content: "worst",
+      badge_single_allergen: "birch",
+      allergens: ["grass", "birch"],
+      pollen_threshold: 1,
+    };
+    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  });
+
+  it("returns the same reference when badge_content is 'aggregate'", () => {
+    const input = {
+      badge_content: "aggregate",
+      badge_single_allergen: "birch",
+    };
+    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  });
+
+  it("returns the same reference when badge_content is absent (no mode set)", () => {
+    const input = {
+      badge_single_allergen: "birch",
+      allergens: ["grass"],
+    };
+    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  });
+});

--- a/test/utils/pin-badge-single-allergen.test.js
+++ b/test/utils/pin-badge-single-allergen.test.js
@@ -1,17 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { pinBadgeSingleAllergen } from "../../src/utils/adapter-helpers.js";
 
-// pinBadgeSingleAllergen rewrites the config so that when badge_content is
-// "single" and badge_single_allergen names a specific allergen, that allergen
-// is guaranteed to be fetched and kept. The fetch is based on the adapter's
-// STUB allergen set (native slugs), not the possibly-custom configured list, so
-// an adapter keyed by localized slugs (pp "bjork", dwd "birke") still fetches
-// the native sensor when the user names a canonical key ("birch"). The named
-// key is appended only when no stub allergen is canonically equivalent, so a
-// canonical name the stub omits but the adapter resolves directly (gpl "birch")
-// is still fetched, without double-fetching a localized stub key. Threshold is
-// set to 0. Non-single modes and unconfigured single modes return the original
-// config unchanged (same reference).
+// pinBadgeSingleAllergen narrows the fetch to the one named allergen, resolved
+// through the adapter's STUB allergen set (native slugs), not the possibly-
+// custom configured list. It picks the stub key(s) whose canonical form matches
+// the named key, so an adapter keyed by localized slugs (pp "Björk", dwd
+// "Birke") fetches its native sensor when the user names a canonical key
+// ("birch"). It falls back to [key] when the stub has no canonical match but
+// the adapter resolves the key directly (gpl "birch"). Threshold is set to 0.
+// Non-single modes and unconfigured single modes return the original config
+// unchanged (same reference).
 
 // pp-like stub: native Swedish slugs, "Björk" canonicalizes to "birch".
 const PP_STUB = ["Al", "Björk", "Ek", "Gräs", "Hassel"];
@@ -19,7 +17,7 @@ const PP_STUB = ["Al", "Björk", "Ek", "Gräs", "Hassel"];
 const GPL_STUB = ["allergy_risk", "grass_cat", "trees_cat", "weeds_cat"];
 
 describe("pinBadgeSingleAllergen", () => {
-  it("uses the stub allergens (not the configured list) and drops the threshold", () => {
+  it("narrows to the native stub slug for a canonical key and drops the threshold", () => {
     const input = {
       integration: "pp",
       badge_content: "single",
@@ -31,9 +29,9 @@ describe("pinBadgeSingleAllergen", () => {
     const result = pinBadgeSingleAllergen(input, PP_STUB);
 
     expect(result).not.toBe(input);
-    // Localized "Björk" already covers canonical "birch", so the stub is used
-    // as-is (the named canonical key is NOT appended, no double fetch).
-    expect(result.allergens).toEqual(PP_STUB);
+    // Canonical "birch" resolves to the native stub slug "Björk"; the fetch is
+    // narrowed to just that allergen (not the full stub, not the trimmed list).
+    expect(result.allergens).toEqual(["Björk"]);
     expect(result.pollen_threshold).toBe(0);
     // Other keys preserved; input not mutated.
     expect(result.integration).toBe("pp");
@@ -42,24 +40,24 @@ describe("pinBadgeSingleAllergen", () => {
     expect(input.pollen_threshold).toBe(3);
   });
 
-  it("does not duplicate when the named key matches a stub slug case-insensitively", () => {
+  it("matches a stub slug case-insensitively without duplicating it", () => {
     const input = {
       badge_content: "single",
       badge_single_allergen: "al", // lowercase variant of stub "Al"
     };
     const result = pinBadgeSingleAllergen(input, PP_STUB);
-    expect(result.allergens).toEqual(PP_STUB);
+    expect(result.allergens).toEqual(["Al"]);
     expect(result.pollen_threshold).toBe(0);
   });
 
-  it("appends a canonical key the stub omits but the adapter resolves directly", () => {
+  it("falls back to the named key when no stub allergen canonically matches", () => {
     const input = {
       integration: "gpl",
       badge_content: "single",
       badge_single_allergen: "birch",
     };
     const result = pinBadgeSingleAllergen(input, GPL_STUB);
-    expect(result.allergens).toEqual([...GPL_STUB, "birch"]);
+    expect(result.allergens).toEqual(["birch"]);
     expect(result.pollen_threshold).toBe(0);
   });
 

--- a/test/utils/pin-badge-single-allergen.test.js
+++ b/test/utils/pin-badge-single-allergen.test.js
@@ -3,109 +3,102 @@ import { pinBadgeSingleAllergen } from "../../src/utils/adapter-helpers.js";
 
 // pinBadgeSingleAllergen rewrites the config so that when badge_content is
 // "single" and badge_single_allergen names a specific allergen, that allergen
-// is guaranteed to be fetched and kept: the named key is ADDED to allergens
-// (deduped) and pollen_threshold is set to 0. The key is added, not
-// substituted, so an adapter keyed by native names (e.g. pp "Bjork") still
-// fetches its own sensors and selectBadgeSensor can resolve a canonical name
-// against them. Non-single modes and unconfigured single modes get the
-// original config back unchanged (same reference).
+// is guaranteed to be fetched and kept. The fetch is based on the adapter's
+// STUB allergen set (native slugs), not the possibly-custom configured list, so
+// an adapter keyed by localized slugs (pp "bjork", dwd "birke") still fetches
+// the native sensor when the user names a canonical key ("birch"). The named
+// key is appended only when no stub allergen is canonically equivalent, so a
+// canonical name the stub omits but the adapter resolves directly (gpl "birch")
+// is still fetched, without double-fetching a localized stub key. Threshold is
+// set to 0. Non-single modes and unconfigured single modes return the original
+// config unchanged (same reference).
+
+// pp-like stub: native Swedish slugs, "Björk" canonicalizes to "birch".
+const PP_STUB = ["Al", "Björk", "Ek", "Gräs", "Hassel"];
+// gpl-like stub: category keys, none canonicalizes to "birch".
+const GPL_STUB = ["allergy_risk", "grass_cat", "trees_cat", "weeds_cat"];
 
 describe("pinBadgeSingleAllergen", () => {
-  it("adds the named allergen and drops the threshold for a named single allergen", () => {
+  it("uses the stub allergens (not the configured list) and drops the threshold", () => {
     const input = {
       integration: "pp",
       badge_content: "single",
       badge_single_allergen: "birch",
-      allergens: ["grass_cat"],
+      allergens: ["Gräs"], // custom list WITHOUT the localized birch slug
       pollen_threshold: 3,
     };
 
-    const result = pinBadgeSingleAllergen(input);
+    const result = pinBadgeSingleAllergen(input, PP_STUB);
 
-    // Must be a NEW object, not the same reference.
     expect(result).not.toBe(input);
-
-    // Core rewrite: the named key is added (not substituted) and threshold drops.
-    expect(result.allergens).toEqual(["grass_cat", "birch"]);
+    // Localized "Björk" already covers canonical "birch", so the stub is used
+    // as-is (the named canonical key is NOT appended, no double fetch).
+    expect(result.allergens).toEqual(PP_STUB);
     expect(result.pollen_threshold).toBe(0);
-
-    // Other keys must be preserved unchanged.
+    // Other keys preserved; input not mutated.
     expect(result.integration).toBe("pp");
-    expect(result.badge_content).toBe("single");
     expect(result.badge_single_allergen).toBe("birch");
-
-    // Input must NOT be mutated.
-    expect(input.allergens).toEqual(["grass_cat"]);
+    expect(input.allergens).toEqual(["Gräs"]);
     expect(input.pollen_threshold).toBe(3);
   });
 
-  it("does not duplicate the named allergen when it is already in allergens", () => {
+  it("does not duplicate when the named key matches a stub slug case-insensitively", () => {
     const input = {
       badge_content: "single",
-      badge_single_allergen: "birch",
-      allergens: ["grass", "birch"],
-      pollen_threshold: 1,
+      badge_single_allergen: "al", // lowercase variant of stub "Al"
     };
-
-    const result = pinBadgeSingleAllergen(input);
-
-    expect(result.allergens).toEqual(["grass", "birch"]);
+    const result = pinBadgeSingleAllergen(input, PP_STUB);
+    expect(result.allergens).toEqual(PP_STUB);
     expect(result.pollen_threshold).toBe(0);
   });
 
-  it("adds the named allergen when the config has no allergens array", () => {
+  it("appends a canonical key the stub omits but the adapter resolves directly", () => {
+    const input = {
+      integration: "gpl",
+      badge_content: "single",
+      badge_single_allergen: "birch",
+    };
+    const result = pinBadgeSingleAllergen(input, GPL_STUB);
+    expect(result.allergens).toEqual([...GPL_STUB, "birch"]);
+    expect(result.pollen_threshold).toBe(0);
+  });
+
+  it("falls back to just the named key when no stub allergens are provided", () => {
     const input = {
       badge_content: "single",
       badge_single_allergen: "birch",
     };
-
     const result = pinBadgeSingleAllergen(input);
-
     expect(result.allergens).toEqual(["birch"]);
     expect(result.pollen_threshold).toBe(0);
   });
 
-  it("returns the same reference when badge_content is 'single' but badge_single_allergen is absent", () => {
-    const input = {
-      badge_content: "single",
-      allergens: ["grass"],
-      pollen_threshold: 2,
-    };
-    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  it("returns the same reference when badge_single_allergen is absent", () => {
+    const input = { badge_content: "single", allergens: ["grass"] };
+    expect(pinBadgeSingleAllergen(input, PP_STUB)).toBe(input);
   });
 
-  it("returns the same reference when badge_content is 'single' but badge_single_allergen is an empty string", () => {
-    const input = {
-      badge_content: "single",
-      badge_single_allergen: "",
-      allergens: ["grass"],
-    };
-    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  it("returns the same reference when badge_single_allergen is an empty string", () => {
+    const input = { badge_content: "single", badge_single_allergen: "" };
+    expect(pinBadgeSingleAllergen(input, PP_STUB)).toBe(input);
   });
 
-  it("returns the same reference when badge_content is not 'single', even if badge_single_allergen is set", () => {
+  it("returns the same reference when badge_content is not 'single'", () => {
     const input = {
       badge_content: "worst",
       badge_single_allergen: "birch",
       allergens: ["grass", "birch"],
-      pollen_threshold: 1,
     };
-    expect(pinBadgeSingleAllergen(input)).toBe(input);
+    expect(pinBadgeSingleAllergen(input, PP_STUB)).toBe(input);
   });
 
   it("returns the same reference when badge_content is 'aggregate'", () => {
-    const input = {
-      badge_content: "aggregate",
-      badge_single_allergen: "birch",
-    };
-    expect(pinBadgeSingleAllergen(input)).toBe(input);
+    const input = { badge_content: "aggregate", badge_single_allergen: "birch" };
+    expect(pinBadgeSingleAllergen(input, PP_STUB)).toBe(input);
   });
 
-  it("returns the same reference when badge_content is absent (no mode set)", () => {
-    const input = {
-      badge_single_allergen: "birch",
-      allergens: ["grass"],
-    };
-    expect(pinBadgeSingleAllergen(input)).toBe(input);
+  it("returns the same reference when badge_content is absent", () => {
+    const input = { badge_single_allergen: "birch", allergens: ["grass"] };
+    expect(pinBadgeSingleAllergen(input, PP_STUB)).toBe(input);
   });
 });

--- a/test/utils/pin-badge-single-allergen.test.js
+++ b/test/utils/pin-badge-single-allergen.test.js
@@ -2,14 +2,16 @@ import { describe, it, expect } from "vitest";
 import { pinBadgeSingleAllergen } from "../../src/utils/adapter-helpers.js";
 
 // pinBadgeSingleAllergen rewrites the config so that when badge_content is
-// "single" and badge_single_allergen names a specific allergen, the badge's
-// fetch/filter pipeline is scoped down to that allergen only (allergens:
-// [named] + pollen_threshold: 0). This avoids leaking unrelated allergens
-// into the fetch path. Non-single modes and unconfigured single modes get the
+// "single" and badge_single_allergen names a specific allergen, that allergen
+// is guaranteed to be fetched and kept: the named key is ADDED to allergens
+// (deduped) and pollen_threshold is set to 0. The key is added, not
+// substituted, so an adapter keyed by native names (e.g. pp "Bjork") still
+// fetches its own sensors and selectBadgeSensor can resolve a canonical name
+// against them. Non-single modes and unconfigured single modes get the
 // original config back unchanged (same reference).
 
 describe("pinBadgeSingleAllergen", () => {
-  it("returns a new object with allergens and threshold overridden for a named single allergen", () => {
+  it("adds the named allergen and drops the threshold for a named single allergen", () => {
     const input = {
       integration: "pp",
       badge_content: "single",
@@ -23,8 +25,8 @@ describe("pinBadgeSingleAllergen", () => {
     // Must be a NEW object, not the same reference.
     expect(result).not.toBe(input);
 
-    // Core rewrite: allergens narrows to the named allergen, threshold drops.
-    expect(result.allergens).toEqual(["birch"]);
+    // Core rewrite: the named key is added (not substituted) and threshold drops.
+    expect(result.allergens).toEqual(["grass_cat", "birch"]);
     expect(result.pollen_threshold).toBe(0);
 
     // Other keys must be preserved unchanged.
@@ -35,6 +37,32 @@ describe("pinBadgeSingleAllergen", () => {
     // Input must NOT be mutated.
     expect(input.allergens).toEqual(["grass_cat"]);
     expect(input.pollen_threshold).toBe(3);
+  });
+
+  it("does not duplicate the named allergen when it is already in allergens", () => {
+    const input = {
+      badge_content: "single",
+      badge_single_allergen: "birch",
+      allergens: ["grass", "birch"],
+      pollen_threshold: 1,
+    };
+
+    const result = pinBadgeSingleAllergen(input);
+
+    expect(result.allergens).toEqual(["grass", "birch"]);
+    expect(result.pollen_threshold).toBe(0);
+  });
+
+  it("adds the named allergen when the config has no allergens array", () => {
+    const input = {
+      badge_content: "single",
+      badge_single_allergen: "birch",
+    };
+
+    const result = pinBadgeSingleAllergen(input);
+
+    expect(result.allergens).toEqual(["birch"]);
+    expect(result.pollen_threshold).toBe(0);
   });
 
   it("returns the same reference when badge_content is 'single' but badge_single_allergen is absent", () => {

--- a/test/utils/select-badge-sensor.test.js
+++ b/test/utils/select-badge-sensor.test.js
@@ -63,14 +63,17 @@ describe("selectBadgeSensor", () => {
     ).toEqual([birch]);
   });
 
-  it("falls back to worst when 'single' names a missing allergen", () => {
-    const sensors = [birch, grass, mugwort];
-    expect(
-      selectBadgeSensor(sensors, {
-        badge_content: "single",
-        badge_single_allergen: "oak",
-      }),
-    ).toEqual([grass]);
+  it("returns [] when 'single' names an allergen absent from the sensor set", () => {
+    // Named but absent: surface a visible miss rather than silently swapping in
+    // the worst other allergen. The badge must NOT show grass (state 4) here.
+    const sensors = [grass, mugwort];
+    const result = selectBadgeSensor(sensors, {
+      badge_content: "single",
+      badge_single_allergen: "birch",
+    });
+    expect(result).toEqual([]);
+    // Confirm worst is NOT returned (grass at state 4 would be the worst).
+    expect(result).not.toEqual([grass]);
   });
 
   it("falls back to worst when 'single' has no allergen configured", () => {


### PR DESCRIPTION
## Problem

With `badge_content: single` + `badge_single_allergen: X` and no explicit `allergens:` key, the badge silently rendered a *different* allergen (the highest-level one) instead of X. No error, no empty state, so it looked like the allergen key "resolved wrong."

Observed:

| integration | `badge_single_allergen` | expected | actually shown |
|-------------|-------------------------|----------|----------------|
| gpl         | `birch`                 | Birch    | Grasses        |
| pp          | `Al`                    | Alder    | Oak            |
| pp          | `Hassel`                | Hazel    | Oak            |

## Root cause

Two distinct causes, both upstream of `selectBadgeSensor`'s single lookup:

1. **gpl** — when no `allergens:` is set, `cfg.allergens` defaults to the adapter **stub**, which omits the named allergen (gpl stub has no `birch`). `filterSensorsPostFetch` drops every sensor whose normalized `allergenReplaced` is not in `cfg.allergens`, so the birch sensor was removed before the lookup.
2. **pp** — the stub *does* include `Al`/`Hassel`, so cause #1 does not apply. They were dropped earlier, inside `pp.fetchForecast`: with the stub default `pollen_threshold: 1`, an allergen whose forecast is all no-data/zero fails `meetsThreshold` and is never returned. (No normalization mismatch — `normalize("Al")` → `"al"` matches via PP_ALIASES.)

In both cases the named sensor was absent by the time `selectBadgeSensor` ran, so its `matchSensorByAllergenKey` found nothing and hit the **silent** `worst()` fallback.

## Fix

- New pure helper `pinBadgeSingleAllergen(config)` in `adapter-helpers.js`: in single mode, restrict the fetch to the one named allergen **and** set `pollen_threshold: 0`, so a no-data / level-0 named allergen still renders its ring instead of being dropped. Fixes both causes and makes a genuine miss inherently non-silent (no other sensors remain for `worst()` to swap in).
- Wired into the badge's `_buildConfig` (`return pinBadgeSingleAllergen(built)`), applied after location auto-select.
- Hardened `selectBadgeSensor`: an explicitly-named-but-absent single allergen now returns `[]` (visible no-data) instead of silently falling back to the worst other allergen; `worst()` remains only for a misconfigured single mode with no allergen named.

## Tests

- `pin-badge-single-allergen.test.js` — helper behaviour (pin, identity for non-single/unnamed, no mutation).
- `select-badge-sensor.test.js` — named-but-absent → `[]`; unnamed → `worst()`; named-present → that sensor. (Replaced the old test that asserted the buggy `worst()` swap.)
- `match-sensor-by-allergen-key.test.js` — regression guarding pp slugs (`Al`→`al`, `Hassel`→`hassel`).

Full suite: 1115 passed.

## Out of scope / compatibility

No config-key changes or renames (additive policy). `pollen_threshold`/`allergens` are only overridden at runtime for single-mode badges, never in user YAML. Card behaviour is unaffected.

## Follow-up: no-data / no-pollen badge states (commit 2)

Review surfaced that pinning single mode with `pollen_threshold: 0` let a no-data named allergen reach the ring, where it was drawn as a green level-0 ring (Codex P2). Two related gaps in how the badge represents *absence* are now fixed:

- **No-data** is rendered as the existing no-data noise pattern, not a green zero ring. New pure helper `badgeRingLevel(day0)` preserves a finite state (incl 0) but maps null/undefined/NaN to `-1`, which the shared `LevelCircleMixin` `level < 0` path renders honestly. (`Number(null) === 0`, so the null guard is explicit.)
- **No pollen** (entities exist, everything below threshold → empty fetch) now shows the card's breezy `no_allergens` image for `worst`/`row` modes via the shared `_renderAllergenSvg("no_allergens", 0)` (same level-0 colour as the card), instead of a blank pill. `single` keeps its named no-data ring; `aggregate` keeps its summary ring (card parity).

New test: `badge-ring-level.test.js`. Doc/comment wording on `pinBadgeSingleAllergen` clarified per review.
