### PR TITLE
Card picker suggestions (HA 2026.6 getEntitySuggestion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Card picker suggestions** (issue #255). On Home Assistant 2026.6+, picking a pollen sensor in the dashboard's "add card" dialog now offers a ready-configured Pollenprognos Card under the picker's Community section, via the new `getEntitySuggestion` hook. The picked entity is reverse-mapped to its integration and its specific location (city/region/location) using the shared autodetection, so the suggested card lands pre-filled; non-pollen entities produce no suggestion. Additive and opt-in by Home Assistant; no config keys changed.
+
 ## [3.3.0-beta3] - 2026-06-03
 
 Bugfix follow-up to beta2: the badge and editor fixes from #252, plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- **Card picker suggestions** (issue #255). On Home Assistant 2026.6+, picking a pollen sensor in the dashboard's "add card" dialog now offers a ready-configured Pollenprognos Card under the picker's Community section, via the new `getEntitySuggestion` hook. The picked entity is reverse-mapped to its integration and its specific location (city/region/location) using the shared autodetection, so the suggested card lands pre-filled; non-pollen entities produce no suggestion. Additive and opt-in by Home Assistant; no config keys changed.
+- **Card picker suggestions** (issue #255, PR #258). On Home Assistant 2026.6+, picking a pollen sensor in the dashboard's "Add card" dialog now offers a ready-configured Pollenprognos Card in the picker's Community section, via the new `window.customCards` `getEntitySuggestion` hook. The picked entity is reverse-mapped to its integration and its specific location (city/region/location) through the shared autodetection, so the suggestion lands pre-filled at the location the picked sensor belongs to, not just the first one found. Works across all 10 integrations (including SILAM weather-only installs, which expose the allergy-risk index via a `weather.*` entity). Entities not owned by a known pollen integration, and non-renderable sibling or diagnostic sensors (for example a Pollen Levels timestamp or in-season helper, or Kleenex `_date`/`_region`), produce no suggestion. Card only (the badge is unchanged); additive and opt-in by Home Assistant, with no config keys changed.
 
 ## [3.3.0-beta3] - 2026-06-03
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import "./pollenprognos-editor.js";
 import "./pollenprognos-badge.js";
 import "./pollenprognos-badge-editor.js";
 
+import { suggestEntityConfig } from "./utils/autodetect.js";
+
 // Register for Lovelace UI picker (HACS)
 window.customCards = window.customCards || [];
 window.customCards.push({
@@ -15,6 +17,10 @@ window.customCards.push({
   preview: true,
   description: "Visar en grafisk prognos för pollenhalter",
   documentationURL: "https://github.com/krissen/pollenprognos-card",
+  // HA 2026.6 card-picker suggestions: when a user picks a pollen sensor, offer
+  // a correctly-configured card under the picker's Community section. Returns
+  // null for entities we don't recognise.
+  getEntitySuggestion: (hass, entityId) => suggestEntityConfig(hass, entityId),
 });
 
 // Register for the Lovelace badge picker. HA reads window.customBadges the same

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -471,3 +471,191 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
 
   return null;
 }
+
+/**
+ * Find the location key of the discovery entry that owns a specific entity id.
+ * Works for every discovery shape used here: device-based discoveries expose
+ * `entities` (Map<key, entityId>), SILAM exposes `sensors` (Map) plus an
+ * optional `weatherEntity`. Returns the location map key (the same value
+ * autoSelectLocation returns as `value`) or null.
+ *
+ * @param {{locations?: Map<string, {entities?: Map, sensors?: Map, weatherEntity?: string}>}} discovery
+ * @param {string} entityId
+ * @returns {string|null}
+ */
+function findLocationKeyInDiscovery(discovery, entityId) {
+  if (!discovery || !discovery.locations) return null;
+  for (const [key, loc] of discovery.locations) {
+    if (!loc) continue;
+    if (loc.weatherEntity === entityId) return key;
+    for (const map of [loc.entities, loc.sensors]) {
+      if (map && typeof map.values === "function") {
+        for (const eid of map.values()) {
+          if (eid === entityId) return key;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Per-entity sibling of autoSelectLocation: derive the location/city/region of a
+ * SPECIFIC entity id (not the integration's first location). Used by the card
+ * picker suggestion so picking sensor.pollen_birch_stockholm yields a Stockholm
+ * card. Returns { key, value } or null when the entity's location can't be
+ * derived (caller falls back to autoSelectLocation).
+ *
+ * Mirrors the per-integration logic in autoSelectLocation; discovery-based
+ * integrations (gp/gpl/msw/silam-discovery/atmo) resolve via
+ * findLocationKeyInDiscovery, id-pattern integrations via their adapter regexes.
+ *
+ * @param {string} integration
+ * @param {string} entityId
+ * @param {object} hass
+ * @param {ReturnType<typeof detectIntegrationStates>} detection
+ * @returns {{key: string, value: *}|null}
+ */
+export function deriveLocationForEntity(integration, entityId, hass, detection) {
+  if (typeof integration !== "string" || typeof entityId !== "string")
+    return null;
+
+  switch (integration) {
+    case "pp": {
+      const value = extractPpCitySlugFromEntityId(entityId);
+      return value ? { key: "city", value } : null;
+    }
+
+    case "dwd": {
+      const value = entityId.match(DWD_ENTITY_ID_RE)?.[2] || null;
+      return value ? { key: "region_id", value } : null;
+    }
+
+    case "peu": {
+      const value = hass?.states?.[entityId]?.attributes?.location_slug || null;
+      return value ? { key: "location", value } : null;
+    }
+
+    case "atmo": {
+      const fromDiscovery = findLocationKeyInDiscovery(
+        detection?.discovery?.atmo,
+        entityId,
+      );
+      if (fromDiscovery) return { key: "location", value: fromDiscovery };
+      // Legacy fallback: niveau_{allergen}_{location}[_j_N].
+      const m = entityId.match(
+        /^sensor\.niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)_(.+?)(?:_j_\d+)?$/,
+      );
+      return m ? { key: "location", value: m[1] } : null;
+    }
+
+    case "silam": {
+      const fromDiscovery = findLocationKeyInDiscovery(
+        detection?.discovery?.silam,
+        entityId,
+      );
+      if (fromDiscovery) return { key: "location", value: fromDiscovery };
+      const m = entityId.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
+      return m ? { key: "location", value: m[1] } : null;
+    }
+
+    case "kleenex": {
+      // Location can contain underscores, so match against the known location
+      // set derived from the `..._date` sensors and pick the longest prefix
+      // that owns this entity.
+      const dateSensors = (detection?.stateIds || []).filter(
+        (id) =>
+          typeof id === "string" &&
+          /^sensor\.kleenex_pollen_radar_.+_date$/.test(id),
+      );
+      const locations = Array.from(
+        new Set(
+          dateSensors
+            .map((eid) => {
+              const m = eid.match(/^sensor\.kleenex_pollen_radar_(.+)_date$/);
+              return m ? m[1] : null;
+            })
+            .filter(Boolean),
+        ),
+      );
+      let best = null;
+      for (const loc of locations) {
+        const prefix = `sensor.kleenex_pollen_radar_${loc}_`;
+        if (
+          entityId === `sensor.kleenex_pollen_radar_${loc}_date` ||
+          entityId.startsWith(prefix)
+        ) {
+          if (!best || loc.length > best.length) best = loc;
+        }
+      }
+      return best ? { key: "location", value: best } : null;
+    }
+
+    case "gp": {
+      const value = findLocationKeyInDiscovery(
+        detection?.discovery?.gp,
+        entityId,
+      );
+      return value ? { key: "location", value } : null;
+    }
+
+    case "gpl": {
+      const value = findLocationKeyInDiscovery(
+        detection?.getGplDiscovery?.(),
+        entityId,
+      );
+      return value ? { key: "location", value } : null;
+    }
+
+    case "msw": {
+      const value = findLocationKeyInDiscovery(
+        detection?.getMswDiscovery?.(),
+        entityId,
+      );
+      return value ? { key: "location", value } : null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build a card-picker suggestion for a picked entity id (HA 2026.6
+ * window.customCards getEntitySuggestion). Reverse-maps the entity to one of our
+ * integrations, derives its specific location, and returns a config the picker
+ * can drop in. Returns null for non-sensor or unrecognised entities so we don't
+ * clutter the picker.
+ *
+ * @param {object} hass
+ * @param {string} entityId
+ * @returns {{config: object}|null}
+ */
+export function suggestEntityConfig(hass, entityId) {
+  if (typeof entityId !== "string" || !entityId.startsWith("sensor."))
+    return null;
+  if (!hass || !hass.states) return null;
+
+  const detection = detectIntegrationStates(hass);
+
+  let integration;
+  for (const id of INTEGRATION_PRIORITY) {
+    if (detection.states[id]?.includes(entityId)) {
+      integration = id;
+      break;
+    }
+  }
+  if (!integration) return null;
+
+  const loc =
+    deriveLocationForEntity(integration, entityId, hass, detection) ||
+    autoSelectLocation(integration, {}, hass, detection);
+
+  const config = {
+    type: "custom:pollenprognos-card",
+    integration,
+    ...(loc ? { [loc.key]: loc.value } : {}),
+  };
+
+  return { config };
+}

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -605,7 +605,19 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
           if (!best || loc.length > best.length) best = loc;
         }
       }
-      return best ? { key: "location", value: best } : null;
+      if (!best) return null;
+      // Reject diagnostic helper sensors (date/last_updated/region); only
+      // category/detail sensors are renderable pollen data.
+      const rest = entityId.slice(
+        `sensor.kleenex_pollen_radar_${best}_`.length,
+      );
+      const KLEENEX_DIAGNOSTIC_SUFFIXES = new Set([
+        "date",
+        "last_updated",
+        "region",
+      ]);
+      if (!rest || KLEENEX_DIAGNOSTIC_SUFFIXES.has(rest)) return null;
+      return { key: "location", value: best };
     }
 
     case "gp": {
@@ -675,15 +687,16 @@ export function suggestEntityConfig(hass, entityId) {
 
   const derived = deriveLocationForEntity(integration, entityId, hass, detection);
 
-  // For gpl/gp/msw the detection list is broader than the set of render-usable
-  // pollen sensors: it includes sibling summary/helper sensors (e.g.
-  // plants_in_season_today, top_pollen_types_today) that the discovery
-  // classifier intentionally skips. There the discovery result is
-  // authoritative, so an entity that didn't resolve to a discovery location is
-  // one the card can't use -- offer no suggestion rather than a wrong one
-  // (which autoSelectLocation's first-location guess would produce).
-  const DISCOVERY_AUTHORITATIVE = new Set(["gpl", "gp", "msw"]);
-  if (!derived && DISCOVERY_AUTHORITATIVE.has(integration)) return null;
+  // For gpl/gp/msw/kleenex the detection list is broader than the set of
+  // render-usable pollen sensors: gpl/gp/msw include sibling summary/helper
+  // sensors (e.g. plants_in_season_today, top_pollen_types_today) the discovery
+  // classifier skips, and kleenex includes diagnostic helpers (_date,
+  // _last_updated, _region). For these, a renderable sensor always yields a
+  // per-entity derivation, so a null derivation means the entity isn't usable
+  // -- offer no suggestion rather than the wrong one autoSelectLocation's
+  // first-location guess would produce.
+  const STRICT_DERIVATION = new Set(["gpl", "gp", "msw", "kleenex"]);
+  if (!derived && STRICT_DERIVATION.has(integration)) return null;
 
   const loc =
     derived || autoSelectLocation(integration, {}, hass, detection);

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -25,7 +25,10 @@ import {
   extractCitySlugFromEntityId as extractPpCitySlugFromEntityId,
 } from "../adapters/pp.js";
 import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "../adapters/dwd.js";
-import { discoverPeuSensors } from "../adapters/peu.js";
+import {
+  discoverPeuSensors,
+  extractPeuLocationSlugFromEntityId,
+} from "../adapters/peu.js";
 import { discoverSilamSensors } from "./silam.js";
 
 // Canonical autodetect priority order. The first integration with detected
@@ -512,7 +515,7 @@ function findLocationKeyInDiscovery(discovery, entityId) {
 /**
  * Per-entity sibling of autoSelectLocation: derive the location/city/region of a
  * SPECIFIC entity id (not the integration's first location). Used by the card
- * picker suggestion so picking sensor.pollen_birch_stockholm yields a Stockholm
+ * picker suggestion so picking sensor.pollen_stockholm_bjork yields a Stockholm
  * card. Returns { key, value } or null when the entity's location can't be
  * derived (caller falls back to autoSelectLocation).
  *
@@ -542,7 +545,12 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
     }
 
     case "peu": {
-      const value = hass?.states?.[entityId]?.attributes?.location_slug || null;
+      // Prefer the integration's own location_slug attribute; fall back to the
+      // PEU adapter's entity-id slug extractor so multi-location installs that
+      // don't expose the (optional) attribute still pin the picked location.
+      const value =
+        hass?.states?.[entityId]?.attributes?.location_slug ||
+        extractPeuLocationSlugFromEntityId(entityId);
       return value ? { key: "location", value } : null;
     }
 

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -641,9 +641,11 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
  * Build a card-picker suggestion for a picked entity id (HA 2026.6
  * window.customCards getEntitySuggestion). Reverse-maps the entity to one of our
  * integrations, derives its specific location, and returns a config the picker
- * can drop in. Only sensor.* and SILAM weather.* entities are considered;
- * returns null for any other domain or unrecognised entity so we don't clutter
- * the picker.
+ * can drop in. Only sensor.* and weather.* entities pass the initial guard
+ * (weather.* supports SILAM weather-only installs, including renamed weather
+ * entities); any entity not owned by a known pollen integration -- including
+ * weather.* entities that aren't SILAM's -- then returns null, so we never
+ * clutter the picker.
  *
  * @param {object} hass
  * @param {string} entityId
@@ -671,9 +673,20 @@ export function suggestEntityConfig(hass, entityId) {
   }
   if (!integration) return null;
 
+  const derived = deriveLocationForEntity(integration, entityId, hass, detection);
+
+  // For gpl/gp/msw the detection list is broader than the set of render-usable
+  // pollen sensors: it includes sibling summary/helper sensors (e.g.
+  // plants_in_season_today, top_pollen_types_today) that the discovery
+  // classifier intentionally skips. There the discovery result is
+  // authoritative, so an entity that didn't resolve to a discovery location is
+  // one the card can't use -- offer no suggestion rather than a wrong one
+  // (which autoSelectLocation's first-location guess would produce).
+  const DISCOVERY_AUTHORITATIVE = new Set(["gpl", "gp", "msw"]);
+  if (!derived && DISCOVERY_AUTHORITATIVE.has(integration)) return null;
+
   const loc =
-    deriveLocationForEntity(integration, entityId, hass, detection) ||
-    autoSelectLocation(integration, {}, hass, detection);
+    derived || autoSelectLocation(integration, {}, hass, detection);
 
   const config = {
     type: "custom:pollenprognos-card",

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -632,7 +632,13 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
  * @returns {{config: object}|null}
  */
 export function suggestEntityConfig(hass, entityId) {
-  if (typeof entityId !== "string" || !entityId.startsWith("sensor."))
+  // Pollen sensors live on sensor.*; SILAM weather-only installs expose the
+  // allergy_risk index via a weather.* entity that detection/discovery already
+  // recognise, so let that domain through too.
+  if (
+    typeof entityId !== "string" ||
+    !(entityId.startsWith("sensor.") || entityId.startsWith("weather."))
+  )
     return null;
   if (!hass || !hass.states) return null;
 

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -165,13 +165,21 @@ export function detectIntegrationStates(hass, { debug = false } = {}) {
     );
   }
 
-  // GPL: hass.entities platform (primary) or attribution (fallback).
+  // GPL: hass.entities platform (primary) or attribution (fallback). Exclude
+  // date/timestamp helper entities (e.g. an "update time" sensor) so they are
+  // never treated as pollen sensors -- matching the attribution fallback below.
+  const isNonDataDeviceClass = (eid) => {
+    const dc = hass?.states?.[eid]?.attributes?.device_class;
+    return dc === "date" || dc === "timestamp";
+  };
   let gplStates = [];
   if (hass && hass.entities) {
     gplStates = Object.entries(hass.entities)
       .filter(
-        ([, entry]) =>
-          entry.platform === "pollenlevels" && !entry.entity_category,
+        ([eid, entry]) =>
+          entry.platform === "pollenlevels" &&
+          !entry.entity_category &&
+          !isNonDataDeviceClass(eid),
       )
       .map(([eid]) => eid);
   }
@@ -198,8 +206,10 @@ export function detectIntegrationStates(hass, { debug = false } = {}) {
     if (hass && hass.entities) {
       gpStates = Object.entries(hass.entities)
         .filter(
-          ([, entry]) =>
-            entry.platform === "google_pollen" && !entry.entity_category,
+          ([eid, entry]) =>
+            entry.platform === "google_pollen" &&
+            !entry.entity_category &&
+            !isNonDataDeviceClass(eid),
         )
         .map(([eid]) => eid);
     }
@@ -624,8 +634,9 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
  * Build a card-picker suggestion for a picked entity id (HA 2026.6
  * window.customCards getEntitySuggestion). Reverse-maps the entity to one of our
  * integrations, derives its specific location, and returns a config the picker
- * can drop in. Returns null for non-sensor or unrecognised entities so we don't
- * clutter the picker.
+ * can drop in. Only sensor.* and SILAM weather.* entities are considered;
+ * returns null for any other domain or unrecognised entity so we don't clutter
+ * the picker.
  *
  * @param {object} hass
  * @param {string} entityId

--- a/src/utils/autodetect.js
+++ b/src/utils/autodetect.js
@@ -547,16 +547,23 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
     }
 
     case "atmo": {
+      // The niveau_{allergen}_{slug} regex gives the precise per-entity slug,
+      // which the adapter resolves in both modern (config-entry) and
+      // legacy/no-registry setups via its legacy-slug path -- mirroring
+      // autoSelectLocation. Prefer it. Only non-niveau entities (pollution /
+      // summary) need the discovery key, and we never return the tier-3
+      // "default" merge bucket (it pins every location to one colliding key).
+      const m = entityId.match(
+        /^sensor\.niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)_(.+?)(?:_j_\d+)?$/,
+      );
+      if (m) return { key: "location", value: m[1] };
       const fromDiscovery = findLocationKeyInDiscovery(
         detection?.discovery?.atmo,
         entityId,
       );
-      if (fromDiscovery) return { key: "location", value: fromDiscovery };
-      // Legacy fallback: niveau_{allergen}_{location}[_j_N].
-      const m = entityId.match(
-        /^sensor\.niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)_(.+?)(?:_j_\d+)?$/,
-      );
-      return m ? { key: "location", value: m[1] } : null;
+      return fromDiscovery && fromDiscovery !== "default"
+        ? { key: "location", value: fromDiscovery }
+        : null;
     }
 
     case "silam": {

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -131,6 +131,51 @@ describe("suggestEntityConfig", () => {
         },
       });
     });
+
+    it("does not suggest for a non-data pollenlevels helper (e.g. update_time)", () => {
+      // A timestamp helper on the pollenlevels platform must not be treated as a
+      // pollen sensor, so picking it offers no card suggestion. (Codex #258)
+      const deviceId = "gpl_device_1";
+      const configEntryId = "abc123";
+      const hass = createHass(
+        {
+          "sensor.gpl_grass": { state: "3", attributes: { icon: "mdi:grass" } },
+          "sensor.pollenlevels_update_time": {
+            state: "2026-06-04T08:00:00+00:00",
+            attributes: { device_class: "timestamp" },
+          },
+        },
+        {
+          entities: {
+            "sensor.gpl_grass": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+            },
+            "sensor.pollenlevels_update_time": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+            },
+          },
+          devices: {
+            [deviceId]: { name: "Home", config_entries: [configEntryId] },
+          },
+        },
+      );
+
+      expect(
+        suggestEntityConfig(hass, "sensor.pollenlevels_update_time"),
+      ).toBeNull();
+      // The real pollen sensor on the same platform still works.
+      expect(suggestEntityConfig(hass, "sensor.gpl_grass")).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "gpl",
+          location: configEntryId,
+        },
+      });
+    });
   });
 
   describe("location fallback", () => {

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -290,17 +290,27 @@ describe("deriveLocationForEntity", () => {
     ).toEqual({ key: "location", value: "wien" });
   });
 
-  it("ATMO: discovery map takes precedence over the legacy regex", () => {
+  it("ATMO: niveau entity yields the precise slug via regex, even with discovery present", () => {
+    // Regex-first: the per-entity slug wins over the discovery config-entry key
+    // so multi-location and no-registry setups stay precise. (Codex #258)
     const detection = {
       discovery: {
         atmo: disc([
-          ["lyon", { entities: new Map([["birch", "sensor.atmo_lyon_birch"]]) }],
+          [
+            "entry_atmo",
+            { entities: new Map([["birch", "sensor.niveau_bouleau_paris"]]) },
+          ],
         ]),
       },
     };
     expect(
-      deriveLocationForEntity("atmo", "sensor.atmo_lyon_birch", {}, detection),
-    ).toEqual({ key: "location", value: "lyon" });
+      deriveLocationForEntity(
+        "atmo",
+        "sensor.niveau_bouleau_paris",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "paris" });
   });
 
   it("ATMO: legacy niveau_ regex when discovery is empty", () => {
@@ -313,6 +323,32 @@ describe("deriveLocationForEntity", () => {
         detection,
       ),
     ).toEqual({ key: "location", value: "paris" });
+  });
+
+  it("ATMO: a non-niveau entity resolves via a real discovery config entry", () => {
+    const detection = {
+      discovery: {
+        atmo: disc([
+          ["entry_atmo", { entities: new Map([["pm25", "sensor.pm25_paris"]]) }],
+        ]),
+      },
+    };
+    expect(
+      deriveLocationForEntity("atmo", "sensor.pm25_paris", {}, detection),
+    ).toEqual({ key: "location", value: "entry_atmo" });
+  });
+
+  it("ATMO: never pins a non-niveau entity to the tier-3 'default' bucket", () => {
+    const detection = {
+      discovery: {
+        atmo: disc([
+          ["default", { entities: new Map([["pm25", "sensor.pm25_paris"]]) }],
+        ]),
+      },
+    };
+    expect(
+      deriveLocationForEntity("atmo", "sensor.pm25_paris", {}, detection),
+    ).toBeNull();
   });
 
   it("SILAM: weatherEntity match in discovery", () => {

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -176,6 +176,49 @@ describe("suggestEntityConfig", () => {
         },
       });
     });
+
+    it("does not suggest for an unclassified pollenlevels helper (e.g. plants_in_season_today)", () => {
+      // A non-timestamp summary/helper sensor passes the broad platform list but
+      // the discovery classifier skips it (render-unsupported), so it must yield
+      // no suggestion instead of being pinned to the first location. (Codex #258)
+      const deviceId = "gpl_device_1";
+      const configEntryId = "abc123";
+      const hass = createHass(
+        {
+          "sensor.gpl_grass": { state: "3", attributes: { icon: "mdi:grass" } },
+          "sensor.plants_in_season_today": { state: "5", attributes: {} },
+        },
+        {
+          entities: {
+            "sensor.gpl_grass": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+            },
+            "sensor.plants_in_season_today": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+              translation_key: "plants_in_season_today",
+            },
+          },
+          devices: {
+            [deviceId]: { name: "Home", config_entries: [configEntryId] },
+          },
+        },
+      );
+
+      expect(
+        suggestEntityConfig(hass, "sensor.plants_in_season_today"),
+      ).toBeNull();
+      expect(suggestEntityConfig(hass, "sensor.gpl_grass")).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "gpl",
+          location: configEntryId,
+        },
+      });
+    });
   });
 
   describe("location fallback", () => {

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { suggestEntityConfig } from "../../src/utils/autodetect.js";
+import { createHass } from "../helpers.js";
+
+// Minimal sensor state object.
+function s(state = "3", attrs = {}) {
+  return { state, attributes: attrs };
+}
+
+// suggestEntityConfig powers HA 2026.6 card-picker suggestions
+// (window.customCards getEntitySuggestion). Given a picked entity id it
+// reverse-maps to an integration and derives that entity's specific location.
+
+describe("suggestEntityConfig", () => {
+  describe("guards", () => {
+    it("returns null for a non-string entity id", () => {
+      const hass = createHass({});
+      expect(suggestEntityConfig(hass, undefined)).toBeNull();
+      expect(suggestEntityConfig(hass, 42)).toBeNull();
+    });
+
+    it("returns null for non-sensor entities", () => {
+      const hass = createHass({ "light.kitchen": s() });
+      expect(suggestEntityConfig(hass, "light.kitchen")).toBeNull();
+    });
+
+    it("returns null when hass has no states", () => {
+      expect(suggestEntityConfig(null, "sensor.pollen_stockholm_bjork")).toBeNull();
+      expect(suggestEntityConfig({}, "sensor.pollen_stockholm_bjork")).toBeNull();
+    });
+
+    it("returns null for an unrecognised sensor", () => {
+      const hass = createHass({ "sensor.living_room_temperature": s("21") });
+      expect(
+        suggestEntityConfig(hass, "sensor.living_room_temperature"),
+      ).toBeNull();
+    });
+  });
+
+  describe("PP (city-based)", () => {
+    it("suggests a card with the picked entity's city", () => {
+      const hass = createHass({
+        "sensor.pollen_stockholm_bjork": s(),
+        "sensor.pollen_stockholm_gras": s(),
+      });
+
+      const result = suggestEntityConfig(hass, "sensor.pollen_stockholm_bjork");
+
+      expect(result).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "pp",
+          city: "stockholm",
+        },
+      });
+    });
+  });
+
+  describe("DWD (region-based)", () => {
+    it("derives region_id from the entity id (incl. device-prefixed)", () => {
+      const hass = createHass({
+        "sensor.pollenflug_birke_50": s(),
+        "sensor.pollenflug_gefahrenindex_pollenflug_erle_91": s(),
+      });
+
+      expect(
+        suggestEntityConfig(hass, "sensor.pollenflug_birke_50"),
+      ).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "dwd",
+          region_id: "50",
+        },
+      });
+
+      expect(
+        suggestEntityConfig(
+          hass,
+          "sensor.pollenflug_gefahrenindex_pollenflug_erle_91",
+        ),
+      ).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "dwd",
+          region_id: "91",
+        },
+      });
+    });
+  });
+
+  describe("GPL (discovery-based)", () => {
+    it("resolves the location from the discovery map", () => {
+      const deviceId = "gpl_device_1";
+      const configEntryId = "abc123";
+      // Non-pollen-prefixed ids so PP/PLU don't claim them; gpl is detected via
+      // the pollenlevels platform regardless of id shape.
+      const hass = createHass(
+        {
+          "sensor.gpl_grass": { state: "3", attributes: { icon: "mdi:grass" } },
+          "sensor.gpl_tree": { state: "2", attributes: { icon: "mdi:tree" } },
+        },
+        {
+          entities: {
+            "sensor.gpl_grass": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+            },
+            "sensor.gpl_tree": {
+              platform: "pollenlevels",
+              device_id: deviceId,
+              entity_category: null,
+            },
+          },
+          devices: {
+            [deviceId]: { name: "Home", config_entries: [configEntryId] },
+          },
+        },
+      );
+
+      const result = suggestEntityConfig(hass, "sensor.gpl_grass");
+
+      expect(result).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "gpl",
+          location: configEntryId,
+        },
+      });
+    });
+  });
+
+  describe("location fallback", () => {
+    it("falls back to autoSelectLocation when per-entity derivation fails", () => {
+      // The picked PEU entity lacks location_slug, but a sibling PEU entity has
+      // one, so autoSelectLocation supplies it.
+      const hass = createHass({
+        "sensor.polleninformation_birch": s("2"), // picked, no location_slug
+        "sensor.polleninformation_grasses": s("3", { location_slug: "wien" }),
+      });
+
+      const result = suggestEntityConfig(
+        hass,
+        "sensor.polleninformation_birch",
+      );
+
+      expect(result).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "peu",
+          location: "wien",
+        },
+      });
+    });
+
+    it("omits the location key when no location can be derived at all", () => {
+      const hass = createHass({
+        "sensor.polleninformation_birch": s("2"),
+      });
+
+      const result = suggestEntityConfig(
+        hass,
+        "sensor.polleninformation_birch",
+      );
+
+      expect(result).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "peu",
+        },
+      });
+    });
+  });
+});

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -298,6 +298,35 @@ describe("suggestEntityConfig", () => {
       });
     });
   });
+
+  describe("Kleenex diagnostic helpers", () => {
+    // Diagnostic sensors share the kleenex prefix and so appear in
+    // detection.states.kleenex, but are not renderable; they must not produce a
+    // suggestion (and must not fall back to the first location). (Codex #258)
+    it("offers no suggestion for a Kleenex date helper, but does for a category sensor", () => {
+      const hass = createHass({
+        "sensor.kleenex_pollen_radar_amsterdam_date": s("2026-06-04"),
+        "sensor.kleenex_pollen_radar_amsterdam_trees": s("3"),
+      });
+
+      expect(
+        suggestEntityConfig(hass, "sensor.kleenex_pollen_radar_amsterdam_date"),
+      ).toBeNull();
+
+      expect(
+        suggestEntityConfig(
+          hass,
+          "sensor.kleenex_pollen_radar_amsterdam_trees",
+        ),
+      ).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "kleenex",
+          location: "amsterdam",
+        },
+      });
+    });
+  });
 });
 
 // deriveLocationForEntity per-integration branches. The discovery-backed
@@ -442,6 +471,31 @@ describe("deriveLocationForEntity", () => {
         detection,
       ),
     ).toEqual({ key: "location", value: "noord_holland" });
+  });
+
+  it("Kleenex: rejects diagnostic helper suffixes (date/last_updated/region)", () => {
+    const detection = {
+      stateIds: ["sensor.kleenex_pollen_radar_amsterdam_date"],
+    };
+    for (const suffix of ["date", "last_updated", "region"]) {
+      expect(
+        deriveLocationForEntity(
+          "kleenex",
+          `sensor.kleenex_pollen_radar_amsterdam_${suffix}`,
+          {},
+          detection,
+        ),
+      ).toBeNull();
+    }
+    // A category sensor for the same location still resolves.
+    expect(
+      deriveLocationForEntity(
+        "kleenex",
+        "sensor.kleenex_pollen_radar_amsterdam_trees",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "amsterdam" });
   });
 
   it("GP: location from the discovery entities map", () => {

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -221,6 +221,27 @@ describe("suggestEntityConfig", () => {
     });
   });
 
+  describe("PEU multi-location", () => {
+    it("suggests the picked entity's location from its id, not a sibling's", () => {
+      // No location_slug attribute; multi-location install. The picked entity's
+      // own location must win, not autoSelectLocation's first pick. (Codex #258)
+      const hass = createHass({
+        "sensor.polleninformation_wien_birch": s("2"),
+        "sensor.polleninformation_graz_birch": s("3"),
+      });
+
+      expect(
+        suggestEntityConfig(hass, "sensor.polleninformation_graz_birch"),
+      ).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "peu",
+          location: "graz",
+        },
+      });
+    });
+  });
+
   describe("location fallback", () => {
     it("falls back to autoSelectLocation when per-entity derivation fails", () => {
       // The picked PEU entity lacks location_slug, but a sibling PEU entity has
@@ -359,6 +380,18 @@ describe("deriveLocationForEntity", () => {
     };
     expect(
       deriveLocationForEntity("peu", "sensor.polleninformation_x", hass, {}),
+    ).toEqual({ key: "location", value: "wien" });
+  });
+
+  it("PEU: derives location from the entity id when the attribute is absent", () => {
+    const hass = { states: { "sensor.polleninformation_wien_birch": { attributes: {} } } };
+    expect(
+      deriveLocationForEntity(
+        "peu",
+        "sensor.polleninformation_wien_birch",
+        hass,
+        {},
+      ),
     ).toEqual({ key: "location", value: "wien" });
   });
 

--- a/test/utils/suggest.test.js
+++ b/test/utils/suggest.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { suggestEntityConfig } from "../../src/utils/autodetect.js";
+import {
+  suggestEntityConfig,
+  deriveLocationForEntity,
+} from "../../src/utils/autodetect.js";
 import { createHass } from "../helpers.js";
 
 // Minimal sensor state object.
@@ -170,5 +173,203 @@ describe("suggestEntityConfig", () => {
         },
       });
     });
+  });
+
+  describe("SILAM weather-only install", () => {
+    // A SILAM install with no allergen sensors still exposes the allergy_risk
+    // index via a weather.* entity; the guard must let that domain through and
+    // resolve its location from discovery (loc.weatherEntity). (Codex #258)
+    it("suggests a card when the picked entity is the SILAM weather entity", () => {
+      const deviceId = "silam_dev";
+      const configEntryId = "silam_entry_1";
+      const hass = createHass(
+        { "weather.silam_pollen_oslo": { state: "sunny", attributes: {} } },
+        {
+          entities: {
+            "weather.silam_pollen_oslo": {
+              platform: "silam_pollen",
+              device_id: deviceId,
+              entity_category: null,
+              translation_key: "forecast",
+            },
+          },
+          devices: {
+            [deviceId]: { name: "Oslo", config_entries: [configEntryId] },
+          },
+        },
+      );
+
+      const result = suggestEntityConfig(hass, "weather.silam_pollen_oslo");
+
+      expect(result).toEqual({
+        config: {
+          type: "custom:pollenprognos-card",
+          integration: "silam",
+          location: configEntryId,
+        },
+      });
+    });
+  });
+});
+
+// deriveLocationForEntity per-integration branches. The discovery-backed
+// integrations (atmo/silam/gp/gpl/msw) are exercised with hand-built detection
+// objects so each findLocationKeyInDiscovery / regex branch is covered
+// deterministically without depending on each adapter's discovery internals.
+describe("deriveLocationForEntity", () => {
+  // Build a minimal discovery: Map<locationKey, { entities | sensors | weatherEntity }>.
+  function disc(entries) {
+    return { locations: new Map(entries) };
+  }
+
+  it("PP: city from the entity id", () => {
+    expect(
+      deriveLocationForEntity("pp", "sensor.pollen_goteborg_bjork", {}, {}),
+    ).toEqual({ key: "city", value: "goteborg" });
+  });
+
+  it("DWD: region_id from the entity id", () => {
+    expect(
+      deriveLocationForEntity("dwd", "sensor.pollenflug_erle_91", {}, {}),
+    ).toEqual({ key: "region_id", value: "91" });
+  });
+
+  it("PEU: location from the location_slug attribute", () => {
+    const hass = {
+      states: {
+        "sensor.polleninformation_x": { attributes: { location_slug: "wien" } },
+      },
+    };
+    expect(
+      deriveLocationForEntity("peu", "sensor.polleninformation_x", hass, {}),
+    ).toEqual({ key: "location", value: "wien" });
+  });
+
+  it("ATMO: discovery map takes precedence over the legacy regex", () => {
+    const detection = {
+      discovery: {
+        atmo: disc([
+          ["lyon", { entities: new Map([["birch", "sensor.atmo_lyon_birch"]]) }],
+        ]),
+      },
+    };
+    expect(
+      deriveLocationForEntity("atmo", "sensor.atmo_lyon_birch", {}, detection),
+    ).toEqual({ key: "location", value: "lyon" });
+  });
+
+  it("ATMO: legacy niveau_ regex when discovery is empty", () => {
+    const detection = { discovery: { atmo: disc([]) } };
+    expect(
+      deriveLocationForEntity(
+        "atmo",
+        "sensor.niveau_bouleau_paris",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "paris" });
+  });
+
+  it("SILAM: weatherEntity match in discovery", () => {
+    const detection = {
+      discovery: {
+        silam: disc([
+          [
+            "entry_s",
+            { weatherEntity: "weather.silam_pollen_oslo", sensors: new Map() },
+          ],
+        ]),
+      },
+    };
+    expect(
+      deriveLocationForEntity(
+        "silam",
+        "weather.silam_pollen_oslo",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "entry_s" });
+  });
+
+  it("SILAM: regex fallback when discovery is empty", () => {
+    const detection = { discovery: { silam: disc([]) } };
+    expect(
+      deriveLocationForEntity(
+        "silam",
+        "sensor.silam_pollen_helsinki_birch",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "helsinki" });
+  });
+
+  it("Kleenex: longest matching location prefix wins", () => {
+    const detection = {
+      stateIds: [
+        "sensor.kleenex_pollen_radar_noord_date",
+        "sensor.kleenex_pollen_radar_noord_holland_date",
+      ],
+    };
+    expect(
+      deriveLocationForEntity(
+        "kleenex",
+        "sensor.kleenex_pollen_radar_noord_holland_trees",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "noord_holland" });
+  });
+
+  it("GP: location from the discovery entities map", () => {
+    const detection = {
+      discovery: {
+        gp: disc([
+          ["entry_gp", { entities: new Map([["grass", "sensor.gp_grass"]]) }],
+        ]),
+      },
+    };
+    expect(
+      deriveLocationForEntity("gp", "sensor.gp_grass", {}, detection),
+    ).toEqual({ key: "location", value: "entry_gp" });
+  });
+
+  it("GPL: location from the lazy discovery getter", () => {
+    const detection = {
+      getGplDiscovery: () =>
+        disc([
+          ["entry_gpl", { entities: new Map([["tree", "sensor.gpl_tree"]]) }],
+        ]),
+    };
+    expect(
+      deriveLocationForEntity("gpl", "sensor.gpl_tree", {}, detection),
+    ).toEqual({ key: "location", value: "entry_gpl" });
+  });
+
+  it("MSW: location from the lazy discovery getter", () => {
+    const detection = {
+      getMswDiscovery: () =>
+        disc([
+          [
+            "entry_msw",
+            {
+              entities: new Map([
+                ["birch", "sensor.bern_pollen_birch_level_at_3000"],
+              ]),
+            },
+          ],
+        ]),
+    };
+    expect(
+      deriveLocationForEntity(
+        "msw",
+        "sensor.bern_pollen_birch_level_at_3000",
+        {},
+        detection,
+      ),
+    ).toEqual({ key: "location", value: "entry_msw" });
+  });
+
+  it("returns null for an unknown integration", () => {
+    expect(deriveLocationForEntity("nope", "sensor.x", {}, {})).toBeNull();
   });
 });


### PR DESCRIPTION
Implements HA 2026.6 [custom card suggestions](https://developers.home-assistant.io/blog/2026/05/27/custom-card-suggestions/) for the card picker.

When a user picks a pollen sensor in the dashboard's "add card" dialog, the picker now offers a ready-configured Pollenprognos Card under its Community section.

### How
- New `suggestEntityConfig(hass, entityId)` + `deriveLocationForEntity(...)` in `src/utils/autodetect.js`. The picked entity is reverse-mapped to its integration via the existing `detectIntegrationStates` layer, then its *specific* location is derived (per-entity sibling of `autoSelectLocation`):
  - id-pattern integrations (pp/dwd/peu/atmo/silam/kleenex) via their adapter regexes
  - discovery-based integrations (gp/gpl/msw, and silam/atmo discovery) via `findLocationKeyInDiscovery`
  - falls back to `autoSelectLocation` when per-entity derivation yields nothing
- Wired into the `window.customCards` registration in `src/index.js` as `getEntitySuggestion`.
- Returns `null` for non-sensor / unrecognised entities so the picker stays uncluttered. Card only; badge suggestions are not yet documented by HA.

Additive and opt-in by Home Assistant; no config keys changed.

### Tests
`test/utils/suggest.test.js` (9 cases): guards, PP city, DWD region_id (incl. device-prefixed), GPL discovery location, autoSelectLocation fallback, and the no-location branch. Full suite green (1167).

Refs #255