### PR TITLE
Restore the visual editor on HA 2026.6 (own input/button components)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Fixed
+- **Visual editor restored on Home Assistant 2026.6** (issue #265). HA 2026.6 removed `ha-textfield` and migrated `ha-button`, which the editor relied on for every text/number input and reset/select-all control — so on 2026.6 the input boxes rendered empty and the reset buttons appeared as oversized circles, making the editor unusable (the card itself on dashboards was unaffected). The editor now uses its own inputs and buttons, styled with Home Assistant's theme tokens so they match the surrounding UI. No configuration changes.
 - **Editor number fields follow the Home Assistant profile, not the OS locale** (issue #263). The visual editor's numeric inputs (icon scale, text size, badge scale, level circle sizes, gaps, threshold, etc.) used native `type="number"` fields, whose decimal separator was dictated by the browser/OS locale. On a device whose OS uses a comma, a point was rejected even when the Home Assistant profile asked for a point, and an invalid entry could reset the value to `0`. Inputs now format and parse via the profile's `number_format` (point vs comma), accept either separator, clamp to range, and revert to the previous value instead of zeroing on invalid input. The threshold and days-to-show readouts follow the profile separator too.
 
 ## [3.3.0] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Editor number fields follow the Home Assistant profile, not the OS locale** (issue #263). The visual editor's numeric inputs (icon scale, text size, badge scale, level circle sizes, gaps, threshold, etc.) used native `type="number"` fields, whose decimal separator was dictated by the browser/OS locale. On a device whose OS uses a comma, a point was rejected even when the Home Assistant profile asked for a point, and an invalid entry could reset the value to `0`. Inputs now format and parse via the profile's `number_format` (point vs comma), accept either separator, clamp to range, and revert to the previous value instead of zeroing on invalid input. The threshold and days-to-show readouts follow the profile separator too.
+
 ## [3.3.0] - 2026-06-06
 
 This is a visual release. pollenprognos grows a companion **badge** element you

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -40,6 +40,10 @@ import { t, detectLang, SUPPORTED_LOCALES } from "../i18n.js";
 import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
 import {
+  formatNumberForInput,
+  parseLocaleNumber,
+} from "../utils/number-format.js";
+import {
   LEVELS_DEFAULTS,
   convertStrokeWidthToGap,
   NORMAL_DEFAULT_THICKNESS,
@@ -420,6 +424,47 @@ export class PollenEditorBase extends LitElement {
           : c.integration === "plu"
             ? { min: 0, max: 3, step: 1 }
             : { min: 0, max: 6, step: 1 };
+  }
+
+  /**
+   * Render a locale-aware numeric textfield. Replaces native
+   * `<ha-textfield type="number">`, whose decimal separator follows the
+   * browser/OS locale; this honours the HA profile's number_format instead and
+   * accepts either separator on input. Commits on `change` (blur/enter) so a
+   * config-driven re-render doesn't reset the box mid-typing; the paired
+   * `<ha-slider>` keeps live preview while dragging.
+   */
+  _renderNumberField({
+    value,
+    min,
+    max,
+    step,
+    onValue,
+    width = "80px",
+    disabled = false,
+  }) {
+    const isInt = Number.isInteger(step ?? 1);
+    return html`
+      <ha-textfield
+        class="num-field"
+        inputmode=${isInt ? "numeric" : "decimal"}
+        .value=${formatNumberForInput(value, this._hass)}
+        .disabled=${disabled}
+        style="width: ${width};"
+        @change=${(e) => {
+          let n = parseLocaleNumber(e.target.value, this._hass);
+          if (n === null) {
+            // Invalid/empty input: revert display, don't write NaN/0.
+            this.requestUpdate();
+            return;
+          }
+          if (typeof min === "number") n = Math.max(min, n);
+          if (typeof max === "number") n = Math.min(max, n);
+          if (isInt) n = Math.round(n);
+          onValue(n);
+        }}
+      ></ha-textfield>
+    `;
   }
 
   // ------------------------------------------------------------------
@@ -1099,7 +1144,7 @@ export class PollenEditorBase extends LitElement {
         </div>
         <div class="slider-row">
           <div class="slider-text">${this._t("pollen_threshold")}</div>
-          <div class="slider-value">${c.pollen_threshold}</div>
+          <div class="slider-value">${formatNumberForInput(c.pollen_threshold, this._hass)}</div>
           <ha-slider
             min="${thresholdParams.min}"
             max="${thresholdParams.max}"
@@ -1379,16 +1424,13 @@ export class PollenEditorBase extends LitElement {
                       this._updateConfig("icon_size", Number(e.target.value))}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    .value=${c.icon_size ?? 48}
-                    type="number"
-                    min="16"
-                    max="128"
-                    step="1"
-                    @input=${(e) =>
-                      this._updateConfig("icon_size", Number(e.target.value))}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.icon_size ?? 48,
+                    min: 16,
+                    max: 128,
+                    step: 1,
+                    onValue: (n) => this._updateConfig("icon_size", n),
+                  })}
                 </ha-formfield>
                 <ha-formfield label="${this._t("text_size_ratio")}">
                   <ha-slider
@@ -1403,19 +1445,13 @@ export class PollenEditorBase extends LitElement {
                       )}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    type="number"
-                    .value=${c.text_size_ratio ?? 1}
-                    min="0.5"
-                    max="2"
-                    step="0.05"
-                    @input=${(e) =>
-                      this._updateConfig(
-                        "text_size_ratio",
-                        Number(e.target.value),
-                      )}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.text_size_ratio ?? 1,
+                    min: 0.5,
+                    max: 2,
+                    step: 0.05,
+                    onValue: (n) => this._updateConfig("text_size_ratio", n),
+                  })}
                 </ha-formfield>
               `
             : ""}
@@ -1712,23 +1748,20 @@ export class PollenEditorBase extends LitElement {
             }}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            min="0"
-            max="150"
-            step="5"
-            .value=${c.allergen_stroke_width ?? LEVELS_DEFAULTS.allergen_stroke_width}
-            @input=${(e) => {
-              const value = e.target.value === "" ? LEVELS_DEFAULTS.allergen_stroke_width : Number(e.target.value);
+          ${this._renderNumberField({
+            value: c.allergen_stroke_width ?? LEVELS_DEFAULTS.allergen_stroke_width,
+            min: 0,
+            max: 150,
+            step: 5,
+            onValue: (value) => {
               this._updateConfig("allergen_stroke_width", value);
               const { inheritMode, gapSynced } = this._inheritState();
               if (inheritMode === "inherit_allergen" && gapSynced) {
                 const levelGap = convertStrokeWidthToGap(value);
                 this._updateConfig("levels_gap", levelGap);
               }
-            }}
-            style="width: 80px;"
-          ></ha-textfield>
+            },
+          })}
           <ha-button
             outlined
             title="${this._t("allergen_stroke_width_reset") || "Reset"}"
@@ -1916,13 +1949,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_thickness", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_thickness}
-            @input=${(e) =>
-              this._updateConfig("levels_thickness", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_thickness,
+            min: 10,
+            max: 90,
+            step: 1,
+            onValue: (n) => this._updateConfig("levels_thickness", n),
+          })}
           <ha-button
             outlined
             title="${this._t("levels_reset")}"
@@ -1947,14 +1980,14 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_gap", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_gap}
-            .disabled=${gapDisabled}
-            @input=${(e) =>
-              this._updateConfig("levels_gap", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_gap,
+            min: 0,
+            max: 20,
+            step: 1,
+            disabled: gapDisabled,
+            onValue: (n) => this._updateConfig("levels_gap", n),
+          })}
           <ha-button
             outlined
             title="${this._t("levels_reset")}"
@@ -2090,13 +2123,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_text_size", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_text_size || 0.3}
-            @input=${(e) =>
-              this._updateConfig("levels_text_size", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_text_size || 0.3,
+            min: 0.1,
+            max: 0.5,
+            step: 0.05,
+            onValue: (n) => this._updateConfig("levels_text_size", n),
+          })}
         </ha-formfield>
 
         <ha-formfield label="${this._t("levels_icon_ratio")}">
@@ -2109,13 +2142,13 @@ export class PollenEditorBase extends LitElement {
               this._updateConfig("levels_icon_ratio", Number(e.target.value))}
             style="width: 120px;"
           ></ha-slider>
-          <ha-textfield
-            type="number"
-            .value=${c.levels_icon_ratio || 1}
-            @input=${(e) =>
-              this._updateConfig("levels_icon_ratio", Number(e.target.value))}
-            style="width: 80px;"
-          ></ha-textfield>
+          ${this._renderNumberField({
+            value: c.levels_icon_ratio || 1,
+            min: 0.1,
+            max: 2,
+            step: 0.05,
+            onValue: (n) => this._updateConfig("levels_icon_ratio", n),
+          })}
         </ha-formfield>
 
         <ha-formfield label="${this._t("levels_text_color")}">
@@ -2194,20 +2227,16 @@ export class PollenEditorBase extends LitElement {
                   Number(e.target.value),
                 )}
             ></ha-slider>
-            <ha-textfield
-              type="number"
-              min="0.2"
-              max="0.9"
-              step="0.05"
-              .value=${c.icon_in_ring_size_ratio ??
-              LEVELS_DEFAULTS.icon_in_ring_size_ratio}
-              @change=${(e) =>
-                this._updateConfig(
-                  "icon_in_ring_size_ratio",
-                  Number(e.target.value),
-                )}
-              style="width: 80px;"
-            ></ha-textfield>
+            ${this._renderNumberField({
+              value:
+                c.icon_in_ring_size_ratio ??
+                LEVELS_DEFAULTS.icon_in_ring_size_ratio,
+              min: 0.2,
+              max: 0.9,
+              step: 0.05,
+              onValue: (n) =>
+                this._updateConfig("icon_in_ring_size_ratio", n),
+            })}
           </div>
         </ha-formfield>
         <ha-formfield

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -173,6 +173,109 @@ export const sectionResetStyles = css`
   }
 `;
 
+/**
+ * Styling for the editor's own form controls, replacing HA's removed/migrated
+ * built-in components (`ha-textfield`, `ha-button`) on HA 2026.6+. Built only
+ * from HA theme tokens so native `<input>`/`<button>` match the surrounding HA
+ * form fields and inherit the user's theme. Shared by both editors.
+ */
+export const editorControlStyles = css`
+  /* Text/number input — emulates HA's filled textfield look. */
+  .pp-input {
+    font-family: inherit;
+    font-size: 1em;
+    color: var(--primary-text-color);
+    background: var(
+      --mdc-text-field-fill-color,
+      var(--secondary-background-color, rgba(0, 0, 0, 0.05))
+    );
+    border: none;
+    border-bottom: 1px solid
+      var(--mdc-text-field-idle-line-color, var(--divider-color, #ccc));
+    border-radius: 4px 4px 0 0;
+    padding: 6px 8px;
+    box-sizing: border-box;
+    outline: none;
+    min-width: 0;
+  }
+  .pp-input:hover {
+    border-bottom-color: var(
+      --mdc-text-field-hover-line-color,
+      var(--primary-text-color, #212121)
+    );
+  }
+  .pp-input:focus {
+    border-bottom: 2px solid var(--primary-color);
+    padding-bottom: 5px;
+  }
+  .pp-input:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  /* Numeric variant keeps the compact width used next to the sliders. */
+  .pp-input.num-field {
+    width: 80px;
+    min-width: 80px;
+    max-width: 100px;
+    font-size: 1.1em;
+  }
+
+  /* Text button — outlined, like HA's buttons. */
+  .pp-button {
+    font-family: inherit;
+    font-size: 0.95em;
+    color: var(--primary-color);
+    background: transparent;
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    padding: 6px 16px;
+    cursor: pointer;
+    line-height: 1.2;
+  }
+  .pp-button:hover {
+    background: rgba(var(--rgb-primary-color, 33, 150, 243), 0.08);
+  }
+  .pp-button:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 1px;
+  }
+  .pp-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  /* Round reset (↺) button — same look as the per-section reset. */
+  .pp-icon-button {
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border-radius: 50%;
+    border: 1px solid var(--divider-color, #ccc);
+    background: transparent;
+    color: var(--secondary-text-color);
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+  }
+  .pp-icon-button:hover,
+  .pp-icon-button:focus-visible {
+    background: var(--secondary-background-color);
+    color: var(--primary-text-color);
+  }
+  .pp-icon-button:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 1px;
+  }
+  .pp-icon-button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+`;
+
 export class PollenEditorBase extends LitElement {
   // ------------------------------------------------------------------
   // Presentation hooks (overridable by subclasses)
@@ -427,12 +530,12 @@ export class PollenEditorBase extends LitElement {
   }
 
   /**
-   * Render a locale-aware numeric textfield. Replaces native
-   * `<ha-textfield type="number">`, whose decimal separator follows the
-   * browser/OS locale; this honours the HA profile's number_format instead and
-   * accepts either separator on input. Commits on `change` (blur/enter) so a
-   * config-driven re-render doesn't reset the box mid-typing; the paired
-   * `<ha-slider>` keeps live preview while dragging.
+   * Render a locale-aware numeric input. Uses our own native `<input>` (HA
+   * removed `ha-textfield` in 2026.6) styled via `.pp-input`. Honours the HA
+   * profile's number_format instead of the browser/OS locale and accepts either
+   * decimal separator. Commits on `change` (blur/enter) so a config-driven
+   * re-render doesn't reset the box mid-typing; the paired `<ha-slider>` keeps
+   * live preview while dragging.
    */
   _renderNumberField({
     value,
@@ -445,11 +548,12 @@ export class PollenEditorBase extends LitElement {
   }) {
     const isInt = Number.isInteger(step ?? 1);
     return html`
-      <ha-textfield
-        class="num-field"
+      <input
+        class="pp-input num-field"
+        type="text"
         inputmode=${isInt ? "numeric" : "decimal"}
         .value=${formatNumberForInput(value, this._hass)}
-        .disabled=${disabled}
+        ?disabled=${disabled}
         style="width: ${width};"
         @change=${(e) => {
           let n = parseLocaleNumber(e.target.value, this._hass);
@@ -471,7 +575,70 @@ export class PollenEditorBase extends LitElement {
           e.target.value = formatNumberForInput(n, this._hass);
           onValue(n);
         }}
-      ></ha-textfield>
+      />
+    `;
+  }
+
+  /**
+   * Render a text input using our own native `<input>` (`.pp-input`), replacing
+   * HA's removed `ha-textfield`. Commits live on `input`, mirroring the previous
+   * `ha-textfield @input` behaviour. `onInput` receives the raw string value.
+   */
+  _renderTextField({
+    value,
+    onInput,
+    placeholder = "",
+    width = "",
+    type = "text",
+    disabled = false,
+  }) {
+    return html`
+      <input
+        class="pp-input"
+        type=${type}
+        .value=${value ?? ""}
+        placeholder=${placeholder}
+        ?disabled=${disabled}
+        style=${width ? `width: ${width};` : ""}
+        @input=${(e) => onInput(e.target.value)}
+      />
+    `;
+  }
+
+  /**
+   * Render the round reset (↺) button using a native `<button>`
+   * (`.pp-icon-button`), replacing HA's migrated `ha-button`.
+   */
+  _renderResetButton({ title = "", onClick, style = "", disabled = false }) {
+    return html`
+      <button
+        class="pp-icon-button"
+        type="button"
+        title=${title}
+        style=${style}
+        ?disabled=${disabled}
+        @click=${onClick}
+      >
+        ↺
+      </button>
+    `;
+  }
+
+  /**
+   * Render a text button (select-all, apply, reset-all) using a native
+   * `<button>` (`.pp-button`), replacing HA's migrated `ha-button`.
+   */
+  _renderTextButton({ label, onClick, style = "", disabled = false }) {
+    return html`
+      <button
+        class="pp-button"
+        type="button"
+        style=${style}
+        ?disabled=${disabled}
+        @click=${onClick}
+      >
+        ${label}
+      </button>
     `;
   }
 
@@ -827,30 +994,28 @@ export class PollenEditorBase extends LitElement {
               <details>
                 <summary>${this._t("summary_entity_prefix_suffix")}</summary>
                 <ha-formfield label="${this._t("entity_prefix")}">
-                  <ha-textfield
-                    .value=${c.entity_prefix || ""}
-                    placeholder="${this._t("entity_prefix_placeholder")}"
-                    @input=${(e) =>
-                      this._updateConfig("entity_prefix", e.target.value)}
-                  ></ha-textfield>
+                  ${this._renderTextField({
+                    value: c.entity_prefix || "",
+                    placeholder: this._t("entity_prefix_placeholder"),
+                    onInput: (v) => this._updateConfig("entity_prefix", v),
+                  })}
                 </ha-formfield>
                 <ha-formfield label="${this._t("entity_suffix")}">
-                  <ha-textfield
-                    .value=${c.entity_suffix || ""}
-                    placeholder="${this._t("entity_suffix_placeholder")}"
-                    @input=${(e) =>
-                      this._updateConfig("entity_suffix", e.target.value)}
-                  ></ha-textfield>
+                  ${this._renderTextField({
+                    value: c.entity_suffix || "",
+                    placeholder: this._t("entity_suffix_placeholder"),
+                    onInput: (v) => this._updateConfig("entity_suffix", v),
+                  })}
                 </ha-formfield>
                 ${c.integration === "silam"
                   ? html`
                       <ha-formfield label="${this._t("entity_weather")}">
-                        <ha-textfield
-                          .value=${c.entity_weather || ""}
-                          placeholder="${this._t("entity_weather_placeholder")}"
-                          @input=${(e) =>
-                            this._updateConfig("entity_weather", e.target.value)}
-                        ></ha-textfield>
+                        ${this._renderTextField({
+                          value: c.entity_weather || "",
+                          placeholder: this._t("entity_weather_placeholder"),
+                          onInput: (v) =>
+                            this._updateConfig("entity_weather", v),
+                        })}
                       </ha-formfield>
                     `
                   : ""}
@@ -889,23 +1054,23 @@ export class PollenEditorBase extends LitElement {
                 </ha-formfield>
               </div>
               <ha-formfield label="${this._t("title")}">
-                <ha-textfield
-                  .value=${typeof c.title === "string"
-                    ? c.title
-                    : c.title === false
-                      ? "(false)"
-                      : ""}
-                  placeholder="${this._t("title_placeholder")}"
-                  .disabled=${c.title === false}
-                  @input=${(e) => {
-                    const val = e.target.value;
+                ${this._renderTextField({
+                  value:
+                    typeof c.title === "string"
+                      ? c.title
+                      : c.title === false
+                        ? "(false)"
+                        : "",
+                  placeholder: this._t("title_placeholder"),
+                  disabled: c.title === false,
+                  onInput: (val) => {
                     if (val.trim() === "") {
                       this._updateConfig("title", true);
                     } else {
                       this._updateConfig("title", val);
                     }
-                  }}
-                ></ha-textfield>
+                  },
+                })}
               </ha-formfield>
             `
           : ""}
@@ -1113,40 +1278,37 @@ export class PollenEditorBase extends LitElement {
                 </div>
               `}
         <div class="preset-buttons">
-          <ha-button
-            @click=${() => {
+          ${this._renderTextButton({
+            label: this._t("select_all_allergens"),
+            onClick: () => {
               const allAllergens =
                 c.integration === "kleenex"
                   ? [...allergens, "trees_cat", "grass_cat", "weeds_cat"]
                   : allergens;
               this._toggleSelectAllAllergens(allAllergens);
-            }}
-          >
-            ${this._t("select_all_allergens")}
-          </ha-button>
+            },
+          })}
           ${c.integration === "atmo"
             ? html`
-                <ha-button
-                  @click=${() => {
+                ${this._renderTextButton({
+                  label: this._t("select_all_pollen"),
+                  onClick: () => {
                     const pollenKeys = allergens.filter(
                       (k) =>
                         !["allergy_risk", "qualite_globale", "pm25", "pm10", "ozone", "no2", "so2"].includes(k),
                     );
                     this._toggleAllergenSubset(pollenKeys);
-                  }}
-                >
-                  ${this._t("select_all_pollen")}
-                </ha-button>
-                <ha-button
-                  @click=${() => {
+                  },
+                })}
+                ${this._renderTextButton({
+                  label: this._t("select_all_pollution"),
+                  onClick: () => {
                     const pollutionKeys = ["pm25", "pm10", "ozone", "no2", "so2"].filter(
                       (k) => allergens.includes(k),
                     );
                     this._toggleAllergenSubset(pollutionKeys);
-                  }}
-                >
-                  ${this._t("select_all_pollution")}
-                </ha-button>
+                  },
+                })}
               `
             : ""}
         </div>
@@ -1399,14 +1561,12 @@ export class PollenEditorBase extends LitElement {
         <div class="section-helper">${this._appearanceSectionHelper()}</div>
         <ha-formfield label="${this._t("background_color")}">
             <div style="display:flex; gap:8px; align-items:center;">
-              <ha-textfield
-                .value=${c.background_color || ""}
-                placeholder="${this._t("background_color_placeholder") ||
-                "#ffffff"}"
-                @input=${(e) =>
-                  this._updateConfig("background_color", e.target.value)}
-                style="width: 120px;"
-              ></ha-textfield>
+              ${this._renderTextField({
+                value: c.background_color || "",
+                placeholder: this._t("background_color_placeholder") || "#ffffff",
+                width: "120px",
+                onInput: (v) => this._updateConfig("background_color", v),
+              })}
               <input
                 type="color"
                 .value=${c.background_color &&
@@ -1583,28 +1743,29 @@ export class PollenEditorBase extends LitElement {
                                 }}
                                 style="width: 28px; height: 28px; border: none; background: none;"
                               />
-                              <ha-textfield
-                                .value=${col}
-                                placeholder="${i === 0
-                                  ? this._t("allergen_empty_placeholder") ||
-                                    "rgba(200,200,200,0.15)"
-                                  : this._t("allergen_colors_placeholder") ||
-                                    "#ffcc00"}"
-                                @input=${(e) => {
+                              ${this._renderTextField({
+                                value: col,
+                                placeholder:
+                                  i === 0
+                                    ? this._t("allergen_empty_placeholder") ||
+                                      "rgba(200,200,200,0.15)"
+                                    : this._t("allergen_colors_placeholder") ||
+                                      "#ffcc00",
+                                width: "120px",
+                                onInput: (v) => {
                                   const newColors = [...allergenColors];
-                                  newColors[i] = e.target.value;
+                                  newColors[i] = v;
                                   this._updateConfig(
                                     "allergen_colors",
                                     newColors,
                                   );
-                                }}
-                                style="width: 120px;"
-                              ></ha-textfield>
-                              <ha-button
-                                outlined
-                                title="${this._t("allergen_colors_reset") ||
-                                "Reset"}"
-                                @click=${() => {
+                                },
+                              })}
+                              ${this._renderResetButton({
+                                title:
+                                  this._t("allergen_colors_reset") || "Reset",
+                                style: "margin-left: 8px;",
+                                onClick: () => {
                                   const newColors = [...allergenColors];
                                   newColors[i] =
                                     LEVELS_DEFAULTS.allergen_colors[i];
@@ -1612,10 +1773,8 @@ export class PollenEditorBase extends LitElement {
                                     "allergen_colors",
                                     newColors,
                                   );
-                                }}
-                                style="margin-left: 8px;"
-                                >↺</ha-button
-                              >
+                                },
+                              })}
                             </div>
                           `,
                         );
@@ -1646,31 +1805,27 @@ export class PollenEditorBase extends LitElement {
                           )}
                         style="width: 28px; height: 28px; border: none; background: none;"
                       />
-                      <ha-textfield
-                        .value=${c.no_allergens_color ||
-                        LEVELS_DEFAULTS.no_allergens_color}
-                        placeholder="${this._t(
-                          "no_allergens_color_placeholder",
-                        ) || "#a9cfe0"}"
-                        @input=${(e) =>
-                          this._updateConfig(
-                            "no_allergens_color",
-                            e.target.value,
-                          )}
-                        style="width: 100px;"
-                      ></ha-textfield>
-                      <ha-button
-                        outlined
-                        title="${this._t("no_allergens_color_reset") ||
-                        "Reset"}"
-                        @click=${() =>
+                      ${this._renderTextField({
+                        value:
+                          c.no_allergens_color ||
+                          LEVELS_DEFAULTS.no_allergens_color,
+                        placeholder:
+                          this._t("no_allergens_color_placeholder") ||
+                          "#a9cfe0",
+                        width: "100px",
+                        onInput: (v) =>
+                          this._updateConfig("no_allergens_color", v),
+                      })}
+                      ${this._renderResetButton({
+                        title:
+                          this._t("no_allergens_color_reset") || "Reset",
+                        style: "margin-left: 8px;",
+                        onClick: () =>
                           this._updateConfig(
                             "no_allergens_color",
                             LEVELS_DEFAULTS.no_allergens_color,
-                          )}
-                        style="margin-left: 8px;"
-                        >↺</ha-button
-                      >
+                          ),
+                      })}
                     </div>
                   </ha-formfield>
                 `
@@ -1699,30 +1854,24 @@ export class PollenEditorBase extends LitElement {
                 )}
               style="width: 28px; height: 28px; border: none; background: none;"
             />
-            <ha-textfield
-              .value=${c.allergen_outline_color ||
-              LEVELS_DEFAULTS.levels_gap_color}
-              placeholder="${this._t(
-                "allergen_outline_placeholder",
-              ) || "rgba(200,200,200,1)"}"
-              @input=${(e) =>
-                this._updateConfig(
-                  "allergen_outline_color",
-                  e.target.value,
-                )}
-              style="width: 100px;"
-            ></ha-textfield>
-            <ha-button
-              outlined
-              title="${this._t("allergen_outline_reset") || "Reset"}"
-              @click=${() =>
+            ${this._renderTextField({
+              value:
+                c.allergen_outline_color || LEVELS_DEFAULTS.levels_gap_color,
+              placeholder:
+                this._t("allergen_outline_placeholder") || "rgba(200,200,200,1)",
+              width: "100px",
+              onInput: (v) =>
+                this._updateConfig("allergen_outline_color", v),
+            })}
+            ${this._renderResetButton({
+              title: this._t("allergen_outline_reset") || "Reset",
+              style: "margin-left: 8px;",
+              onClick: () =>
                 this._updateConfig(
                   "allergen_outline_color",
                   LEVELS_DEFAULTS.levels_gap_color,
-                )}
-              style="margin-left: 8px;"
-              >↺</ha-button
-            >
+                ),
+            })}
           </div>
         </ha-formfield>
         <ha-formfield
@@ -1770,17 +1919,15 @@ export class PollenEditorBase extends LitElement {
               }
             },
           })}
-          <ha-button
-            outlined
-            title="${this._t("allergen_stroke_width_reset") || "Reset"}"
-            @click=${() =>
+          ${this._renderResetButton({
+            title: this._t("allergen_stroke_width_reset") || "Reset",
+            style: "margin-left: 8px;",
+            onClick: () =>
               this._updateConfig(
                 "allergen_stroke_width",
                 LEVELS_DEFAULTS.allergen_stroke_width,
-              )}
-            style="margin-left: 8px;"
-            >↺</ha-button
-          >
+              ),
+          })}
         </ha-formfield>
         <div class="field-helper">${this._t("helper_allergen_stroke_width")}</div>
       </details>
@@ -1878,27 +2025,25 @@ export class PollenEditorBase extends LitElement {
                           }}
                           style="width: 28px; height: 28px; border: none; background: none;"
                         />
-                        <ha-textfield
-                          .value=${col}
-                          placeholder="${this._t("levels_colors_placeholder")}"
-                          @input=${(e) => {
+                        ${this._renderTextField({
+                          value: col,
+                          placeholder: this._t("levels_colors_placeholder"),
+                          width: "100px",
+                          onInput: (v) => {
                             const newColors = [...c.levels_colors];
-                            newColors[i] = e.target.value;
+                            newColors[i] = v;
                             this._updateConfig("levels_colors", newColors);
-                          }}
-                          style="width: 100px;"
-                        ></ha-textfield>
-                        <ha-button
-                          outlined
-                          title="${this._t("levels_reset")}"
-                          @click=${() => {
+                          },
+                        })}
+                        ${this._renderResetButton({
+                          title: this._t("levels_reset"),
+                          style: "margin-left: 8px;",
+                          onClick: () => {
                             const newColors = [...c.levels_colors];
                             newColors[i] = LEVELS_DEFAULTS.levels_colors[i];
                             this._updateConfig("levels_colors", newColors);
-                          }}
-                          style="margin-left: 8px;"
-                          >↺</ha-button
-                        >
+                          },
+                        })}
                       </div>
                     `,
                   )}
@@ -1924,24 +2069,22 @@ export class PollenEditorBase extends LitElement {
                       this._updateConfig("levels_empty_color", e.target.value)}
                     style="width: 28px; height: 28px; border: none; background: none;"
                   />
-                  <ha-textfield
-                    .value=${c.levels_empty_color}
-                    placeholder="${this._t("levels_colors_placeholder")}"
-                    @input=${(e) =>
-                      this._updateConfig("levels_empty_color", e.target.value)}
-                    style="width: 100px;"
-                  ></ha-textfield>
-                  <ha-button
-                    outlined
-                    title="${this._t("levels_reset")}"
-                    @click=${() =>
+                  ${this._renderTextField({
+                    value: c.levels_empty_color,
+                    placeholder: this._t("levels_colors_placeholder"),
+                    width: "100px",
+                    onInput: (v) =>
+                      this._updateConfig("levels_empty_color", v),
+                  })}
+                  ${this._renderResetButton({
+                    title: this._t("levels_reset"),
+                    style: "margin-left: 8px;",
+                    onClick: () =>
                       this._updateConfig(
                         "levels_empty_color",
                         LEVELS_DEFAULTS.levels_empty_color,
-                      )}
-                    style="margin-left: 8px;"
-                    >↺</ha-button
-                  >
+                      ),
+                  })}
                 </div>
               </ha-formfield>
             `
@@ -1964,14 +2107,12 @@ export class PollenEditorBase extends LitElement {
             step: 1,
             onValue: (n) => this._updateConfig("levels_thickness", n),
           })}
-          <ha-button
-            outlined
-            title="${this._t("levels_reset")}"
-            @click=${() =>
-              this._updateConfig("levels_thickness", LEVELS_DEFAULTS.levels_thickness)}
-            style="margin-left: 8px;"
-            >↺</ha-button
-          >
+          ${this._renderResetButton({
+            title: this._t("levels_reset"),
+            style: "margin-left: 8px;",
+            onClick: () =>
+              this._updateConfig("levels_thickness", LEVELS_DEFAULTS.levels_thickness),
+          })}
         </ha-formfield>
 
         <ha-formfield
@@ -1996,15 +2137,13 @@ export class PollenEditorBase extends LitElement {
             disabled: gapDisabled,
             onValue: (n) => this._updateConfig("levels_gap", n),
           })}
-          <ha-button
-            outlined
-            title="${this._t("levels_reset")}"
-            .disabled=${gapDisabled}
-            @click=${() =>
-              this._updateConfig("levels_gap", LEVELS_DEFAULTS.levels_gap)}
-            style="margin-left: 8px;"
-            >↺</ha-button
-          >
+          ${this._renderResetButton({
+            title: this._t("levels_reset"),
+            style: "margin-left: 8px;",
+            disabled: gapDisabled,
+            onClick: () =>
+              this._updateConfig("levels_gap", LEVELS_DEFAULTS.levels_gap),
+          })}
         </ha-formfield>
         <div class="field-helper">
           ${gapDisabled
@@ -2032,24 +2171,21 @@ export class PollenEditorBase extends LitElement {
                       this._updateConfig("levels_gap_color", e.target.value)}
                     style="width: 28px; height: 28px; border: none; background: none;"
                   />
-                  <ha-textfield
-                    .value=${c.levels_gap_color}
-                    placeholder="${this._t("levels_colors_placeholder")}"
-                    @input=${(e) =>
-                      this._updateConfig("levels_gap_color", e.target.value)}
-                    style="width: 100px;"
-                  ></ha-textfield>
-                  <ha-button
-                    outlined
-                    title="${this._t("levels_reset")}"
-                    @click=${() =>
+                  ${this._renderTextField({
+                    value: c.levels_gap_color,
+                    placeholder: this._t("levels_colors_placeholder"),
+                    width: "100px",
+                    onInput: (v) => this._updateConfig("levels_gap_color", v),
+                  })}
+                  ${this._renderResetButton({
+                    title: this._t("levels_reset"),
+                    style: "margin-left: 8px;",
+                    onClick: () =>
                       this._updateConfig(
                         "levels_gap_color",
                         LEVELS_DEFAULTS.levels_gap_color,
-                      )}
-                    style="margin-left: 8px;"
-                    >↺</ha-button
-                  >
+                      ),
+                  })}
                 </div>
               </ha-formfield>
             `
@@ -2172,13 +2308,12 @@ export class PollenEditorBase extends LitElement {
                 this._updateConfig("levels_text_color", e.target.value)}
               style="width: 28px; height: 28px; border: none; background: none;"
             />
-            <ha-textfield
-              .value=${c.levels_text_color || ""}
-              placeholder="var(--primary-text-color)"
-              @input=${(e) =>
-                this._updateConfig("levels_text_color", e.target.value)}
-              style="width: 100px;"
-            ></ha-textfield>
+            ${this._renderTextField({
+              value: c.levels_text_color || "",
+              placeholder: "var(--primary-text-color)",
+              width: "100px",
+              onInput: (v) => this._updateConfig("levels_text_color", v),
+            })}
           </div>
         </ha-formfield>
       </details>
@@ -2299,16 +2434,13 @@ export class PollenEditorBase extends LitElement {
                       )}
                     style="width: 28px; height: 28px; border: none; background: none;"
                   />
-                  <ha-textfield
-                    .value=${c.icon_in_ring_static_color || ""}
-                    placeholder="${LEVELS_DEFAULTS.icon_in_ring_static_color}"
-                    @input=${(e) =>
-                      this._updateConfig(
-                        "icon_in_ring_static_color",
-                        e.target.value,
-                      )}
-                    style="width: 100px;"
-                  ></ha-textfield>
+                  ${this._renderTextField({
+                    value: c.icon_in_ring_static_color || "",
+                    placeholder: LEVELS_DEFAULTS.icon_in_ring_static_color,
+                    width: "100px",
+                    onInput: (v) =>
+                      this._updateConfig("icon_in_ring_static_color", v),
+                  })}
                 </div>
               </ha-formfield>
             `
@@ -2420,10 +2552,10 @@ export class PollenEditorBase extends LitElement {
           ${this._t("helper_translation_and_strings")}
         </div>
         <ha-formfield label="${this._t("locale")}">
-          <ha-textfield
-            .value=${dateLocale || ""}
-            @input=${(e) => this._updateConfig("date_locale", e.target.value)}
-          ></ha-textfield>
+          ${this._renderTextField({
+            value: dateLocale || "",
+            onInput: (v) => this._updateConfig("date_locale", v),
+          })}
         </ha-formfield>
         <h3>${this._t("phrases")}</h3>
         <div class="preset-buttons">
@@ -2449,29 +2581,27 @@ export class PollenEditorBase extends LitElement {
               }}
             ></ha-selector>
           </ha-formfield>
-          <ha-button
-            outlined
-            @click=${() =>
-              this._resetPhrases(this._selectedPhraseLang || selectedLang)}
-          >
-            ${this._t("phrases_apply")}
-          </ha-button>
+          ${this._renderTextButton({
+            label: this._t("phrases_apply"),
+            onClick: () =>
+              this._resetPhrases(this._selectedPhraseLang || selectedLang),
+          })}
         </div>
         <details>
           <summary>${this._t("phrases_full")}</summary>
           ${allergens.map(
             (a) => html`
               <ha-formfield .label=${a}>
-                <ha-textfield
-                  .value=${full[a] || ""}
-                  @input=${(e) => {
+                ${this._renderTextField({
+                  value: full[a] || "",
+                  onInput: (v) => {
                     const p = {
                       ...phrases,
-                      full: { ...full, [a]: e.target.value },
+                      full: { ...full, [a]: v },
                     };
                     this._updateConfig("phrases", p);
-                  }}
-                ></ha-textfield>
+                  },
+                })}
               </ha-formfield>
             `,
           )}
@@ -2483,16 +2613,16 @@ export class PollenEditorBase extends LitElement {
                 ${allergens.map(
                   (a) => html`
                     <ha-formfield .label=${a}>
-                      <ha-textfield
-                        .value=${short[a] || ""}
-                        @input=${(e) => {
+                      ${this._renderTextField({
+                        value: short[a] || "",
+                        onInput: (v) => {
                           const p = {
                             ...phrases,
-                            short: { ...short, [a]: e.target.value },
+                            short: { ...short, [a]: v },
                           };
                           this._updateConfig("phrases", p);
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `,
                 )}
@@ -2506,17 +2636,17 @@ export class PollenEditorBase extends LitElement {
                 ${Array.from({ length: numLevels }, (_, i) => i).map(
                   (i) => html`
                     <ha-formfield .label=${i}>
-                      <ha-textfield
-                        .value=${levels[i] || ""}
-                        @input=${(e) => {
+                      ${this._renderTextField({
+                        value: levels[i] || "",
+                        onInput: (v) => {
                           const lv = [...levels];
-                          lv[i] = e.target.value;
+                          lv[i] = v;
                           this._updateConfig("phrases", {
                             ...phrases,
                             levels: lv,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `,
                 )}
@@ -2530,16 +2660,16 @@ export class PollenEditorBase extends LitElement {
                 ${[0, 1, 2].map(
                   (i) => html`
                     <ha-formfield .label=${i}>
-                      <ha-textfield
-                        .value=${days[i] || ""}
-                        @input=${(e) => {
-                          const dd = { ...days, [i]: e.target.value };
+                      ${this._renderTextField({
+                        value: days[i] || "",
+                        onInput: (v) => {
+                          const dd = { ...days, [i]: v };
                           this._updateConfig("phrases", {
                             ...phrases,
                             days: dd,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `,
                 )}
@@ -2547,14 +2677,14 @@ export class PollenEditorBase extends LitElement {
             `
           : ""}
         <ha-formfield label="${this._t("no_information")}">
-          <ha-textfield
-            .value=${phrases.no_information || ""}
-            @input=${(e) =>
+          ${this._renderTextField({
+            value: phrases.no_information || "",
+            onInput: (v) =>
               this._updateConfig("phrases", {
                 ...phrases,
-                no_information: e.target.value,
-              })}
-          ></ha-textfield>
+                no_information: v,
+              }),
+          })}
         </ha-formfield>
       </details>
     `;
@@ -2759,42 +2889,42 @@ export class PollenEditorBase extends LitElement {
               ${this._tapType === "more-info"
                 ? html`
                     <ha-formfield label="${this._t("tap_action_entity")}">
-                      <ha-textfield
-                        .value=${this._tapEntity}
-                        @input=${(e) => {
-                          this._tapEntity = e.target.value;
+                      ${this._renderTextField({
+                        value: this._tapEntity,
+                        onInput: (v) => {
+                          this._tapEntity = v;
                           this._updateConfig("tap_action", {
                             type: "more-info",
                             entity: this._tapEntity,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `
                 : ""}
               ${this._tapType === "navigate"
                 ? html`
                     <ha-formfield label="${this._t("tap_action_navigation_path")}">
-                      <ha-textfield
-                        .value=${this._tapNavigation}
-                        @input=${(e) => {
-                          this._tapNavigation = e.target.value;
+                      ${this._renderTextField({
+                        value: this._tapNavigation,
+                        onInput: (v) => {
+                          this._tapNavigation = v;
                           this._updateConfig("tap_action", {
                             type: "navigate",
                             navigation_path: this._tapNavigation,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `
                 : ""}
               ${this._tapType === "call-service"
                 ? html`
                     <ha-formfield label="${this._t("tap_action_service")}">
-                      <ha-textfield
-                        .value=${this._tapService}
-                        @input=${(e) => {
-                          this._tapService = e.target.value;
+                      ${this._renderTextField({
+                        value: this._tapService,
+                        onInput: (v) => {
+                          this._tapService = v;
                           let data = {};
                           try {
                             data = JSON.parse(this._tapServiceData || "{}");
@@ -2804,14 +2934,14 @@ export class PollenEditorBase extends LitElement {
                             service: this._tapService,
                             service_data: data,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                     <ha-formfield label="${this._t("tap_action_service_data")}">
-                      <ha-textfield
-                        .value=${this._tapServiceData}
-                        @input=${(e) => {
-                          this._tapServiceData = e.target.value;
+                      ${this._renderTextField({
+                        value: this._tapServiceData,
+                        onInput: (v) => {
+                          this._tapServiceData = v;
                           let data = {};
                           try {
                             data = JSON.parse(this._tapServiceData || "{}");
@@ -2821,8 +2951,8 @@ export class PollenEditorBase extends LitElement {
                             service: this._tapService,
                             service_data: data,
                           });
-                        }}
-                      ></ha-textfield>
+                        },
+                      })}
                     </ha-formfield>
                   `
                 : ""}

--- a/src/editor/base.js
+++ b/src/editor/base.js
@@ -454,13 +454,21 @@ export class PollenEditorBase extends LitElement {
         @change=${(e) => {
           let n = parseLocaleNumber(e.target.value, this._hass);
           if (n === null) {
-            // Invalid/empty input: revert display, don't write NaN/0.
-            this.requestUpdate();
+            // Invalid/empty input: restore the displayed value from config.
+            // Assigning .value directly is required because Lit dirty-checks the
+            // bound .value expression: when the config is unchanged a re-render
+            // won't write back, so the invalid text would otherwise persist.
+            e.target.value = formatNumberForInput(value, this._hass);
             return;
           }
           if (typeof min === "number") n = Math.max(min, n);
           if (typeof max === "number") n = Math.min(max, n);
           if (isInt) n = Math.round(n);
+          // Normalise the displayed text to the canonical formatted value so
+          // clamped/reformatted input (e.g. "999" -> "3", a different
+          // separator, trailing zeros) is reflected even when the resulting
+          // config value is unchanged (same Lit dirty-check caveat).
+          e.target.value = formatNumberForInput(n, this._hass);
           onValue(n);
         }}
       ></ha-textfield>

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -623,16 +623,13 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             this._updateConfig("badge_scale", Number(e.target.value))}
           style="width: 120px;"
         ></ha-slider>
-        <ha-textfield
-          type="number"
-          min="0.5"
-          max="3"
-          step="0.1"
-          .value=${typeof c.badge_scale === "number" ? c.badge_scale : 1}
-          @input=${(e) =>
-            this._updateConfig("badge_scale", Number(e.target.value))}
-          style="width: 80px;"
-        ></ha-textfield>
+        ${this._renderNumberField({
+          value: typeof c.badge_scale === "number" ? c.badge_scale : 1,
+          min: 0.5,
+          max: 3,
+          step: 0.1,
+          onValue: (n) => this._updateConfig("badge_scale", n),
+        })}
       </ha-formfield>
 
       <!-- badge_icon_scale: scale the allergen visual as a whole — the ring
@@ -651,18 +648,13 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
             this._updateConfig("badge_icon_scale", Number(e.target.value))}
           style="width: 120px;"
         ></ha-slider>
-        <ha-textfield
-          type="number"
-          min="0.3"
-          max="3"
-          step="0.05"
-          .value=${typeof c.badge_icon_scale === "number"
-            ? c.badge_icon_scale
-            : 1}
-          @input=${(e) =>
-            this._updateConfig("badge_icon_scale", Number(e.target.value))}
-          style="width: 80px;"
-        ></ha-textfield>
+        ${this._renderNumberField({
+          value: typeof c.badge_icon_scale === "number" ? c.badge_icon_scale : 1,
+          min: 0.3,
+          max: 3,
+          step: 0.05,
+          onValue: (n) => this._updateConfig("badge_icon_scale", n),
+        })}
       </ha-formfield>
 
       <!-- badge_show_label / badge_label_position -->
@@ -906,7 +898,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-right: 24px;
       }
 
-      ha-textfield[type="number"] {
+      ha-textfield.num-field {
         width: 80px;
         min-width: 80px;
         max-width: 100px;

--- a/src/pollenprognos-badge-editor.js
+++ b/src/pollenprognos-badge-editor.js
@@ -5,7 +5,12 @@
 
 import { html, css } from "lit";
 import { getStubConfig } from "./adapter-registry.js";
-import { PollenEditorBase, deepMerge, sectionResetStyles } from "./editor/base.js";
+import {
+  PollenEditorBase,
+  deepMerge,
+  sectionResetStyles,
+  editorControlStyles,
+} from "./editor/base.js";
 import { LEVELS_DEFAULTS } from "./utils/levels-defaults.js";
 import { coerceBool } from "./utils/adapter-helpers.js";
 import { deepEqual } from "./utils/confcompare.js";
@@ -702,9 +707,10 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     return html`
       <div class="card-config">
         <!-- Reset button (inherited from PollenEditorBase) -->
-        <ha-button outlined @click=${() => this._resetAll()}>
-          ${this._t("preset_reset_all")}
-        </ha-button>
+        ${this._renderTextButton({
+          label: this._t("preset_reset_all"),
+          onClick: () => this._resetAll(),
+        })}
 
         ${this._renderIntegrationSection()}
         ${this._renderBadgeContentSection()}
@@ -826,6 +832,9 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       /* Per-section ↺ reset button styles (shared with the card editor). */
       ${sectionResetStyles}
 
+      /* Own form controls (input/button) replacing HA's removed components. */
+      ${editorControlStyles}
+
       details details {
         margin-left: 24px;
         margin-right: 24px;
@@ -898,15 +907,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
         margin-right: 24px;
       }
 
-      ha-textfield.num-field {
-        width: 80px;
-        min-width: 80px;
-        max-width: 100px;
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-        font-size: 1.1em;
-      }
+      /* Numeric input box sizing lives in editorControlStyles (.pp-input.num-field). */
     `;
   }
 }

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -25,6 +25,7 @@ import {
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
 import { findLocationBySlug } from "./utils/adapter-helpers.js";
+import { formatNumberForInput } from "./utils/number-format.js";
 import {
   detectIntegrationStates,
   pickIntegration,
@@ -1422,16 +1423,13 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                       this._updateConfig("minimal_gap", Number(e.target.value))}
                     style="width: 120px;"
                   ></ha-slider>
-                  <ha-textfield
-                    type="number"
-                    .value=${c.minimal_gap ?? 35}
-                    min="0"
-                    max="100"
-                    step="1"
-                    @input=${(e) =>
-                      this._updateConfig("minimal_gap", Number(e.target.value))}
-                    style="width: 80px;"
-                  ></ha-textfield>
+                  ${this._renderNumberField({
+                    value: c.minimal_gap ?? 35,
+                    min: 0,
+                    max: 100,
+                    step: 1,
+                    onValue: (n) => this._updateConfig("minimal_gap", n),
+                  })}
                 </ha-formfield>
                 <div class="field-helper">${this._t("helper_minimal_gap")}</div>
               `
@@ -1556,7 +1554,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                   ? this._t("to_show_hours")
                   : this._t("to_show_days")}
             </div>
-            <div class="slider-value">${c.days_to_show}</div>
+            <div class="slider-value">${formatNumberForInput(c.days_to_show, this._hass)}</div>
             <ha-slider
               min="0"
               max="${(c.integration === "silam" || c.integration === "peu") &&
@@ -1844,9 +1842,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         (such as minimal_gap, icon size, text size, etc) display at least
         three digits clearly, without white space truncating the value.
         This patch sets width and internal padding. Applies to all number-type
-        ha-textfield elements in the editor.
+        ha-textfield elements in the editor (rendered via _renderNumberField,
+        which tags them with the .num-field class).
 */
-      ha-textfield[type="number"] {
+      ha-textfield.num-field {
         /* Set a specific width to fit at least three digits and controls */
         width: 80px;
         min-width: 80px;
@@ -1860,7 +1859,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       /* Ensure the input itself inherits width and font size */
-      ha-textfield[type="number"] input[type="number"] {
+      ha-textfield.num-field input {
         width: 100%;
         min-width: 0;
         max-width: 100%;
@@ -1876,7 +1875,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
   Slider row input: force numeric box to be visible and aligned
   (applies to all numeric ha-textfield within .slider-row)
 */
-      .slider-row ha-textfield[type="number"] {
+      .slider-row ha-textfield.num-field {
         width: 80px;
         min-width: 80px;
         max-width: 100px;

--- a/src/pollenprognos-editor.js
+++ b/src/pollenprognos-editor.js
@@ -9,7 +9,12 @@ import {
 import { COSMETIC_FIELDS } from "./constants.js";
 
 // Shared editor base (deepMerge, section methods, helpers)
-import { PollenEditorBase, deepMerge, sectionResetStyles } from "./editor/base.js";
+import {
+  PollenEditorBase,
+  deepMerge,
+  sectionResetStyles,
+  editorControlStyles,
+} from "./editor/base.js";
 
 // Adapter registry (stub config lookup) + direct adapter imports for constants
 import { getStubConfig } from "./adapter-registry.js";
@@ -1380,9 +1385,10 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     return html`
       <div class="card-config">
         <!-- Reset button -->
-        <ha-button outlined @click=${() => this._resetAll()}>
-          ${this._t("preset_reset_all")}
-        </ha-button>
+        ${this._renderTextButton({
+          label: this._t("preset_reset_all"),
+          onClick: () => this._resetAll(),
+        })}
 
         <!-- §1 Integration & Location -->
         ${this._renderIntegrationSection()}
@@ -1708,6 +1714,9 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       /* Per-section ↺ reset button styles (shared with the badge editor). */
       ${sectionResetStyles}
 
+      /* Own form controls (input/button) replacing HA's removed components. */
+      ${editorControlStyles}
+
       /* Nested details styling */
       details details {
         margin-left: 24px; /* More indent */
@@ -1835,54 +1844,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       /* End of boolean control styles */
-      /* --- Numeric input box width and padding fix for ha-textfield --- */
-
-      /*
-        Ensures that all ha-textfield elements used for numeric input
-        (such as minimal_gap, icon size, text size, etc) display at least
-        three digits clearly, without white space truncating the value.
-        This patch sets width and internal padding. Applies to all number-type
-        ha-textfield elements in the editor (rendered via _renderNumberField,
-        which tags them with the .num-field class).
-*/
-      ha-textfield.num-field {
-        /* Set a specific width to fit at least three digits and controls */
-        width: 80px;
-        min-width: 80px;
-        max-width: 100px;
-        /* Remove extra margin and padding */
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-        /* Set font size for clarity */
-        font-size: 1.1em;
-      }
-
-      /* Ensure the input itself inherits width and font size */
-      ha-textfield.num-field input {
-        width: 100%;
-        min-width: 0;
-        max-width: 100%;
-        font-size: 1.1em;
-        box-sizing: border-box;
-        padding: 2px 8px;
-        /* Remove border/background if needed */
-        background: none;
-        border: none;
-      }
-
-      /*
-  Slider row input: force numeric box to be visible and aligned
-  (applies to all numeric ha-textfield within .slider-row)
-*/
-      .slider-row ha-textfield.num-field {
-        width: 80px;
-        min-width: 80px;
-        max-width: 100px;
-        font-size: 1.1em;
-        margin: 0;
-        padding: 0;
-      }
+      /* Numeric input box sizing lives in editorControlStyles (.pp-input.num-field). */
     `;
   }
 }

--- a/src/utils/number-format.js
+++ b/src/utils/number-format.js
@@ -32,6 +32,7 @@ export function getDecimalSeparator(hass) {
   const fmt = hass?.locale?.number_format;
   switch (fmt) {
     case "comma_decimal": // 1,234.56
+    case "quote_decimal": // 1'234.56
     case "none": // 1234.56
       return ".";
     case "decimal_comma": // 1.234,56

--- a/src/utils/number-format.js
+++ b/src/utils/number-format.js
@@ -1,0 +1,81 @@
+// Locale-aware number formatting/parsing for editor input fields.
+//
+// Native `<input type="number">` (and `ha-textfield type="number">`) derive their
+// decimal separator from the browser/OS locale, ignoring the Home Assistant
+// profile's number-format setting. These helpers drive the formatting/parsing in
+// JS instead, so editor number fields honour `hass.locale.number_format`
+// (point vs comma) and accept either separator on input.
+
+/**
+ * Derive a decimal separator ("." or ",") from an Intl locale.
+ * @param {string} [locale] - BCP-47 tag, or undefined for the runtime default.
+ * @returns {string}
+ */
+function intlDecimalSeparator(locale) {
+  try {
+    const parts = new Intl.NumberFormat(locale || undefined).formatToParts(1.1);
+    const dec = parts.find((p) => p.type === "decimal");
+    return dec ? dec.value : ".";
+  } catch {
+    return ".";
+  }
+}
+
+/**
+ * Resolve the decimal separator the user expects, based on the HA profile's
+ * `number_format` setting (falling back to their language, then the OS, then ".").
+ * Mirrors Home Assistant's NumberFormat enum.
+ * @param {object} [hass]
+ * @returns {string} "." or ","
+ */
+export function getDecimalSeparator(hass) {
+  const fmt = hass?.locale?.number_format;
+  switch (fmt) {
+    case "comma_decimal": // 1,234.56
+    case "none": // 1234.56
+      return ".";
+    case "decimal_comma": // 1.234,56
+    case "space_comma": // 1 234,56
+      return ",";
+    case "system":
+      return intlDecimalSeparator(undefined);
+    case "language":
+    default: {
+      const lang = hass?.locale?.language;
+      return lang ? intlDecimalSeparator(lang) : ".";
+    }
+  }
+}
+
+/**
+ * Format a numeric value for display in an editable input: no grouping, decimal
+ * separator per the HA profile. Empty/non-finite values render as "".
+ * @param {number|string|null|undefined} value
+ * @param {object} [hass]
+ * @returns {string}
+ */
+export function formatNumberForInput(value, hass) {
+  if (value === null || value === undefined || value === "") return "";
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return "";
+  const sep = getDecimalSeparator(hass);
+  return sep === "," ? String(num).replace(".", ",") : String(num);
+}
+
+/**
+ * Parse user input from a number field, accepting either decimal separator and
+ * tolerating grouping whitespace. Returns a finite number, or null when the
+ * input is empty/invalid (so callers can revert instead of writing NaN/0).
+ * @param {string} str
+ * @param {object} [hass] - reserved for future locale-specific parsing
+ * @returns {number|null}
+ */
+export function parseLocaleNumber(str, hass) {
+  if (typeof str !== "string") str = String(str ?? "");
+  const trimmed = str.trim();
+  if (trimmed === "") return null;
+  // Strip grouping whitespace, unify comma -> dot for a single decimal value.
+  const normalized = trimmed.replace(/\s/g, "").replace(",", ".");
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+}

--- a/src/utils/number-format.js
+++ b/src/utils/number-format.js
@@ -75,8 +75,11 @@ export function parseLocaleNumber(str, hass) {
   if (typeof str !== "string") str = String(str ?? "");
   const trimmed = str.trim();
   if (trimmed === "") return null;
-  // Strip grouping whitespace, unify comma -> dot for a single decimal value.
-  const normalized = trimmed.replace(/\s/g, "").replace(",", ".");
+  // Strip grouping whitespace, unify any comma -> dot. These fields hold a
+  // single small decimal value (no thousands grouping), so a bare comma->dot
+  // swap is sufficient; replace all commas (not just the first) so stray
+  // separators yield NaN -> null (revert) rather than a partial parse.
+  const normalized = trimmed.replace(/\s/g, "").replace(/,/g, ".");
   const num = Number(normalized);
   return Number.isFinite(num) ? num : null;
 }

--- a/test/utils/number-format.test.js
+++ b/test/utils/number-format.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDecimalSeparator,
+  formatNumberForInput,
+  parseLocaleNumber,
+} from "../../src/utils/number-format.js";
+
+const hassWith = (locale) => ({ locale });
+
+describe("number-format", () => {
+  describe("getDecimalSeparator", () => {
+    it("maps point-decimal number_format enums to '.'", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "comma_decimal" }))).toBe(".");
+      expect(getDecimalSeparator(hassWith({ number_format: "none" }))).toBe(".");
+    });
+
+    it("maps comma-decimal number_format enums to ','", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "decimal_comma" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ number_format: "space_comma" }))).toBe(",");
+    });
+
+    it("derives from language when number_format is 'language' or unset", () => {
+      expect(getDecimalSeparator(hassWith({ number_format: "language", language: "de" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ number_format: "language", language: "en" }))).toBe(".");
+      // unset number_format falls through to language derivation
+      expect(getDecimalSeparator(hassWith({ language: "fr" }))).toBe(",");
+      expect(getDecimalSeparator(hassWith({ language: "en-US" }))).toBe(".");
+    });
+
+    it("falls back to '.' for missing hass/locale", () => {
+      expect(getDecimalSeparator(undefined)).toBe(".");
+      expect(getDecimalSeparator({})).toBe(".");
+      expect(getDecimalSeparator(hassWith({}))).toBe(".");
+    });
+  });
+
+  describe("formatNumberForInput", () => {
+    it("renders with a point under a point profile", () => {
+      const hass = hassWith({ number_format: "comma_decimal" });
+      expect(formatNumberForInput(0.05, hass)).toBe("0.05");
+      expect(formatNumberForInput(1, hass)).toBe("1");
+      expect(formatNumberForInput(48, hass)).toBe("48");
+    });
+
+    it("renders with a comma under a comma profile", () => {
+      const hass = hassWith({ number_format: "decimal_comma" });
+      expect(formatNumberForInput(0.05, hass)).toBe("0,05");
+      expect(formatNumberForInput(1, hass)).toBe("1");
+      expect(formatNumberForInput(1.5, hass)).toBe("1,5");
+    });
+
+    it("accepts numeric strings", () => {
+      expect(formatNumberForInput("0.8", hassWith({ language: "de" }))).toBe("0,8");
+    });
+
+    it("returns empty string for empty/non-finite values", () => {
+      const hass = hassWith({ number_format: "comma_decimal" });
+      expect(formatNumberForInput(null, hass)).toBe("");
+      expect(formatNumberForInput(undefined, hass)).toBe("");
+      expect(formatNumberForInput("", hass)).toBe("");
+      expect(formatNumberForInput(NaN, hass)).toBe("");
+      expect(formatNumberForInput("abc", hass)).toBe("");
+    });
+  });
+
+  describe("parseLocaleNumber", () => {
+    it("accepts both point and comma separators", () => {
+      expect(parseLocaleNumber("0.8")).toBe(0.8);
+      expect(parseLocaleNumber("0,8")).toBe(0.8);
+    });
+
+    it("tolerates grouping whitespace", () => {
+      expect(parseLocaleNumber(" 1 234,5 ")).toBe(1234.5);
+    });
+
+    it("returns null for empty/invalid input", () => {
+      expect(parseLocaleNumber("")).toBeNull();
+      expect(parseLocaleNumber("   ")).toBeNull();
+      expect(parseLocaleNumber("abc")).toBeNull();
+      expect(parseLocaleNumber(null)).toBeNull();
+      expect(parseLocaleNumber(undefined)).toBeNull();
+    });
+
+    it("parses integers", () => {
+      expect(parseLocaleNumber("48")).toBe(48);
+    });
+  });
+});

--- a/test/utils/number-format.test.js
+++ b/test/utils/number-format.test.js
@@ -11,6 +11,7 @@ describe("number-format", () => {
   describe("getDecimalSeparator", () => {
     it("maps point-decimal number_format enums to '.'", () => {
       expect(getDecimalSeparator(hassWith({ number_format: "comma_decimal" }))).toBe(".");
+      expect(getDecimalSeparator(hassWith({ number_format: "quote_decimal" }))).toBe(".");
       expect(getDecimalSeparator(hassWith({ number_format: "none" }))).toBe(".");
     });
 


### PR DESCRIPTION
Fixes #265 and folds in #263 (supersedes #264).

## Problem
HA **2026.6 removed `ha-textfield`** (deprecated 2026.4, replacement `ha-input`) and migrated `ha-button`. The visual editor used these for every text/number input (40 sites) and every reset/select-all/apply control (15 sites), so on 2026.6 the input boxes rendered empty and the reset `↺` buttons rendered as oversized circles — the editor was unusable for **all users on HA 2026.6+** (released 3.3.0 too). The card itself on dashboards (Chart.js + SVG) was unaffected. HA advises custom cards not to depend on built-in components.

## Fix
- New shared `editorControlStyles` (in `src/editor/base.js`) defining `.pp-input`, `.pp-button`, `.pp-icon-button`, built **only from HA theme tokens** (`--mdc-text-field-*`, `--primary-text-color`, `--divider-color`, `--primary-color`, `--secondary-background-color`, …) so our own native `<input>`/`<button>` match the surrounding HA form fields. Spread into both editors styles.
- New render helpers in `base.js`: `_renderTextField`, `_renderResetButton`, `_renderTextButton`; `_renderNumberField` switched to a native `<input>` while keeping the locale-aware parse/format/clamp/revert.
- Converted all `ha-textfield` and `ha-button` call sites in the card and badge editors. Kept `ha-slider`, `ha-selector`, `ha-checkbox`, `ha-switch`, `ha-formfield` and native `<input type="color">` (unaffected on 2026.6).
- **#263 folded in:** the new number input keeps `getDecimalSeparator`/`formatNumberForInput`/`parseLocaleNumber` (incl. HAs `quote_decimal`), so editor numbers honour the profile decimal separator and accept either separator.

No config keys change (additive/none).

## Verification
Built and deployed to hass-test (**HA 2026.6.0**); verified by the maintainer: every text and number input renders and is usable, reset/select-all/reset-all buttons render normally, the controls visually match the surrounding HA UI, the #263 decimal-separator behaviour works, and checkboxes/switches/dropdowns/sliders still work. Full suite green (1209 tests).

## Reviewer note
Replacing HA-internal components with our own native elements is the durable direction here (HA explicitly discourages depending on its built-in components). Appearance is driven entirely by HA theme tokens to stay consistent with the user's theme.