### PR TITLE
Add Dependabot + Test & Build CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # Bundled npm deps. Runtime deps ship inside dist/, so these bumps change
+  # shipped code -- now verified by the Test & Build PR workflow.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "(deps)"
+    labels:
+      - "dependencies"
+    ignore:
+      # lit stays on 2.x until the 4.0.0 TS+Lit3 migration (#259).
+      - dependency-name: "lit"
+        update-types: ["version-update:semver-major"]
+    groups:
+      production:
+        dependency-type: "production"
+        patterns: ["*"]
+      dev:
+        dependency-type: "development"
+        patterns: ["*"]
+
+  # GitHub Actions -- keep checkout / upload-release-action current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test & Build
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # update-version.js (prebuild) reads git tags to stamp the version;
+          # a shallow checkout would break the build step.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
## Summary

Introduces automated dependency management and closes the CI verification gap.

- **`.github/dependabot.yml`** — monthly updates for two ecosystems:
  - **npm**: grouped into `production` / `dev`. `lit` major updates are ignored (stays on 2.x until the 4.0.0 TS+Lit3 migration, #259).
  - **github-actions**: single group, keeps `actions/checkout`, `svenstaro/upload-release-action` current.
  - Both use `(deps)` commit prefix, `dependencies` label, and target `dev`.
- **`.github/workflows/test.yml`** — new "Test & Build" workflow running `npm ci` → `npm run test` → `npm run build` on every PR and on pushes to `master`/`dev`. Previously PRs only ran HACS validation; dependency bumps would have landed unverified. `fetch-depth: 0` so the prebuild version-stamp step has git tags.

## Notes

- `hacs/action@main` is a branch ref, so Dependabot won't manage it (it updates tags/SHAs only). Can be pinned to a SHA later as an optional hardening step.
- The `dependencies` label is auto-created by Dependabot on first run.

## Verification

Locally: both YAML files parse, `npm run test` passes (1294 tests), `npm run build` succeeds. The new workflow runs the same commands here.