### PR TITLE
Honour HA profile decimal separator in editor number fields (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Editor number fields follow the Home Assistant profile, not the OS locale** (issue #263). The visual editor's numeric inputs (icon scale, text size, badge scale, level circle sizes, gaps, threshold, etc.) used native `type="number"` fields, whose decimal separator was dictated by the browser/OS locale. On a device whose OS uses a comma, a point was rejected even when the Home Assistant profile asked for a point, and an invalid entry could reset the value to `0`. Inputs now format and parse via the profile's `number_format` (point vs comma), accept either separator, clamp to range, and revert to the previous value instead of zeroing on invalid input. The threshold and days-to-show readouts follow the profile separator too.
+
 ## [3.3.0] - 2026-06-06
 
 This is a visual release. pollenprognos grows a companion **badge** element you

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -40,6 +40,10 @@ import { t, detectLang, SUPPORTED_LOCALES } from "../i18n.js";
 import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
 import {
+  formatNumberForInput,
+  parseLocaleNumber,
+} from "../utils/number-format.js";
+import {
   LEVELS_DEFAULTS,
   convertStrokeWidthToGap,
   NORMAL_DEFAULT_THICKNESS,
@@ -420,6 +424,47 @@ export class PollenEditorBase extends LitElement {
           : c.integration === "plu"
             ? { min: 0, max: 3, step: 1 }
             : { min: 0, max: 6, step: 1 };
+  }
+
+  /**
+   * Render a locale-aware numeric textfield. Replaces native
+   * `<ha-textfield type="number">`, whose decimal separator follows the
+   * browser/OS locale; this honours the HA profile's number_format instead and
+   * accepts either separator on input. Commits on `change` (blur/enter) so a
+   * config-driven re-render doesn't reset the box mid-typing; the paired
+   * `<ha-slider>` keeps live preview while dragging.
+   */
+  _renderNumberField({
+    value,
+    min,
+    max,
+    step,
+    onValue,
+    width = "80px",
+    disabled = false,
+  }) {
+    const isInt = Number.isInteger(step ?? 1);
+    return html`
+      <ha-textfield
+        class="num-field"
+        inputmode=${isInt ? "numeric" : "decimal"}
+        .value=${formatNumberForInput(value, this._hass)}
+        .disabled=${disabled}
+        style="width: ${width};"
+        @change=${(e) => {
+          let n = parseLocaleNumber(e.target.value, this._hass);
+          if (n === null) {
+            // Invalid/empty input: revert display, don't write NaN/0.
+            this.requestUpdate();
+            return;
+          }
+          if (typeof min === "number") n = Math.max(min, n);
+          if (typeof max === "number") n = Math.min(max, n);
+          if (isInt) n = Math.round(n);
+          onValue(n);
+        }}
+      ></ha-textfield>
+    `;
   }
 
   // ------------------------------------------------------------------
@@ -1099,7 +1144,7 @@ export class PollenEditorBase extends LitElement {
         </div>
         <div class="slider-row">
           <div class="slider-text">${this._t("pollen_threshold")}</div>
-          <div class="slider-value">${c.pollen_threshold}</div>
+          <div class="slider-value">${formatNumberForInput(c.pollen_threshold, this._hass)}</div>
           <ha-slider
             min="${thresholdParams.min}"
             max="${thresholdParams.max}"
@@ -1379,16 +1424,13 @@ export class PollenEditorBase extends LitElement {
                       this._updateConfig("icon_size", Number(e.target.value))}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    .value=${c.icon_size ?? 48}
-                    type="number"
-                    min="16"
-                    max="128"
-                    step="1"
-                    @input=${(e) =>
-                      this._updateConfig("icon_size", Number(e.target.value))}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.icon_size ?? 48,
+                    min: 16,
+                    max: 128,
+                    step: 1,
+                    onValue: (n) => this._updateConfig("icon_size", n),
+                  })}
                 </ha-formfield>
                 <ha-formfield label="${this._t("text_size_ratio")}">
                   <ha-slider
@@ -1403,19 +1445,13 @@ export class PollenEditorBase extends LitElement {
                       )}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    type="number"
-                    .value=${c.text_size_ratio ?? 1}
-                    min="0.5"
-                    max="2"
-                    step="0.05"
-                    @input=${(e) =>
-                      this._updateConfig(
-                        "text_size_ratio",
-                        Number(e.target.value),
-                      )}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.text_size_ratio ?? 1,
+                    min: 0.5,
+                    max: 2,
+                    step: 0.05,
+                    onValue: (n) => this._updateConfig("text_size_ratio", n),
+                  })}
                 </ha-formfield>
               `
             : ""}
@@ -1712,23 +1748,20 @@ export class PollenEditorBase extends LitElement {
             }}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            min="0"
-            max="150"
-            step="5"
-            .value=${c.allergen_stroke_width ?? LEVELS_DEFAULTS.allergen_stroke_width}
-            @input=${(e) => {
-              const value = e.target.value === "" ? LEVELS_DEFAULTS.allergen_stroke_width : Number(e.target.value);
+          ${this._renderNumberField({
+            value: c.allergen_stroke_width ?? LEVELS_DEFAULTS.allergen_stroke_width,
+            min: 0,
+            max: 150,
+            step: 5,
+            onValue: (value) => {
               this._updateConfig("allergen_stroke_width", value);
               const { inheritMode, gapSynced } = this._inheritState();
               if (inheritMode === "inherit_allergen" && gapSynced) {
                 const levelGap = convertStrokeWidthToGap(value);
                 this._updateConfig("levels_gap", levelGap);
               }
-            }}
-            style="width: 80px;"
-          ></ha-textfield>
+            },
+          })}
           <ha-button
             outlined
             title="${this._t("allergen_stroke_width_reset") || "Reset"}"
@@ -1916,13 +1949,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_thickness", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_thickness}
-            @input=${(e) =>
-              this._updateConfig("levels_thickness", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_thickness,
+            min: 10,
+            max: 90,
+            step: 1,
+            onValue: (n) => this._updateConfig("levels_thickness", n),
+          })}
           <ha-button
             outlined
             title="${this._t("levels_reset")}"
@@ -1947,14 +1980,14 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_gap", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_gap}
-            .disabled=${gapDisabled}
-            @input=${(e) =>
-              this._updateConfig("levels_gap", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_gap,
+            min: 0,
+            max: 20,
+            step: 1,
+            disabled: gapDisabled,
+            onValue: (n) => this._updateConfig("levels_gap", n),
+          })}
           <ha-button
             outlined
             title="${this._t("levels_reset")}"
@@ -2090,13 +2123,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_text_size", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_text_size || 0.3}
-            @input=${(e) =>
-              this._updateConfig("levels_text_size", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_text_size || 0.3,
+            min: 0.1,
+            max: 0.5,
+            step: 0.05,
+            onValue: (n) => this._updateConfig("levels_text_size", n),
+          })}
         </ha-formfield>
 
         <ha-formfield label="${this._t("levels_icon_ratio")}">
@@ -2109,13 +2142,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_icon_ratio", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_icon_ratio || 1}
-            @input=${(e) =>
-              this._updateConfig("levels_icon_ratio", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_icon_ratio || 1,
+            min: 0.1,
+            max: 2,
+            step: 0.05,
+            onValue: (n) => this._updateConfig("levels_icon_ratio", n),
+          })}
         </ha-formfield>
 
         <ha-formfield label="${this._t("levels_text_color")}">
@@ -2194,20 +2227,16 @@ export class PollenEditorBase extends LitElement {
                   Number(e.target.value),
                 )}
             ></ha-slider>
-            <ha-textfield
-              type="number"
-              min="0.2"
-              max="0.9"
-              step="0.05"
-              .value=${c.icon_in_ring_size_ratio ??
-              LEVELS_DEFAULTS.icon_in_ring_size_ratio}
-              @change=${(e) =>
-                this._updateConfig(
-                  "icon_in_ring_size_ratio",
-                  Number(e.target.value),
-                )}
-              style="width: 80px;"
-            ></ha-textfield>
+            ${this._renderNumberField({
+              value:
+                c.icon_in_ring_size_ratio ??
+                LEVELS_DEFAULTS.icon_in_ring_size_ratio,
+              min: 0.2,
+              max: 0.9,
+              step: 0.05,
+              onValue: (n) =>
+                this._updateConfig("icon_in_ring_size_ratio", n),
+            })}
           </div>
         </ha-formfield>
         <ha-formfield

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -454,13 +454,21 @@ export class PollenEditorBase extends LitElement {
         @change=${(e) => {
           let n = parseLocaleNumber(e.target.value, this._hass);
           if (n === null) {
-            // Invalid/empty input: revert display, don't write NaN/0.
-            this.requestUpdate();
+            // Invalid/empty input: restore the displayed value from config.
+            // Assigning .value directly is required because Lit dirty-checks the
+            // bound .value expression: when the config is unchanged a re-render
+            // won't write back, so the invalid text would otherwise persist.
+            e.target.value = formatNumberForInput(value, this._hass);
             return;
           }
           if (typeof min === "number") n = Math.max(min, n);
           if (typeof max === "number") n = Math.min(max, n);
           if (isInt) n = Math.round(n);
+          // Normalise the displayed text to the canonical formatted value so
+          // clamped/reformatted input (e.g. "999" -> "3", a different
+          // separator, trailing zeros) is reflected even when the resulting
+          // config value is unchanged (same Lit dirty-check caveat).
+          e.target.value = formatNumberForInput(n, this._hass);
           onValue(n);
         }}
       ></ha-textfield>

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -623,16 +623,13 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             this._updateConfig("badge_scale", Number(e.target.value))}
           style="width: 120px;"
         ></ha-slider>
-        <ha-textfield
-          type="number"
-          min="0.5"
-          max="3"
-          step="0.1"
-          .value=${typeof c.badge_scale === "number" ? c.badge_scale : 1}
-          @input=${(e) =>
-            this._updateConfig("badge_scale", Number(e.target.value))}
-          style="width: 80px;"
-        ></ha-textfield>
+        ${this._renderNumberField({
+          value: typeof c.badge_scale === "number" ? c.badge_scale : 1,
+          min: 0.5,
+          max: 3,
+          step: 0.1,
+          onValue: (n) => this._updateConfig("badge_scale", n),
+        })}
       </ha-formfield>
 
       <!-- badge_icon_scale: scale the allergen visual as a whole — the ring
@@ -651,18 +648,13 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             this._updateConfig("badge_icon_scale", Number(e.target.value))}
           style="width: 120px;"
         ></ha-slider>
-        <ha-textfield
-          type="number"
-          min="0.3"
-          max="3"
-          step="0.05"
-          .value=${typeof c.badge_icon_scale === "number"
-            ? c.badge_icon_scale
-            : 1}
-          @input=${(e) =>
-            this._updateConfig("badge_icon_scale", Number(e.target.value))}
-          style="width: 80px;"
-        ></ha-textfield>
+        ${this._renderNumberField({
+          value: typeof c.badge_icon_scale === "number" ? c.badge_icon_scale : 1,
+          min: 0.3,
+          max: 3,
+          step: 0.05,
+          onValue: (n) => this._updateConfig("badge_icon_scale", n),
+        })}
       </ha-formfield>
 
       <!-- badge_show_label / badge_label_position -->
@@ -906,7 +898,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-right: 24px;
       }
 
-      ha-textfield[type="number"] {
+      ha-textfield.num-field {
         width: 80px;
         min-width: 80px;
         max-width: 100px;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -25,6 +25,7 @@ import {
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
 import { findLocationBySlug } from "./utils/adapter-helpers.js";
+import { formatNumberForInput } from "./utils/number-format.js";
 import {
   detectIntegrationStates,
   pickIntegration,
@@ -1422,16 +1423,13 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                       this._updateConfig("minimal_gap", Number(e.target.value))}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    type="number"
-                    .value=${c.minimal_gap ?? 35}
-                    min="0"
-                    max="100"
-                    step="1"
-                    @input=${(e) =>
-                      this._updateConfig("minimal_gap", Number(e.target.value))}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.minimal_gap ?? 35,
+                    min: 0,
+                    max: 100,
+                    step: 1,
+                    onValue: (n) => this._updateConfig("minimal_gap", n),
+                  })}
                 </ha-formfield>
                 <div class="field-helper">${this._t("helper_minimal_gap")}</div>
               `
@@ -1556,7 +1554,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                   ? this._t("to_show_hours")
                   : this._t("to_show_days")}
             </div>
-            <div class="slider-value">${c.days_to_show}</div>
+            <div class="slider-value">${formatNumberForInput(c.days_to_show, this._hass)}</div>
             <ha-slider
               min="0"
               max="${(c.integration === "silam" || c.integration === "peu") &&
@@ -1844,9 +1842,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         (such as minimal_gap, icon size, text size, etc) display at least
         three digits clearly, without white space truncating the value.
         This patch sets width and internal padding. Applies to all number-type
-        ha-textfield elements in the editor.
+        ha-textfield elements in the editor (rendered via _renderNumberField,
+        which tags them with the .num-field class).
 */
-      ha-textfield[type="number"] {
+      ha-textfield.num-field {
         /* Set a specific width to fit at least three digits and controls */
         width: 80px;
         min-width: 80px;
@@ -1860,7 +1859,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       /* Ensure the input itself inherits width and font size */
-      ha-textfield[type="number"] input[type="number"] {
+      ha-textfield.num-field input {
         width: 100%;
         min-width: 0;
         max-width: 100%;
@@ -1876,7 +1875,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
   Slider row input: force numeric box to be visible and aligned
   (applies to all numeric ha-textfield within .slider-row)
 */
-      .slider-row ha-textfield[type="number"] {
+      .slider-row ha-textfield.num-field {
         width: 80px;
         min-width: 80px;
         max-width: 100px;

--- a/src/utils/number-format.js
+++ b/src/utils/number-format.js
@@ -32,6 +32,7 @@ export function getDecimalSeparator(hass) {
   const fmt = hass?.locale?.number_format;
   switch (fmt) {
     case "comma_decimal": // 1,234.56
+    case "quote_decimal": // 1'234.56
     case "none": // 1234.56
       return ".";
     case "decimal_comma": // 1.234,56

--- a/src/utils/number-format.js
+++ b/src/utils/number-format.js
@@ -1,0 +1,81 @@
+// Locale-aware number formatting/parsing for editor input fields.
+//
+// Native `<input type="number">` (and `ha-textfield type="number">`) derive their
+// decimal separator from the browser/OS locale, ignoring the Home Assistant
+// profile's number-format setting. These helpers drive the formatting/parsing in
+// JS instead, so editor number fields honour `hass.locale.number_format`
+// (point vs comma) and accept either separator on input.
+
+/**
+ * Derive a decimal separator ("." or ",") from an Intl locale.
+ * @param {string} [locale] - BCP-47 tag, or undefined for the runtime default.
+ * @returns {string}
+ */
+function intlDecimalSeparator(locale) {
+  try {
+    const parts = new Intl.NumberFormat(locale || undefined).formatToParts(1.1);
+    const dec = parts.find((p) => p.type === "decimal");
+    return dec ? dec.value : ".";
+  } catch {
+    return ".";
+  }
+}
+
+/**
+ * Resolve the decimal separator the user expects, based on the HA profile's
+ * `number_format` setting (falling back to their language, then the OS, then ".").
+ * Mirrors Home Assistant's NumberFormat enum.
+ * @param {object} [hass]
+ * @returns {string} "." or ","
+ */
+export function getDecimalSeparator(hass) {
+  const fmt = hass?.locale?.number_format;
+  switch (fmt) {
+    case "comma_decimal": // 1,234.56
+    case "none": // 1234.56
+      return ".";
+    case "decimal_comma": // 1.234,56
+    case "space_comma": // 1 234,56
+      return ",";
+    case "system":
+      return intlDecimalSeparator(undefined);
+    case "language":
+    default: {
+      const lang = hass?.locale?.language;
+      return lang ? intlDecimalSeparator(lang) : ".";
+    }
+  }
+}
+
+/**
+ * Format a numeric value for display in an editable input: no grouping, decimal
+ * separator per the HA profile. Empty/non-finite values render as "".
+ * @param {number|string|null|undefined} value
+ * @param {object} [hass]
+ * @returns {string}
+ */
+export function formatNumberForInput(value, hass) {
+  if (value === null || value === undefined || value === "") return "";
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return "";
+  const sep = getDecimalSeparator(hass);
+  return sep === "," ? String(num).replace(".", ",") : String(num);
+}
+
+/**
+ * Parse user input from a number field, accepting either decimal separator and
+ * tolerating grouping whitespace. Returns a finite number, or null when the
+ * input is empty/invalid (so callers can revert instead of writing NaN/0).
+ * @param {string} str
+ * @param {object} [hass] - reserved for future locale-specific parsing
+ * @returns {number|null}
+ */
+export function parseLocaleNumber(str, hass) {
+  if (typeof str !== "string") str = String(str ?? "");
+  const trimmed = str.trim();
+  if (trimmed === "") return null;
+  // Strip grouping whitespace, unify comma -> dot for a single decimal value.
+  const normalized = trimmed.replace(/\s/g, "").replace(",", ".");
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+}

--- a/test/utils/number-format.test.js
+++ b/test/utils/number-format.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDecimalSeparator,
+  formatNumberForInput,
+  parseLocaleNumber,
+} from "../../src/utils/number-format.js";
+
+const hassWith = (locale) => ({ locale });
+
+describe("number-format", () => {
+  describe("getDecimalSeparator", () => {
+    it("maps point-decimal number_format enums to '.'", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "comma_decimal" }))).toBe(".");
+      expect(getDecimalSeparator(hassWith({ number_format: "none" }))).toBe(".");
+    });
+
+    it("maps comma-decimal number_format enums to ','", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "decimal_comma" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ number_format: "space_comma" }))).toBe(",");
+    });
+
+    it("derives from language when number_format is 'language' or unset", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "language", language: "de" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ number_format: "language", language: "en" }))).toBe(".");
+      // unset number_format falls through to language derivation
+      expect(getDecimalSeparator(hassWith({ language: "fr" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ language: "en-US" }))).toBe(".");
+    });
+
+    it("falls back to '.' for missing hass/locale", () => {
+      expect(getDecimalSeparator(undefined)).toBe(".");
+      expect(getDecimalSeparator({})).toBe(".");
+      expect(getDecimalSeparator(hassWith({}))).toBe(".");
+    });
+  });
+
+  describe("formatNumberForInput", () => {
+    it("renders with a point under a point profile", () => {
+      const hass = hassWith({ number_format: "comma_decimal" });
+      expect(formatNumberForInput(0.05, hass)).toBe("0.05");
+      expect(formatNumberForInput(1, hass)).toBe("1");
+      expect(formatNumberForInput(48, hass)).toBe("48");
+    });
+
+    it("renders with a comma under a comma profile", () => {
+      const hass = hassWith({ number_format: "decimal_comma" });
+      expect(formatNumberForInput(0.05, hass)).toBe("0,05");
+      expect(formatNumberForInput(1, hass)).toBe("1");
+      expect(formatNumberForInput(1.5, hass)).toBe("1,5");
+    });
+
+    it("accepts numeric strings", () => {
+      expect(formatNumberForInput("0.8", hassWith({ language: "de" }))).toBe("0,8");
+    });
+
+    it("returns empty string for empty/non-finite values", () => {
+      const hass = hassWith({ number_format: "comma_decimal" });
+      expect(formatNumberForInput(null, hass)).toBe("");
+      expect(formatNumberForInput(undefined, hass)).toBe("");
+      expect(formatNumberForInput("", hass)).toBe("");
+      expect(formatNumberForInput(NaN, hass)).toBe("");
+      expect(formatNumberForInput("abc", hass)).toBe("");
+    });
+  });
+
+  describe("parseLocaleNumber", () => {
+    it("accepts both point and comma separators", () => {
+      expect(parseLocaleNumber("0.8")).toBe(0.8);
+      expect(parseLocaleNumber("0,8")).toBe(0.8);
+    });
+
+    it("tolerates grouping whitespace", () => {
+      expect(parseLocaleNumber(" 1 234,5 ")).toBe(1234.5);
+    });
+
+    it("returns null for empty/invalid input", () => {
+      expect(parseLocaleNumber("")).toBeNull();
+      expect(parseLocaleNumber("   ")).toBeNull();
+      expect(parseLocaleNumber("abc")).toBeNull();
+      expect(parseLocaleNumber(null)).toBeNull();
+      expect(parseLocaleNumber(undefined)).toBeNull();
+    });
+
+    it("parses integers", () => {
+      expect(parseLocaleNumber("48")).toBe(48);
+    });
+  });
+});

--- a/test/utils/number-format.test.js
+++ b/test/utils/number-format.test.js
@@ -11,6 +11,7 @@ describe("number-format", () => {
   describe("getDecimalSeparator", () => {
     it("maps point-decimal number_format enums to '.'", () => {
       expect(getDecimalSeparator(hassWith({ number_format: "comma_decimal" }))).toBe(".");
+      expect(getDecimalSeparator(hassWith({ number_format: "quote_decimal" }))).toBe(".");
       expect(getDecimalSeparator(hassWith({ number_format: "none" }))).toBe(".");
     });
 


### PR DESCRIPTION
Fixes #263 (follow-up from #235, reported by @LinqLover).

## Problem
The visual editors numeric inputs were native `<ha-textfield type="number">`, whose decimal separator follows the **browser/OS locale**, not the Home Assistant profiles number-format setting. On a comma-locale device a point (`0.8`) was rejected even when the HA profile asked for a point, and a rejected/empty entry fell through `Number("")` → `0`, silently wedging the value. The threshold readout always rendered a point regardless of profile.

## Fix
- New pure util `src/utils/number-format.js`: `getDecimalSeparator`, `formatNumberForInput`, `parseLocaleNumber` — driven by `hass.locale.number_format` (mirrors HAs NumberFormat enum), with language/OS fallback.
- Shared `_renderNumberField()` helper in `src/editor/base.js` replaces every native number textfield (card + badge editors). It:
  - formats the displayed value with the profile separator,
  - accepts **both** `.` and `,` on input,
  - clamps to range and rounds integer fields,
  - reverts (instead of writing `0`/`NaN`) on invalid input,
  - commits on `change` so a config-driven re-render no longer resets the box mid-typing (paired sliders keep live preview).
- Threshold and days-to-show readouts now format via the profile separator. Threshold font left as-is (cosmetic, reporter didnt need it).
- CSS retargeted from `ha-textfield[type="number"]` to the new `.num-field` class.

## Tests
- `test/utils/number-format.test.js` covers the enum mapping, language fallback, formatting under point/comma profiles, and parsing of both separators / invalid input. Full suite green (1209 tests).

## Verification
Built and deployed to the hass-test environment. Manual check: set the user profile **Number format** to comma-decimal vs decimal-comma and confirm the editor fields show the matching separator, accept both `0.8` and `0,8`, clamp, and revert on garbage input.