### PR TITLE
(types) Add core type layer and convert leaf utils to TypeScript

### DIFF
--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -1,0 +1,41 @@
+import type { HomeAssistant } from "./home-assistant.js";
+import type { PollenSensor } from "./sensor.js";
+import type { CardConfig } from "./config.js";
+
+/**
+ * A forecast event delivered via `hass.connection.subscribeMessage` (SILAM
+ * hourly/twice_daily). Its shape is integration-defined; the card forwards it
+ * opaquely to `fetchForecast`, so it stays permissive here.
+ */
+export type ForecastEvent = Record<string, unknown>;
+
+/**
+ * The common shape of an integration adapter module (the namespace object from
+ * `import * as X`). Every adapter exports `fetchForecast`, `resolveEntityIds`,
+ * and a `stubConfig*`. Discovery/classifier helpers are adapter-specific and
+ * optional here.
+ *
+ * Call-site notes:
+ * - `fetchForecast` takes an optional third `forecastEvent`; only SILAM reads
+ *   it, the others ignore the extra argument.
+ * - `resolveEntityIds` takes an optional fourth `precomputedDiscovery`; only
+ *   SILAM uses it. It returns a Map of allergen key -> entity id (both
+ *   auto-detect and manual mode); `findAvailableSensors` reads `.values()`.
+ */
+export interface AdapterModule {
+  fetchForecast(
+    hass: HomeAssistant,
+    config: CardConfig,
+    forecastEvent?: ForecastEvent | null,
+  ): Promise<PollenSensor[]>;
+
+  resolveEntityIds(
+    cfg: CardConfig,
+    hass: HomeAssistant,
+    debug?: boolean,
+    precomputedDiscovery?: unknown,
+  ): Map<string, string>;
+
+  /** Default configuration template consumed by the editor (`stubConfig*`). */
+  stubConfig?: CardConfig;
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,32 @@
+import type { LovelaceCardConfig } from "./home-assistant.js";
+
+/**
+ * User-facing card configuration.
+ *
+ * YAML is the reality here: a value declared as a boolean in the editor can
+ * arrive as the string "true"/"false" (or a number) from a hand-written YAML
+ * config, which is why the code coerces via `coerceBool` and friends. The value
+ * union reflects that. A full key inventory is deferred; the index signature
+ * keeps the type open until keys are enumerated in a later PR.
+ */
+export interface CardConfig extends LovelaceCardConfig {
+  /** Selected integration id (pp, dwd, silam, ...). */
+  integration?: string;
+  [key: string]: boolean | string | number | unknown;
+}
+
+/**
+ * Badge configuration. Shares the same YAML-value reality as {@link CardConfig};
+ * kept as a distinct alias so badge-specific keys can be enumerated separately
+ * later.
+ */
+export interface BadgeConfig extends LovelaceCardConfig {
+  integration?: string;
+  [key: string]: boolean | string | number | unknown;
+}
+
+/**
+ * Raw configuration as received before `setConfig` validation/coercion runs.
+ * Nothing about it is trustworthy yet, hence fully opaque values.
+ */
+export type RawCardConfig = Record<string, unknown>;

--- a/src/types/home-assistant.ts
+++ b/src/types/home-assistant.ts
@@ -1,0 +1,107 @@
+// Minimal hand-rolled Home Assistant typings.
+//
+// Following the Mushroom-cards approach, we vendor a small, purpose-built slice
+// of the HA frontend types instead of depending on `custom-card-helpers` (which
+// lags HA releases). Only the properties this codebase actually reads are typed;
+// grep the `hass.` / registry access sites before widening any of these.
+
+/**
+ * A single entity state from `hass.states`. The card only reads `state` and
+ * `attributes`; the timestamp fields are included for completeness since HA
+ * always provides them. `attributes` is genuinely dynamic per-integration data,
+ * so it stays an open record (matching HA's own `any`-typed attributes).
+ */
+export interface HassEntity {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, any>;
+  last_changed?: string;
+  last_updated?: string;
+}
+
+/**
+ * Reduced entity-registry entry as exposed on `hass.entities`. This is the
+ * frontend's display shape: it lacks `unique_id`/`config_entry_id` for most
+ * entities, though some integrations do surface `unique_id` (read by the GP
+ * adapter). Location discovery that needs config-subentry data must read the
+ * device (see {@link DeviceRegistryEntry.config_entries_subentries}), not this.
+ */
+export interface EntityRegistryDisplayEntry {
+  entity_id: string;
+  device_id?: string;
+  platform?: string;
+  translation_key?: string;
+  // HA reports "config" | "diagnostic" | null; discovery only checks falsiness.
+  entity_category?: string | null;
+  unique_id?: string;
+}
+
+/**
+ * Device-registry entry from `hass.devices` (the full registry, unlike the
+ * reduced `hass.entities`). `config_entries_subentries` maps each config-entry
+ * id to its subentry ids (or `[null]` for legacy top-level entries) and is the
+ * basis for subentry-aware location keying in `deviceLocationKey`.
+ */
+export interface DeviceRegistryEntry {
+  id: string;
+  identifiers: Array<[string, string]>;
+  name?: string | null;
+  name_by_user?: string | null;
+  config_entries?: string[];
+  config_entries_subentries?: Record<string, Array<string | null>>;
+  primary_config_entry?: string | null;
+}
+
+/** Unsubscribe callback returned by `connection.subscribeMessage`. */
+export type UnsubscribeFunc = () => void;
+
+/**
+ * The websocket connection off `hass.connection`. Only `subscribeMessage` is
+ * used (SILAM hourly/twice_daily forecast subscriptions).
+ */
+export interface HassConnection {
+  subscribeMessage<T = unknown>(
+    callback: (message: T) => void,
+    subscribeMessage: Record<string, unknown>,
+  ): Promise<UnsubscribeFunc>;
+}
+
+/** Locale settings from `hass.locale`. */
+export interface HassLocale {
+  language?: string;
+  // Mirrors HA's NumberFormat enum (e.g. "comma_decimal", "decimal_comma",
+  // "system", "language", "none", ...); read by number-format helpers.
+  number_format?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The `hass` object handed to the card/badge and passed through adapters.
+ * Typed to the surface this codebase touches; other members remain permissive
+ * via the index signature so future access sites do not require a widening.
+ */
+export interface HomeAssistant {
+  states: Record<string, HassEntity>;
+  entities: Record<string, EntityRegistryDisplayEntry>;
+  devices: Record<string, DeviceRegistryEntry>;
+  language: string;
+  locale: HassLocale;
+  connection: HassConnection;
+  callService?: (
+    domain: string,
+    service: string,
+    serviceData?: Record<string, unknown>,
+    target?: Record<string, unknown>,
+  ) => Promise<unknown>;
+  localize?: (key: string, ...args: unknown[]) => string;
+  callWS?: <T = unknown>(msg: Record<string, unknown>) => Promise<T>;
+  themes?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Base Lovelace card config: a `type` plus arbitrary integration keys. */
+export interface LovelaceCardConfig {
+  type: string;
+  [key: string]: unknown;
+}

--- a/src/types/sensor.ts
+++ b/src/types/sensor.ts
@@ -1,8 +1,8 @@
 // The normalized sensor contract every adapter's `fetchForecast` returns, and
 // which the card/badge render paths consume. Fields are documented per their
 // current, empirically-verified usage across all 11 adapters. This type mirrors
-// the NULÄGE (present state) of the contract; a later PR normalizes the day-key
-// / day0 divergence noted below. Do not change adapter behaviour to fit the type.
+// the present state of the contract; a later PR normalizes the day-key / day0
+// divergence noted below. Do not change adapter behaviour to fit the type.
 
 /**
  * One forecast day within a sensor's `days` array.

--- a/src/types/sensor.ts
+++ b/src/types/sensor.ts
@@ -1,0 +1,86 @@
+// The normalized sensor contract every adapter's `fetchForecast` returns, and
+// which the card/badge render paths consume. Fields are documented per their
+// current, empirically-verified usage across all 11 adapters. This type mirrors
+// the NULÄGE (present state) of the contract; a later PR normalizes the day-key
+// / day0 divergence noted below. Do not change adapter behaviour to fit the type.
+
+/**
+ * One forecast day within a sensor's `days` array.
+ *
+ * Universal fields (`name`, `day`, `state`, `state_text`) are emitted by every
+ * adapter. The rest are integration-specific and absent elsewhere.
+ */
+export interface ForecastDay {
+  /** Localized day label (e.g. weekday name or "Today"). */
+  name: string;
+  /** Day index/offset, or a date string, depending on adapter. */
+  day: string | number;
+  /**
+   * Normalized severity level. Scale varies by integration (0-6 for
+   * PP/SILAM/Atmo, 0-5 for GPL/GP, 0-4 for PEU/Kleenex/MSW/IRMKMI, 0-3 for PLU).
+   * `-1` is the sentinel "no data" state honoured by the render path.
+   */
+  state: number;
+  /** Localized level name for `state`. */
+  state_text: string;
+  /**
+   * Alternate display value distinct from the clamped `state`. Absent in
+   * pp + silam today; present where the adapter shows something other than the
+   * bare level.
+   */
+  display_state?: number | string;
+  /** Raw underlying measurement (concentration/index): peu, silam, plu. */
+  raw_value?: number | string | null;
+  /** Per-day icon key: peu, silam. */
+  icon?: string;
+  /** plu-specific: category thresholds carried through for display. */
+  thresholds?: unknown;
+  /** plu-specific: raw level string from the source. */
+  level_string?: string;
+  /** plu-specific: last-update timestamp. */
+  last_update?: string;
+  /** plu-specific: next scheduled poll timestamp. */
+  next_poll?: string;
+}
+
+/**
+ * A normalized pollen (or, for atmo, pollution) sensor.
+ *
+ * `day0`..`dayN` are dynamic per-day keys mirroring `days[i]`. NOTE: `day0` is
+ * currently set in two different ways across adapters and is sometimes
+ * `undefined`; this divergence is intentional-for-now and normalized in a later
+ * PR, so the type reflects the present reality (optional, possibly undefined)
+ * rather than an idealized contract. The template-literal index signature admits
+ * arbitrary `dayN` keys with the same optionality.
+ */
+export interface PollenSensor {
+  /** Adapter-normalized allergen slug (e.g. "birch", "graeser"). */
+  allergenReplaced: string;
+  /** Capitalized human label for the allergen. */
+  allergenCapitalized: string;
+  /** Short human label for the allergen. */
+  allergenShort: string;
+  /** Backing HA entity id. */
+  entity_id: string;
+  /** Ordered forecast days. */
+  days: ForecastDay[];
+
+  /** First forecast day; see the note above on its provisional shape. */
+  day0?: ForecastDay;
+  /** Dynamic per-day columns (day0, day1, ...); may be undefined per above. */
+  [day: `day${number}`]: ForecastDay | undefined;
+
+  /** Aggregate/overview row rather than a single allergen: atmo, silam, gpl. */
+  isSummary?: boolean;
+  /** Row grouping for mixed pollen/pollution sensors: atmo. */
+  group?: "pollen" | "pollution";
+  /** Data-freshness flags: peu. */
+  stale?: boolean;
+  staleSince?: string | null;
+  /** Dominant pollen summary: gpl. */
+  topPollen?: unknown;
+  /** In-season plant list: gpl. */
+  plantsInSeasonList?: unknown;
+  /** Raw entity attributes carried through: plu. */
+  attributes?: Record<string, any>;
+}

--- a/src/utils/allergen-label.ts
+++ b/src/utils/allergen-label.ts
@@ -1,4 +1,4 @@
-// src/utils/allergen-label.js
+// src/utils/allergen-label.ts
 import { t } from "../i18n.js";
 
 /**
@@ -22,7 +22,11 @@ import { t } from "../i18n.js";
  * @param {string} [opts.lang] - locale code; passed through to t().
  * @returns {string}
  */
-export function resolveAllergenPhrase(canonical, raw, { short = false, lang } = {}) {
+export function resolveAllergenPhrase(
+  canonical: string,
+  raw: string,
+  { short = false, lang }: { short?: boolean; lang?: string } = {},
+): string {
   const editorKey = `editor.phrases_${short ? "short" : "full"}.${canonical}`;
   const editorVal = t(editorKey, lang);
   if (editorVal && editorVal !== editorKey) return editorVal;

--- a/src/utils/confcompare.ts
+++ b/src/utils/confcompare.ts
@@ -2,19 +2,22 @@
  * Returns true if a and b are deeply equal.
  * Arrays are compared unordered (["a","b"] == ["b","a"]).
  */
-export function deepEqual(a, b) {
+export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (typeof a !== "object" || typeof b !== "object" || !a || !b) return false;
-  const aKeys = Object.keys(a),
-    bKeys = Object.keys(b);
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao),
+    bKeys = Object.keys(bo);
   if (aKeys.length !== bKeys.length) return false;
-  for (let k of aKeys) {
-    if (!(k in b)) return false;
-    if (Array.isArray(a[k]) && Array.isArray(b[k])) {
-      if (!arraysEqualUnordered(a[k], b[k])) return false;
-    } else if (typeof a[k] === "object" && typeof b[k] === "object") {
-      if (!deepEqual(a[k], b[k])) return false;
-    } else if (a[k] !== b[k]) {
+  for (const k of aKeys) {
+    if (!(k in bo)) return false;
+    if (Array.isArray(ao[k]) && Array.isArray(bo[k])) {
+      if (!arraysEqualUnordered(ao[k] as unknown[], bo[k] as unknown[]))
+        return false;
+    } else if (typeof ao[k] === "object" && typeof bo[k] === "object") {
+      if (!deepEqual(ao[k], bo[k])) return false;
+    } else if (ao[k] !== bo[k]) {
       return false;
     }
   }
@@ -25,11 +28,11 @@ export function deepEqual(a, b) {
  * Unordered array comparison that handles primitives and objects.
  * Uses deepEqual for object elements instead of toString().
  */
-function arraysEqualUnordered(a, b) {
+function arraysEqualUnordered(a: unknown[], b: unknown[]): boolean {
   if (a.length !== b.length) return false;
   // Fast path: all primitives
   if (a.every((v) => typeof v !== "object" || v === null)) {
-    const sorted = (arr) => [...arr].sort().join("\0");
+    const sorted = (arr: unknown[]) => [...arr].sort().join("\0");
     return sorted(a) === sorted(b);
   }
   // Slow path: match each element in a to one in b

--- a/src/utils/device-label.ts
+++ b/src/utils/device-label.ts
@@ -1,4 +1,4 @@
-// src/utils/device-label.js
+// src/utils/device-label.ts
 
 /**
  * Normalize an HA-derived device name for display as a location label.
@@ -29,7 +29,7 @@
  * inline cleanup logic in adapter discovery code keeps getting refactored
  * away. See issue #208 for the latest occurrence.
  */
-export function cleanDeviceLabel(raw) {
+export function cleanDeviceLabel(raw: string): string {
   if (typeof raw !== "string") return raw;
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
@@ -38,7 +38,8 @@ export function cleanDeviceLabel(raw) {
   // legitimate names like "Office (123)" or "Paris (2024)" aren't stripped.
   // Each value: optional sign, digits, optional decimal part. Whitespace
   // tolerated around values and the comma.
-  const COORD_PAREN = /\s*\(\s*[+\-]?\d+(?:\.\d+)?\s*,\s*[+\-]?\d+(?:\.\d+)?\s*\)\s*$/;
+  const COORD_PAREN =
+    /\s*\(\s*[+\-]?\d+(?:\.\d+)?\s*,\s*[+\-]?\d+(?:\.\d+)?\s*\)\s*$/;
   const stripped = trimmed.replace(COORD_PAREN, "").trim();
   if (stripped === trimmed) return trimmed;
 

--- a/src/utils/grid-options.ts
+++ b/src/utils/grid-options.ts
@@ -20,7 +20,12 @@
 // normal mode = a forecast table whose height varies (title on/off, icon_size,
 //   day-label header, one row per allergen, no-data / no-information states), so
 //   the height is likewise content-driven via rows:"auto".
-export function computeGridOptions(config = {}) {
+export function computeGridOptions(config: Record<string, unknown> = {}): {
+  rows: string;
+  columns: number;
+  min_rows: number;
+  min_columns: number;
+} {
   const configured = Array.isArray(config?.allergens)
     ? config.allergens.length
     : 0;

--- a/src/utils/level-counts.ts
+++ b/src/utils/level-counts.ts
@@ -17,7 +17,7 @@
  * @param {string} integration
  * @returns {number}
  */
-export function ringSegmentsForIntegration(integration) {
+export function ringSegmentsForIntegration(integration: string): number {
   switch (integration) {
     case "peu":
     case "kleenex":
@@ -46,7 +46,7 @@ export function ringSegmentsForIntegration(integration) {
  * @param {string} integration
  * @returns {number}
  */
-export function numLevelsForIntegration(integration) {
+export function numLevelsForIntegration(integration: string): number {
   if (integration === "dwd") return 4;
   return ringSegmentsForIntegration(integration) + 1;
 }

--- a/src/utils/level-names.ts
+++ b/src/utils/level-names.ts
@@ -1,4 +1,4 @@
-// src/utils/level-names.js
+// src/utils/level-names.ts
 // Helpers to merge user-provided level names with defaults.
 // Locales declare a default name per index for each scale we support:
 //   card.levels.0..6   - 7-level scale (PP / SILAM / Atmo, also the legacy
@@ -18,11 +18,14 @@ import { t } from "../i18n.js";
  * Atmo) and for adapters whose level-name lookup still spreads native to
  * 0-6 (DWD).
  *
- * @param {Array<string|null|undefined>|undefined} userLevels - per-index overrides
- * @param {string} lang - active language code
- * @returns {string[]} length-7 array of level names
+ * @param userLevels - per-index overrides
+ * @param lang - active language code
+ * @returns length-7 array of level names
  */
-export function buildLevelNames(userLevels, lang) {
+export function buildLevelNames(
+  userLevels: Array<string | null | undefined> | undefined,
+  lang: string,
+): string[] {
   return buildLevelNamesForScale(7, userLevels, lang);
 }
 
@@ -32,14 +35,18 @@ export function buildLevelNames(userLevels, lang) {
  * legacy `card.levels.{i}` when scale === 7. User-supplied entries at the
  * matching index override the default.
  *
- * @param {number} scale - native level count for this integration
- * @param {Array<string|null|undefined>|undefined} userLevels
- * @param {string} lang
- * @returns {string[]} length-`scale` array of level names
+ * @param scale - native level count for this integration
+ * @param userLevels
+ * @param lang
+ * @returns length-`scale` array of level names
  */
-export function buildLevelNamesForScale(scale, userLevels, lang) {
+export function buildLevelNamesForScale(
+  scale: number,
+  userLevels: Array<string | null | undefined> | undefined,
+  lang: string,
+): string[] {
   const keyPrefix = scale === 7 ? "card.levels" : `card.levels${scale}`;
-  const defaults = Array.from({ length: scale }, (_, i) =>
+  const defaults: string[] = Array.from({ length: scale }, (_, i) =>
     t(`${keyPrefix}.${i}`, lang),
   );
   if (!Array.isArray(userLevels)) return defaults;

--- a/src/utils/levels-defaults.ts
+++ b/src/utils/levels-defaults.ts
@@ -1,4 +1,4 @@
-// src/utils/levels-defaults.js
+// src/utils/levels-defaults.ts
 export const LEVELS_DEFAULTS = {
   levels_colors: [
     "#FFE55A",
@@ -16,7 +16,7 @@ export const LEVELS_DEFAULTS = {
   levels_text_size: 0.2,
   levels_icon_ratio: 1,
   levels_text_color: "var(--primary-text-color)",
-  
+
   // Default allergen colors: [empty_color, ...levels_colors]
   // This ensures both allergen icons and level circles use the same color mapping
   allergen_colors: [
@@ -28,16 +28,16 @@ export const LEVELS_DEFAULTS = {
     "#FF6140", // Level 5
     "#FF001C", // Level 6
   ],
-  
+
   // Default allergen stroke width - changed from old default to 15
   allergen_stroke_width: 15,
-  
+
   // Sync allergen stroke color with allergen level color
   allergen_stroke_color_synced: true,
-  
+
   // Sync allergen stroke width with level circle gap
   allergen_levels_gap_synced: true,
-  
+
   // Default color for no allergens icon
   no_allergens_color: "#a9cfe0",
 
@@ -84,6 +84,6 @@ export const STROKE_WIDTH_TO_GAP_RATIO = 30;
  * @param {number} strokeWidth - The stroke width in pixels
  * @returns {number} The calculated gap value
  */
-export function convertStrokeWidthToGap(strokeWidth) {
+export function convertStrokeWidthToGap(strokeWidth: number): number {
   return Math.round(strokeWidth / STROKE_WIDTH_TO_GAP_RATIO);
 }

--- a/src/utils/no-data-pattern.ts
+++ b/src/utils/no-data-pattern.ts
@@ -1,4 +1,4 @@
-// src/utils/no-data-pattern.js
+// src/utils/no-data-pattern.ts
 //
 // Noise-pattern generator for the "no data" visual treatment (level === -1).
 // Two output forms are provided so distinct textures can be applied to the
@@ -16,7 +16,7 @@ const ICON_DOT_DENSITY = 0.5;
 const ICON_DOT_TILE = 12;
 
 const RING_TILE = 32;
-const RING_PIX_DENSITY = 0.10;
+const RING_PIX_DENSITY = 0.1;
 const RING_SCRATCH_DENSITY_FACTOR = 0.25;
 const RING_MAX_PIX_SIZE = 2;
 
@@ -32,7 +32,7 @@ const DEFAULT_SEED = 13;
  * The order matters: `&` first, so we don't double-encode entity refs we
  * introduce in later replacements.
  */
-function escapeXmlAttr(value) {
+function escapeXmlAttr(value: unknown): string {
   return String(value)
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")
@@ -45,7 +45,7 @@ function escapeXmlAttr(value) {
  * Seedable PRNG. Stable output for a given seed so headless screenshots and
  * unit tests don't flake across runs.
  */
-function mulberry32(seed) {
+function mulberry32(seed: number): () => number {
   return function () {
     let t = (seed += 0x6d2b79f5);
     t = Math.imul(t ^ (t >>> 15), t | 1);
@@ -60,7 +60,10 @@ function mulberry32(seed) {
  * SVG). Density defaults to 50% so the silhouette reads even against a
  * heavily-textured ring.
  */
-export function buildNoiseSvgUri(color = "#888888", opts = {}) {
+export function buildNoiseSvgUri(
+  color = "#888888",
+  opts: { density?: number; tile?: number; seed?: number } = {},
+): string {
   const density = opts.density ?? ICON_DOT_DENSITY;
   const tile = opts.tile ?? ICON_DOT_TILE;
   const seed = opts.seed ?? DEFAULT_SEED;
@@ -87,7 +90,16 @@ export function buildNoiseSvgUri(color = "#888888", opts = {}) {
  * offscreen canvas. Returns null when there's no `document` (Node test env);
  * production callers must fall back to an emptyColor fill in that case.
  */
-export function buildNoiseTileCanvas(color = "#888888", opts = {}) {
+export function buildNoiseTileCanvas(
+  color = "#888888",
+  opts: {
+    tile?: number;
+    seed?: number;
+    pixDensity?: number;
+    scratchDensity?: number;
+    maxPx?: number;
+  } = {},
+): HTMLCanvasElement | null {
   if (typeof document === "undefined") return null;
   const tile = opts.tile ?? RING_TILE;
   const seed = opts.seed ?? DEFAULT_SEED;
@@ -146,7 +158,17 @@ export function buildNoiseTileCanvas(color = "#888888", opts = {}) {
  * destination chart's 2D context so the pattern is allocated in the right
  * rendering context.
  */
-export function buildNoiseCanvasPattern(ctx, color = "#888888", opts = {}) {
+export function buildNoiseCanvasPattern(
+  ctx: CanvasRenderingContext2D | null,
+  color = "#888888",
+  opts: {
+    tile?: number;
+    seed?: number;
+    pixDensity?: number;
+    scratchDensity?: number;
+    maxPx?: number;
+  } = {},
+): CanvasPattern | null {
   if (!ctx || typeof ctx.createPattern !== "function") return null;
   const tile = buildNoiseTileCanvas(color, opts);
   if (!tile) return null;
@@ -159,7 +181,7 @@ export function buildNoiseCanvasPattern(ctx, color = "#888888", opts = {}) {
  * its own seed so identical no-data layouts don't repeat across adjacent
  * allergen rows.
  */
-export function hashStringSeed(s) {
+export function hashStringSeed(s: string): number {
   let h = 5381;
   if (typeof s !== "string") s = String(s);
   // Math.imul keeps the multiplication in 32-bit integer space; plain
@@ -168,5 +190,5 @@ export function hashStringSeed(s) {
   for (let i = 0; i < s.length; i++) {
     h = Math.imul(h, 33) ^ s.charCodeAt(i);
   }
-  return (h >>> 0) || 1;
+  return h >>> 0 || 1;
 }

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,10 +1,10 @@
-// src/utils/normalize.js
+// src/utils/normalize.ts
 
 /**
  * Tar en text som kan innehålla diakritiska tecken,
  * tar bort dem och mappar allt till [a–z0–9_] för nycklar.
  */
-export function normalize(text) {
+export function normalize(text: string): string {
   return (
     text
       // Dela upp accent (NFD)
@@ -20,7 +20,7 @@ export function normalize(text) {
 }
 
 // Special-normalize för DWD-sensorer:
-export function normalizeDWD(text) {
+export function normalizeDWD(text: string): string {
   return (
     text
       .toLowerCase()

--- a/src/utils/number-format.ts
+++ b/src/utils/number-format.ts
@@ -6,12 +6,13 @@
 // JS instead, so editor number fields honour `hass.locale.number_format`
 // (point vs comma) and accept either separator on input.
 
+import type { HomeAssistant } from "../types/home-assistant.js";
+
 /**
  * Derive a decimal separator ("." or ",") from an Intl locale.
- * @param {string} [locale] - BCP-47 tag, or undefined for the runtime default.
- * @returns {string}
+ * @param locale - BCP-47 tag, or undefined for the runtime default.
  */
-function intlDecimalSeparator(locale) {
+function intlDecimalSeparator(locale?: string): string {
   try {
     const parts = new Intl.NumberFormat(locale || undefined).formatToParts(1.1);
     const dec = parts.find((p) => p.type === "decimal");
@@ -25,10 +26,9 @@ function intlDecimalSeparator(locale) {
  * Resolve the decimal separator the user expects, based on the HA profile's
  * `number_format` setting (falling back to their language, then the OS, then ".").
  * Mirrors Home Assistant's NumberFormat enum.
- * @param {object} [hass]
- * @returns {string} "." or ","
+ * @returns "." or ","
  */
-export function getDecimalSeparator(hass) {
+export function getDecimalSeparator(hass?: HomeAssistant): string {
   const fmt = hass?.locale?.number_format;
   switch (fmt) {
     case "comma_decimal": // 1,234.56
@@ -51,11 +51,11 @@ export function getDecimalSeparator(hass) {
 /**
  * Format a numeric value for display in an editable input: no grouping, decimal
  * separator per the HA profile. Empty/non-finite values render as "".
- * @param {number|string|null|undefined} value
- * @param {object} [hass]
- * @returns {string}
  */
-export function formatNumberForInput(value, hass) {
+export function formatNumberForInput(
+  value: number | string | null | undefined,
+  hass?: HomeAssistant,
+): string {
   if (value === null || value === undefined || value === "") return "";
   const num = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(num)) return "";
@@ -67,11 +67,13 @@ export function formatNumberForInput(value, hass) {
  * Parse user input from a number field, accepting either decimal separator and
  * tolerating grouping whitespace. Returns a finite number, or null when the
  * input is empty/invalid (so callers can revert instead of writing NaN/0).
- * @param {string} str
- * @param {object} [hass] - reserved for future locale-specific parsing
- * @returns {number|null}
+ * @param hass - reserved for future locale-specific parsing
  */
-export function parseLocaleNumber(str, hass) {
+export function parseLocaleNumber(
+  str: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  hass?: HomeAssistant,
+): number | null {
   if (typeof str !== "string") str = String(str ?? "");
   const trimmed = str.trim();
   if (trimmed === "") return null;

--- a/src/utils/sensors.ts
+++ b/src/utils/sensors.ts
@@ -1,13 +1,22 @@
-// src/utils/sensors.js
+// src/utils/sensors.ts
 import { getAdapter } from "../adapter-registry.js";
+import type { AdapterModule } from "../types/adapter.js";
+import type { CardConfig } from "../types/config.js";
+import type { HomeAssistant } from "../types/home-assistant.js";
 
 /**
  * Detect available sensor entity IDs for the configured integration.
  * Delegates all resolution (including manual mode) to the adapter's
  * resolveEntityIds().
  */
-export function findAvailableSensors(cfg, hass, debug = false) {
-  const adapter = getAdapter(cfg.integration);
+export function findAvailableSensors(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): string[] {
+  // adapter-registry is still untyped JS; cast the returned module to the
+  // adapter contract until the adapters themselves migrate to TypeScript.
+  const adapter = getAdapter(cfg.integration) as AdapterModule | undefined;
   if (!adapter?.resolveEntityIds) return [];
 
   const map = adapter.resolveEntityIds(cfg, hass, debug);

--- a/src/utils/silam.ts
+++ b/src/utils/silam.ts
@@ -1,14 +1,39 @@
-import silamAllergenMap from "../adapters/silam_allergen_map.json";
-import { discoverEntitiesByDevice, isConfigEntryId, deviceLocationKey } from "./adapter-helpers.js";
+import silamAllergenMapRaw from "../adapters/silam_allergen_map.json";
+import {
+  discoverEntitiesByDevice,
+  isConfigEntryId,
+  deviceLocationKey,
+} from "./adapter-helpers.js";
+import type { HomeAssistant } from "../types/home-assistant.js";
+import type { EntityRegistryDisplayEntry } from "../types/home-assistant.js";
+
+// The JSON import resolves to a type with literal per-language keys, which
+// blocks dynamic indexing (mapping[lang]). Re-type it with index signatures so
+// language/locale lookups by variable key type-check.
+interface SilamAllergenMap {
+  mapping: Record<string, Record<string, string>>;
+  weather_suffixes: Record<string, string[]>;
+}
+const silamAllergenMap = silamAllergenMapRaw as SilamAllergenMap;
+
+/** A discovered SILAM location, keyed by config-entry (or subentry) id. */
+interface SilamLocation {
+  label: string;
+  weatherEntity: string | null;
+  sensors: Map<string, string>;
+}
+interface SilamDiscovery {
+  locations: Map<string, SilamLocation>;
+}
 
 // Re-export so editor and other callers can keep their silam.js import path.
 export { isConfigEntryId };
 
 // Skapa dynamisk reverse-map: masterAllergen => slug för rätt språk
-export function getSilamReverseMap(lang) {
+export function getSilamReverseMap(lang: string): Record<string, string> {
   const mapping =
     silamAllergenMap.mapping?.[lang] || silamAllergenMap.mapping?.en || {};
-  const reverse = {};
+  const reverse: Record<string, string> = {};
   for (const [slug, master] of Object.entries(mapping)) {
     reverse[master] = slug;
   }
@@ -20,10 +45,14 @@ export function getSilamReverseMap(lang) {
  * Returns the canonical master allergen key, or null for non-allergen entities
  * (weather/forecast entities return null so they are excluded from sensors).
  */
-function classifySilamEntity(eid, { entry }) {
+function classifySilamEntity(
+  eid: string,
+  { entry }: { entry: EntityRegistryDisplayEntry | null | undefined },
+): string | null {
   if (!entry) return null;
   // Weather/forecast entities are handled as a separate postprocess step
-  if (eid.startsWith("weather.") || entry.translation_key === "forecast") return null;
+  if (eid.startsWith("weather.") || entry.translation_key === "forecast")
+    return null;
   const tk = entry.translation_key;
   if (!tk) return null;
   // Map through all language mappings to find the master allergen key
@@ -58,14 +87,19 @@ function classifySilamEntity(eid, { entry }) {
  * device name so downstream consumers (editor dropdown, card title) get a
  * clean location label like "Karis" rather than "SILAM Pollen - Karis".
  */
-function stripSilamPrefix(name) {
+function stripSilamPrefix(
+  name: string | null | undefined,
+): string | null | undefined {
   if (typeof name !== "string") return name;
   const stripped = name.replace(/^\s*silam\s*pollen\b[\s:\-–—]*/i, "").trim();
   return stripped || name;
 }
 
-export function discoverSilamSensors(hass, debug = false) {
-  const result = { locations: new Map() };
+export function discoverSilamSensors(
+  hass: HomeAssistant,
+  debug = false,
+): SilamDiscovery {
+  const result: SilamDiscovery = { locations: new Map() };
   if (!hass?.entities) return result;
 
   // Run shared discovery for allergen sensors (weather entities classified as null → skipped).
@@ -74,7 +108,7 @@ export function discoverSilamSensors(hass, debug = false) {
     platform: "silam_pollen",
     classify: classifySilamEntity,
     classifyRelaxed: classifySilamEntity,
-    resolveLabel: (ctx) => {
+    resolveLabel: (ctx: any) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
       if (ctx.device?.name) return stripSilamPrefix(ctx.device.name);
       if (ctx.state?.attributes?.friendly_name) {
@@ -93,8 +127,11 @@ export function discoverSilamSensors(hass, debug = false) {
   //
   // Identifies weather entities by eid starting with "weather." OR by
   // translation_key === "forecast" (both are reliable in current HA versions).
-  const deviceWeatherMap = new Map(); // deviceId -> weatherEntityId
-  const deviceInfoMap = new Map();    // deviceId -> { configEntryId, label }
+  const deviceWeatherMap = new Map<string, string>(); // deviceId -> weatherEntityId
+  const deviceInfoMap = new Map<
+    string,
+    { configEntryId: string; label: string }
+  >(); // deviceId -> { configEntryId, label }
   for (const [eid, entry] of Object.entries(hass.entities)) {
     if (entry.platform !== "silam_pollen") continue;
     if (eid.startsWith("weather.") || entry.translation_key === "forecast") {
@@ -124,7 +161,7 @@ export function discoverSilamSensors(hass, debug = false) {
   //   { label, weatherEntity, sensors: Map<allergenKey, entityId> }
   for (const [locKey, loc] of rawLocations) {
     const weatherEntity = loc.deviceId
-      ? (deviceWeatherMap.get(loc.deviceId) || null)
+      ? deviceWeatherMap.get(loc.deviceId) || null
       : null;
     result.locations.set(locKey, {
       label: loc.label,
@@ -177,12 +214,19 @@ export function discoverSilamSensors(hass, debug = false) {
  * - Slug-style configLocation matching a label substring → that location.
  * - Otherwise → null.
  */
-export function resolveDiscoveredLocation(discovery, configLocation, debug = false) {
+export function resolveDiscoveredLocation(
+  discovery: SilamDiscovery | null | undefined,
+  configLocation: string | null | undefined,
+  debug = false,
+): SilamLocation | null {
   if (!discovery?.locations?.size) return null;
 
   if (isConfigEntryId(configLocation)) {
-    if (discovery.locations.has(configLocation)) {
-      return discovery.locations.get(configLocation);
+    // isConfigEntryId only returns true for a ULID string, so configLocation
+    // is a string here (the untyped helper isn't a TS narrowing guard).
+    const key = configLocation as string;
+    if (discovery.locations.has(key)) {
+      return discovery.locations.get(key) ?? null;
     }
     if (debug) {
       console.debug(
@@ -221,7 +265,13 @@ export function resolveDiscoveredLocation(discovery, configLocation, debug = fal
  * @param {boolean} debug
  * @param {object} [precomputedDiscovery] - pass to avoid redundant discoverSilamSensors call
  */
-export function findSilamWeatherEntity(hass, location, locale, debug = false, precomputedDiscovery = null) {
+export function findSilamWeatherEntity(
+  hass: HomeAssistant,
+  location: string,
+  locale: string,
+  debug = false,
+  precomputedDiscovery: SilamDiscovery | null = null,
+): string | null {
   if (!hass) return null;
 
   // Primärt: discovery-baserad lookup (config_entry_id eller slug-match)
@@ -232,7 +282,7 @@ export function findSilamWeatherEntity(hass, location, locale, debug = false, pr
   // Fallback: regex-baserad lookup (äldre HA utan hass.entities)
   if (!location || isConfigEntryId(location)) return null;
   const loc = location.toLowerCase();
-  let tried = new Set();
+  const tried = new Set<string>();
 
   // 1. Testa suffixar för aktuell locale
   const suffixesLocale =

--- a/src/utils/slugify.ts
+++ b/src/utils/slugify.ts
@@ -1,13 +1,13 @@
-// src/utils/slugify.js
+// src/utils/slugify.ts
 // Matches Home Assistant frontend slugify (common/string/slugify.ts).
 // Uses character table for Latin diacritics + Cyrillic transliteration.
 // https://github.com/home-assistant/frontend/blob/dev/src/common/string/slugify.ts
-export const slugify = (value, delimiter = "_") => {
+export const slugify = (value: string, delimiter = "_"): string => {
   const a =
     "àáâäæãåāăąабçćčđďдèéêëēėęěеёэфğǵгḧхîïíīįìıİийкłлḿмñńǹňнôöòóœøōõőоṕпŕřрßśšşșсťțтûüùúūǘůűųувẃẍÿýыžźżз·";
   const b = `aaaaaaaaaaabcccdddeeeeeeeeeeefggghhiiiiiiiiijkllmmnnnnnoooooooooopprrrsssssstttuuuuuuuuuuvwxyyyzzzz${delimiter}`;
   const p = new RegExp(a.split("").join("|"), "g");
-  const complex_cyrillic = {
+  const complex_cyrillic: Record<string, string> = {
     ж: "zh",
     х: "kh",
     ц: "ts",


### PR DESCRIPTION
Third PR of the v4.0.0 migration (#259): the core type layer and the first batch of TypeScript conversions. No behaviour changes; test files are untouched and all 1294 tests pass unmodified.

## What

- **`src/types/`** (new): hand-rolled minimal Home Assistant typings (`HomeAssistant`, `HassEntity`, `EntityRegistryDisplayEntry`, `DeviceRegistryEntry`, ...) vendored Mushroom-style instead of depending on the stale `custom-card-helpers`; the domain contract (`PollenSensor`/`ForecastDay`) documented per the current, empirically verified behaviour of all 11 adapters (including the known `day0`/scale divergences, which are deliberately *not* normalized here — that is a later, behaviour-reviewed PR); the `AdapterModule` interface (3-arg `fetchForecast`, 4-arg `resolveEntityIds`); and YAML-realistic `CardConfig`/`BadgeConfig` (values may arrive as `boolean | string | number` from hand-written YAML).
- **13 leaf utils converted to TS** via `git mv` + annotations: slugify, normalize, number-format, confcompare, level-names, levels-defaults, level-counts, sensors, allergen-label, device-label, grid-options, no-data-pattern, silam. Existing runtime YAML-coercion guards are kept intact.
- Two incidental `let` → `const` fixes surfaced by lint on converted lines (never reassigned; behaviour identical).

## Verification

- 1294/1294 tests green with test files untouched (`.js` import specifiers resolve to the new `.ts` files via bundler module resolution — zero churn in callers).
- `tsc --noEmit` clean, `eslint` 0 errors, build OK, bundle gzip unchanged (+0.02 kB), within budget.
