### PR TITLE
(adapters) Convert msw, irmkmi and kleenex to TypeScript

### DIFF
--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -1,4 +1,4 @@
-// src/adapters/irmkmi.js
+// src/adapters/irmkmi.ts
 // IRM KMI / meteo.be adapter.
 //
 // Reads current pollen levels from the enum sensors created by the
@@ -18,7 +18,17 @@
 //     Saint-Ghislain) are disambiguated by config entry rather than mixed.
 //   - Stale config_entry_id values fall back to the first discovered location,
 //     mirroring DWD/GPL/GP/SILAM/Atmo/MSW recovery behavior.
+//
+// IRM KMI keeps its own resolveEntityIds and fetchForecast rather than the
+// shared base helpers: its discovery-only resolveEntityIds treats "manual" as
+// autodetect and falls back to the first location for ANY unmatched key (not
+// just config-entry ids as createEntityResolver's recoverStaleConfig does),
+// with no manual/template path, and its fetchForecast emits a single
+// current-day row rather than the multi-day window runForecastScaffold targets.
 
+import type { HomeAssistant } from "../types/home-assistant.js";
+import type { CardConfig, AdapterStubConfig } from "../types/config.js";
+import type { PollenSensor, ForecastDay } from "../types/sensor.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import {
@@ -31,11 +41,16 @@ import {
   discoverEntitiesByDevice,
   resolveLocationByKey,
   deviceLocationKey,
+  type DiscoveryContext,
+  type DiscoveredLocation,
 } from "../utils/adapter-helpers.js";
+
+// The subset of the discovery result irmkmi uses (config-entry keyed locations).
+type IrmkmiDiscovery = { locations: Map<string, DiscoveredLocation> };
 
 // irm-kmi-ha entity slug -> canonical allergen key.
 // "grasses" is the slug used in entity IDs by the integration.
-const IRMKMI_POLLEN_TYPES = {
+const IRMKMI_POLLEN_TYPES: Record<string, string> = {
   alder: "alder",
   ash: "ash",
   birch: "birch",
@@ -52,7 +67,8 @@ const IRMKMI_POLLEN_TYPES = {
 // green=null < yellow=low < orange=moderate < red=high < purple=very high.
 // `none` (no data) and the legacy `active` flag are intentionally absent: any
 // state not in this map is treated as no-data and the row is skipped.
-const IRMKMI_LEVEL_MAP = {
+// TODO(#259-normalize): preserve this native 0-4 level map.
+const IRMKMI_LEVEL_MAP: Record<string, number> = {
   green: 0,
   yellow: 1,
   orange: 2,
@@ -65,10 +81,9 @@ const IRMKMI_LEVEL_MAP = {
 // location (e.g. "antwerp", "saint_ghislain"). Anchoring on
 // _<allergen>_level$ extracts the allergen regardless of how many underscores
 // the location slug contains.
-const IRMKMI_LEVEL_RE =
-  /_(alder|ash|birch|grasses|hazel|mugwort|oak)_level$/;
+const IRMKMI_LEVEL_RE = /_(alder|ash|birch|grasses|hazel|mugwort|oak)_level$/;
 
-function classifyIrmkmiEntity(eid) {
+function classifyIrmkmiEntity(eid: string): string | null {
   if (typeof eid !== "string") return null;
   const m = IRMKMI_LEVEL_RE.exec(eid);
   if (!m) return null;
@@ -85,13 +100,15 @@ function classifyIrmkmiEntity(eid) {
 const IRMKMI_LOCATION_SLUG_RE =
   /^sensor\.(.+)_(?:alder|ash|birch|grasses|hazel|mugwort|oak)_level$/;
 
-export function extractIrmkmiLocationSlugFromEntityId(eid) {
+export function extractIrmkmiLocationSlugFromEntityId(
+  eid: string,
+): string | null {
   if (typeof eid !== "string") return null;
   const m = IRMKMI_LOCATION_SLUG_RE.exec(eid);
   return m ? m[1] : null;
 }
 
-export const stubConfigIRMKMI = {
+export const stubConfigIRMKMI: AdapterStubConfig = {
   integration: "irmkmi",
   location: "",
   allergens: ["alder", "ash", "birch", "grass", "hazel", "mugwort", "oak"],
@@ -140,15 +157,13 @@ export const stubConfigIRMKMI = {
  * name is the config-entry title, which is already the location (e.g.
  * "Antwerp", "Saint-Ghislain"); the RMI attribution lives in `manufacturer`,
  * not the name, so no prefix-stripping is needed.
- *
- * @param {{ device?: { name?: string, name_by_user?: string }, state?: { attributes?: { friendly_name?: string } } }} ctx
- * @returns {string}
  */
-function resolveIrmkmiLabel(ctx) {
+function resolveIrmkmiLabel(ctx: DiscoveryContext): string {
   const device = ctx?.device;
   if (device?.name_by_user) return device.name_by_user;
   if (device?.name) return device.name;
-  if (ctx?.state?.attributes?.friendly_name) return ctx.state.attributes.friendly_name;
+  if (ctx?.state?.attributes?.friendly_name)
+    return ctx.state.attributes.friendly_name;
   return "Auto";
 }
 
@@ -159,12 +174,11 @@ function resolveIrmkmiLabel(ctx) {
  *   1. Device registry: hass.devices with identifiers ["irm_kmi", ...].
  *   2. Entity registry: hass.entities filtered by platform === "irm_kmi".
  *   3. Regex fallback: hass.states scanned for the level-entity pattern.
- *
- * @param {Object} hass
- * @param {boolean} [debug]
- * @returns {{ locations: Map<string, { label: string, entities: Map<string, string>, deviceId?: string }> }}
  */
-export function discoverIrmkmiSensors(hass, debug = false) {
+export function discoverIrmkmiSensors(
+  hass: HomeAssistant,
+  debug = false,
+): IrmkmiDiscovery {
   if (!hass) return { locations: new Map() };
 
   const fallbackRe =
@@ -195,13 +209,12 @@ export function discoverIrmkmiSensors(hass, debug = false) {
  * Map allergen keys from config to irm-kmi-ha entity IDs for the resolved
  * location. Falls back to the first discovered location when the configured
  * location key does not match (auto-recovery from stale config_entry_id).
- *
- * @param {Object} cfg
- * @param {Object} hass
- * @param {boolean} [debug]
- * @returns {Map<string, string>} allergen -> entity_id
  */
-export function resolveEntityIds(cfg, hass, debug = false) {
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
   if (!hass?.states) return new Map();
 
   const discovery = discoverIrmkmiSensors(hass, debug);
@@ -215,7 +228,8 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   // Treat "manual" as autodetect (first discovered location), matching the
   // card header's pervasive `location !== "manual"` handling, instead of
   // silently relying on the stale-location fallback below.
-  const wantedLocation = cfg?.location === "manual" ? "" : cfg?.location;
+  const wantedLocation =
+    cfg?.location === "manual" ? "" : (cfg?.location as string);
   let resolved = resolveLocationByKey(discovery, wantedLocation, {
     slugExtractor: extractIrmkmiLocationSlugFromEntityId,
   });
@@ -232,14 +246,17 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   if (!resolved) return new Map();
 
   const [, location] = resolved;
-  const map = new Map();
-  for (const allergen of cfg?.allergens || []) {
+  const map = new Map<string, string>();
+  for (const allergen of (cfg?.allergens as string[] | undefined) || []) {
     const eid = location.entities.get(allergen);
     if (eid) {
       map.set(allergen, eid);
-      if (debug) console.debug(`[IRMKMI:resolveEntityIds] ${allergen} -> ${eid}`);
+      if (debug)
+        console.debug(`[IRMKMI:resolveEntityIds] ${allergen} -> ${eid}`);
     } else if (debug) {
-      console.debug(`[IRMKMI:resolveEntityIds] No entity for '${allergen}' in resolved location`);
+      console.debug(
+        `[IRMKMI:resolveEntityIds] No entity for '${allergen}' in resolved location`,
+      );
     }
   }
   return map;
@@ -248,26 +265,39 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 /**
  * Fetch current pollen levels from irm-kmi-ha entities.
  * Returns one day (today) per allergen.
- *
- * @param {Object} hass
- * @param {Object} config
- * @returns {Promise<Array>} Sensor dicts compatible with pollenprognos-card renderer
  */
-export async function fetchForecast(hass, config) {
-  if (!hass?.states || !config.allergens?.length) return [];
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
+  if (!hass?.states || !(config.allergens as string[] | undefined)?.length)
+    return [];
   const debug = Boolean(config.debug);
 
   const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
-    getLangAndLocale(hass, config, stubConfigIRMKMI.date_locale);
-  const { fullPhrases, shortPhrases, userLevels, userDays } =
-    mergePhrases(config, lang);
+    getLangAndLocale(
+      hass,
+      config,
+      stubConfigIRMKMI.date_locale as string | undefined,
+    );
+  const { fullPhrases, shortPhrases, userLevels, userDays } = mergePhrases(
+    config,
+    lang,
+  );
   // Five-level scale: defaults from card.levels5.0..4, native-indexed.
-  const levelNames = buildLevelNamesForScale(5, userLevels, lang);
-  const pollen_threshold = config.pollen_threshold ?? stubConfigIRMKMI.pollen_threshold;
+  const levelNames = buildLevelNamesForScale(
+    5,
+    userLevels as Array<string | null | undefined>,
+    lang,
+  );
+  const pollen_threshold =
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigIRMKMI.pollen_threshold as number);
 
-  if (debug) console.debug("IRMKMI adapter: start fetchForecast", { config, lang });
+  if (debug)
+    console.debug("IRMKMI adapter: start fetchForecast", { config, lang });
 
-  const sensors = [];
+  const sensors: PollenSensor[] = [];
   const entityMap = resolveEntityIds(config, hass, debug);
 
   const today = new Date();
@@ -281,7 +311,7 @@ export async function fetchForecast(hass, config) {
     locale,
   });
 
-  for (const allergen of config.allergens) {
+  for (const allergen of config.allergens as string[]) {
     try {
       const entityId = entityMap.get(allergen);
       if (!entityId) continue;
@@ -289,23 +319,25 @@ export async function fetchForecast(hass, config) {
       const stateObj = hass.states[entityId];
       if (!stateObj) continue;
 
-      const rawState = typeof stateObj.state === "string"
-        ? stateObj.state.toLowerCase()
-        : "";
+      const rawState =
+        typeof stateObj.state === "string" ? stateObj.state.toLowerCase() : "";
       const level = IRMKMI_LEVEL_MAP[rawState];
       if (level === undefined) continue; // none / active / unavailable / unknown -> no-data
 
-      const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergen, {
-        fullPhrases,
-        shortPhrases,
-        abbreviated: config.allergens_abbreviated,
-        lang,
-        configKey: allergen,
-      });
+      const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+        allergen,
+        {
+          fullPhrases,
+          shortPhrases,
+          abbreviated: config.allergens_abbreviated as boolean,
+          lang,
+          configKey: allergen,
+        },
+      );
 
       const stateText = levelNames[level] ?? rawState;
 
-      const day0 = {
+      const day0: ForecastDay = {
         name: allergenCapitalized,
         day: dayLabel,
         state: level,
@@ -313,7 +345,7 @@ export async function fetchForecast(hass, config) {
         state_text: stateText,
       };
 
-      const dict = {
+      const dict: PollenSensor = {
         allergenReplaced: allergen,
         allergenCapitalized,
         allergenShort,
@@ -328,7 +360,7 @@ export async function fetchForecast(hass, config) {
     }
   }
 
-  sortSensors(sensors, config.sort);
+  sortSensors(sensors, config.sort as string);
 
   if (debug) console.debug("IRMKMI adapter complete sensors:", sensors);
   return sensors;

--- a/src/adapters/kleenex/constants.ts
+++ b/src/adapters/kleenex/constants.ts
@@ -1,10 +1,11 @@
-// src/adapters/kleenex/constants.js
+// src/adapters/kleenex/constants.ts
+import type { AdapterStubConfig } from "../../types/config.js";
 import { LEVELS_DEFAULTS } from "../../utils/levels-defaults.js";
 
 export const DOMAIN = "kleenex_pollen_radar";
 
 // Map kleenex allergen names to our canonical names (supports all regional language variations)
-export const KLEENEX_ALLERGEN_MAP = {
+export const KLEENEX_ALLERGEN_MAP: Record<string, string> = {
   // Trees - English (EN/US)
   hazel: "hazel",
   elm: "elm",
@@ -80,7 +81,7 @@ export const KLEENEX_ALLERGEN_MAP = {
   brandnetel: "nettle",
 };
 
-export const stubConfigKleenex = {
+export const stubConfigKleenex: AdapterStubConfig = {
   integration: "kleenex",
   location: "",
   // Optional entity naming used when location is "manual"
@@ -137,7 +138,7 @@ export const stubConfigKleenex = {
 };
 
 // Category-specific allergen mapping for kleenex integration
-export const KLEENEX_ALLERGEN_CATEGORIES = {
+export const KLEENEX_ALLERGEN_CATEGORIES: Record<string, string> = {
   // Trees category
   trees_cat: "trees",
   trees: "trees", // Keep compatibility for sensor mapping
@@ -166,11 +167,21 @@ export const KLEENEX_ALLERGEN_CATEGORIES = {
 };
 
 // Map allergens to the kleenex category they belong to
-export const INDIVIDUAL_TO_CATEGORY = {
-  alder: "trees", birch: "trees", cypress: "trees", elm: "trees",
-  hazel: "trees", oak: "trees", pine: "trees", plane: "trees", poplar: "trees",
+export const INDIVIDUAL_TO_CATEGORY: Record<string, string> = {
+  alder: "trees",
+  birch: "trees",
+  cypress: "trees",
+  elm: "trees",
+  hazel: "trees",
+  oak: "trees",
+  pine: "trees",
+  plane: "trees",
+  poplar: "trees",
   poaceae: "grass",
-  mugwort: "weeds", ragweed: "weeds", chenopod: "weeds", nettle: "weeds",
+  mugwort: "weeds",
+  ragweed: "weeds",
+  chenopod: "weeds",
+  nettle: "weeds",
 };
 
 // Re-exported from the shared helper so the three adapter constants modules

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -1,4 +1,6 @@
-// src/adapters/kleenex/discovery.js
+// src/adapters/kleenex/discovery.ts
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
 import { KLEENEX_LOCALIZED_CATEGORY_NAMES } from "../../constants.js";
 import { slugify } from "../../utils/slugify.js";
 import { normalizeManualPrefix } from "../../utils/adapter-helpers.js";
@@ -7,12 +9,12 @@ import { INDIVIDUAL_TO_CATEGORY, KLEENEX_ALLERGEN_MAP } from "./constants.js";
 // Static reverse index: canonical allergen name -> Set of slugified alias
 // entity-suffixes. Built once from KLEENEX_ALLERGEN_MAP since the map is
 // module-level constant data.
-const CANONICAL_TO_ALIAS_SLUGS = (() => {
-  const m = new Map();
+const CANONICAL_TO_ALIAS_SLUGS: Map<string, Set<string>> = (() => {
+  const m = new Map<string, Set<string>>();
   for (const [alias, canonical] of Object.entries(KLEENEX_ALLERGEN_MAP)) {
     let slugs = m.get(canonical);
     if (!slugs) {
-      slugs = new Set();
+      slugs = new Set<string>();
       m.set(canonical, slugs);
     }
     slugs.add(slugify(alias));
@@ -31,14 +33,18 @@ const CANONICAL_TO_ALIAS_SLUGS = (() => {
  *     `KleenexDetailSensor` entity, covered when such an entity exists in HA
  *     (the user has manually enabled the disabled-by-default detail sensors).
  */
-export function resolveEntityIds(cfg, hass, debug = false) {
-  const map = new Map();
-  const locationSlug = slugify(cfg.location || "");
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const locationSlug = slugify((cfg.location as string) || "");
   const categoryAllergens = ["trees", "grass", "weeds"];
 
   // Determine which categories are needed
-  const needsCategories = new Set();
-  for (const allergen of cfg.allergens || []) {
+  const needsCategories = new Set<string>();
+  for (const allergen of (cfg.allergens as string[] | undefined) || []) {
     if (categoryAllergens.includes(allergen)) {
       needsCategories.add(allergen);
     } else if (allergen.endsWith("_cat")) {
@@ -53,15 +59,15 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   }
 
   for (const category of needsCategories) {
-    let sensorId;
+    let sensorId: string | undefined;
     if (cfg.location === "manual") {
       const prefix = normalizeManualPrefix(cfg.entity_prefix);
-      const suffix = cfg.entity_suffix || "";
+      const suffix = (cfg.entity_suffix as string) || "";
 
       sensorId = `sensor.${prefix}${category}${suffix}`;
       if (!hass.states[sensorId]) {
         const possiblePrefixes = Object.entries(KLEENEX_LOCALIZED_CATEGORY_NAMES)
-          .filter(([_, canonical]) => canonical === category)
+          .filter(([, canonical]) => canonical === category)
           .map(([localPrefix]) => localPrefix);
 
         const expectedPrefix = `sensor.${prefix}`;
@@ -69,7 +75,9 @@ export function resolveEntityIds(cfg, hass, debug = false) {
           if (!id.startsWith(expectedPrefix)) return false;
           const middle = id.substring(expectedPrefix.length);
           if (suffix && !middle.endsWith(suffix)) return false;
-          const categoryPart = suffix ? middle.substring(0, middle.length - suffix.length) : middle;
+          const categoryPart = suffix
+            ? middle.substring(0, middle.length - suffix.length)
+            : middle;
           return possiblePrefixes.some((lp) => categoryPart.startsWith(lp));
         });
         if (candidates.length >= 1) sensorId = candidates[0];
@@ -77,16 +85,18 @@ export function resolveEntityIds(cfg, hass, debug = false) {
     } else {
       sensorId = locationSlug
         ? `sensor.kleenex_pollen_radar_${locationSlug}_${category}`
-        : null;
+        : undefined;
       if (!sensorId || !hass.states[sensorId]) {
         const possiblePrefixes = Object.entries(KLEENEX_LOCALIZED_CATEGORY_NAMES)
-          .filter(([_, canonical]) => canonical === category)
+          .filter(([, canonical]) => canonical === category)
           .map(([lp]) => lp);
 
         const candidates = Object.keys(hass.states).filter((id) => {
           if (!id.startsWith("sensor.kleenex_pollen_radar_")) return false;
           if (locationSlug) {
-            const afterPrefix = id.substring("sensor.kleenex_pollen_radar_".length);
+            const afterPrefix = id.substring(
+              "sensor.kleenex_pollen_radar_".length,
+            );
             if (!afterPrefix.startsWith(locationSlug + "_")) return false;
           }
           const parts = id.split("_");
@@ -99,33 +109,38 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 
     if (debug) {
       console.debug(
-        `[Kleenex:resolveEntityIds] category: '${category}', sensorId: '${sensorId}', exists: ${!!hass.states[sensorId]}`,
+        `[Kleenex:resolveEntityIds] category: '${category}', sensorId: '${sensorId}', exists: ${!!(sensorId && hass.states[sensorId])}`,
       );
     }
-    if (hass.states[sensorId]) map.set(category, sensorId);
+    if (sensorId && hass.states[sensorId]) map.set(category, sensorId);
   }
 
   // Also probe for individually-enabled DetailSensor entities.
   // These are disabled by default in HA (entity_registry_enabled_default=False) but
   // users may enable them. For NA zones they don't exist at all; for EU/UK zones they
   // give per-allergen data when the category sensor's details[] is empty.
-  const individualAllergens = (cfg.allergens || []).filter(
-    (a) => !["trees_cat", "grass_cat", "weeds_cat", "trees", "grass", "weeds"].includes(a),
+  const individualAllergens = ((cfg.allergens as string[] | undefined) || []).filter(
+    (a) =>
+      !["trees_cat", "grass_cat", "weeds_cat", "trees", "grass", "weeds"].includes(
+        a,
+      ),
   );
 
   for (const allergen of individualAllergens) {
     // map already has this allergen (from some other path) — skip.
     if (map.has(allergen)) continue;
 
-    let detailSensorId;
+    let detailSensorId: string | undefined;
     // Cover both alias-keyed slugs and the canonical name itself (in case the
     // canonical isn't an alias key in KLEENEX_ALLERGEN_MAP).
-    const aliasesForCanonical = new Set(CANONICAL_TO_ALIAS_SLUGS.get(allergen) || []);
+    const aliasesForCanonical = new Set(
+      CANONICAL_TO_ALIAS_SLUGS.get(allergen) || [],
+    );
     aliasesForCanonical.add(slugify(allergen));
 
     if (cfg.location === "manual") {
       const prefix = normalizeManualPrefix(cfg.entity_prefix);
-      const suffix = cfg.entity_suffix || "";
+      const suffix = (cfg.entity_suffix as string) || "";
       for (const aliasSlug of aliasesForCanonical) {
         const candidate = `sensor.${prefix}${aliasSlug}${suffix}`;
         if (hass.states[candidate]) {

--- a/src/adapters/kleenex/forecast.ts
+++ b/src/adapters/kleenex/forecast.ts
@@ -1,16 +1,45 @@
-// src/adapters/kleenex/forecast.js
+// src/adapters/kleenex/forecast.ts
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
+import type { PollenSensor, ForecastDay } from "../../types/sensor.js";
 import { t } from "../../i18n.js";
 import { KLEENEX_LOCALIZED_CATEGORY_NAMES } from "../../constants.js";
 import { slugify } from "../../utils/slugify.js";
 import { buildLevelNames } from "../../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, normalizeManualPrefix } from "../../utils/adapter-helpers.js";
+import {
+  getLangAndLocale,
+  mergePhrases,
+  buildDayLabel,
+  clampLevel,
+  sortSensors,
+  meetsThreshold,
+  resolveAllergenNames,
+  normalizeManualPrefix,
+} from "../../utils/adapter-helpers.js";
 import { DOMAIN, KLEENEX_ALLERGEN_MAP, stubConfigKleenex } from "./constants.js";
 import { ppmToLevel } from "./levels.js";
 
+// One collected day of data for an allergen (raw level 0-4 plus the ppm value).
+interface KleenexLevelDay {
+  date: Date;
+  level: number;
+  value: number;
+}
+
+// Per-allergen collection bucket accumulated across the sensor passes.
+interface KleenexAllergenEntry {
+  levels: KleenexLevelDay[];
+  entity_id: string;
+  source: string;
+}
+
+// A forecast/detail item as reported by the integration (loosely shaped).
+type KleenexItem = Record<string, unknown>;
+
 // Static lookup: slugified alias key -> canonical allergen name. Built once
 // from KLEENEX_ALLERGEN_MAP since the map is module-level constant data.
-const SLUGIFIED_ALIAS_MAP = (() => {
-  const m = new Map();
+const SLUGIFIED_ALIAS_MAP: Map<string, string> = (() => {
+  const m = new Map<string, string>();
   for (const [alias, canonical] of Object.entries(KLEENEX_ALLERGEN_MAP)) {
     const slug = slugify(alias);
     if (!m.has(slug)) m.set(slug, canonical);
@@ -20,29 +49,46 @@ const SLUGIFIED_ALIAS_MAP = (() => {
 
 // Diagnostic suffixes that are not allergen names — skip them in Pass 2.
 const DIAGNOSTIC_SUFFIXES = new Set([
-  "level", "date", "last_updated", "latitude", "longitude",
-  "city", "region", "error",
+  "level",
+  "date",
+  "last_updated",
+  "latitude",
+  "longitude",
+  "city",
+  "region",
+  "error",
 ]);
 
 // Track which (location, entity_prefix) combinations have already received the
 // NA-zone warning so it isn't re-emitted on every HA state update.
-const NA_WARNED_KEYS = new Set();
+const NA_WARNED_KEYS = new Set<string>();
 
 // Test-only hook to clear the dedup state between cases.
-export function _resetNaWarningsForTest() {
+export function _resetNaWarningsForTest(): void {
   NA_WARNED_KEYS.clear();
 }
 
-export async function fetchForecast(hass, config) {
-  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } = getLangAndLocale(hass, config);
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
+  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
+    getLangAndLocale(hass, config);
   const debug = config.debug;
-  const days_to_show = config.days_to_show || stubConfigKleenex.days_to_show;
-  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } = mergePhrases(config, lang);
+  const days_to_show =
+    (config.days_to_show as number) ||
+    (stubConfigKleenex.days_to_show as number);
+  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } =
+    mergePhrases(config, lang);
   const pollen_threshold =
-    config.pollen_threshold ?? stubConfigKleenex.pollen_threshold;
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigKleenex.pollen_threshold as number);
+  const allergens = config.allergens as string[];
 
-  // Kleenex uses 5-level system (0-4), validate and clamp level values
-  const testVal = (v) => clampLevel(v, 4, -1);
+  // Kleenex uses 5-level system (0-4), validate and clamp level values.
+  // TODO(#259-normalize): preserve the native 0-4 scale (scaled to 0-6 only for
+  // the level-name lookup below, mirroring PEU).
+  const testVal = (v: unknown): number => clampLevel(v, 4, -1);
 
   if (debug)
     console.debug("[Kleenex] Adapter: start fetchForecast", { config, lang });
@@ -57,7 +103,7 @@ export async function fetchForecast(hass, config) {
 
   // Filter by location if specified (and not manual mode)
   if (config.location && config.location !== "manual") {
-    const wantedLocation = slugify(config.location);
+    const wantedLocation = slugify(config.location as string);
 
     if (debug) {
       console.debug(
@@ -86,7 +132,7 @@ export async function fetchForecast(hass, config) {
     }
   } else if (config.location === "manual") {
     // Manual mode: filter by entity_prefix
-    let prefix = config.entity_prefix || "";
+    let prefix = (config.entity_prefix as string) || "";
     // Remove 'sensor.' prefix if user included it
     if (prefix.startsWith("sensor.")) {
       prefix = prefix.substring(7); // Remove 'sensor.'
@@ -97,9 +143,7 @@ export async function fetchForecast(hass, config) {
     }
 
     if (debug) {
-      console.debug(
-        `[Kleenex] Manual mode filtering with prefix: '${prefix}'`,
-      );
+      console.debug(`[Kleenex] Manual mode filtering with prefix: '${prefix}'`);
     }
 
     if (prefix) {
@@ -108,9 +152,7 @@ export async function fetchForecast(hass, config) {
         const matches = entity.entity_id.startsWith(expectedPrefix);
 
         if (debug && matches) {
-          console.debug(
-            `[Kleenex] Manual mode match: ${entity.entity_id}`,
-          );
+          console.debug(`[Kleenex] Manual mode match: ${entity.entity_id}`);
         }
 
         return matches;
@@ -131,8 +173,8 @@ export async function fetchForecast(hass, config) {
     );
   }
 
-  let sensors = [];
-  const allergenData = new Map(); // Map to collect data by allergen name
+  let sensors: PollenSensor[] = [];
+  const allergenData = new Map<string, KleenexAllergenEntry>(); // Map to collect data by allergen name
 
   if (debug) {
     console.debug(
@@ -148,13 +190,15 @@ export async function fetchForecast(hass, config) {
     }
 
     const attributes = sensor.attributes || {};
-    const details = attributes.details || [];
-    const forecastData = attributes.forecast || [];
+    const details: KleenexItem[] = attributes.details || [];
+    const forecastData: KleenexItem[] = attributes.forecast || [];
 
     // Determine sensor category from entity_id by checking all localized name prefixes
-    let sensorCategory = null;
-    const entitySuffix = sensor.entity_id.split('_').pop();
-    for (const [localizedPrefix, canonicalCategory] of Object.entries(KLEENEX_LOCALIZED_CATEGORY_NAMES)) {
+    let sensorCategory: string | null = null;
+    const entitySuffix = sensor.entity_id.split("_").pop() as string;
+    for (const [localizedPrefix, canonicalCategory] of Object.entries(
+      KLEENEX_LOCALIZED_CATEGORY_NAMES,
+    )) {
       if (entitySuffix.startsWith(localizedPrefix)) {
         sensorCategory = canonicalCategory;
         break;
@@ -171,31 +215,28 @@ export async function fetchForecast(hass, config) {
     if (sensorCategory) {
       // Map sensor category to config allergen name
       let configAllergenName = sensorCategory;
-      if (
-        sensorCategory === "trees" &&
-        config.allergens.includes("trees_cat")
-      ) {
+      if (sensorCategory === "trees" && allergens.includes("trees_cat")) {
         configAllergenName = "trees_cat";
       } else if (
         sensorCategory === "grass" &&
-        config.allergens.includes("grass_cat")
+        allergens.includes("grass_cat")
       ) {
         configAllergenName = "grass_cat";
       } else if (
         sensorCategory === "weeds" &&
-        config.allergens.includes("weeds_cat")
+        allergens.includes("weeds_cat")
       ) {
         configAllergenName = "weeds_cat";
       }
 
       if (debug) {
         console.debug(
-          `[Kleenex] Category sensor mapping: ${sensorCategory} -> ${configAllergenName}, included in config: ${config.allergens.includes(configAllergenName)}`,
+          `[Kleenex] Category sensor mapping: ${sensorCategory} -> ${configAllergenName}, included in config: ${allergens.includes(configAllergenName)}`,
         );
       }
 
       // Only process if the config allergen name is requested
-      if (config.allergens.includes(configAllergenName)) {
+      if (allergens.includes(configAllergenName)) {
         if (debug) {
           console.debug(
             `[Kleenex] Processing CATEGORY sensor for: ${sensorCategory} -> ${configAllergenName}`,
@@ -210,11 +251,13 @@ export async function fetchForecast(hass, config) {
           });
 
           if (debug) {
-            console.debug(`[Kleenex] CREATED allergenData entry for category: ${configAllergenName}`);
+            console.debug(
+              `[Kleenex] CREATED allergenData entry for category: ${configAllergenName}`,
+            );
           }
         }
 
-        const allergenEntry = allergenData.get(configAllergenName);
+        const allergenEntry = allergenData.get(configAllergenName)!;
 
         // Today's data from sensor state - prioritize numeric value over level text
         const sensorValue = Number(sensor.state) || 0;
@@ -234,7 +277,9 @@ export async function fetchForecast(hass, config) {
         };
 
         if (debug) {
-          console.debug(`[Kleenex] CATEGORY ${configAllergenName} TODAY DATA SET: level=${currentLevel}, value=${sensorValue}`);
+          console.debug(
+            `[Kleenex] CATEGORY ${configAllergenName} TODAY DATA SET: level=${currentLevel}, value=${sensorValue}`,
+          );
         }
 
         // Forecast data for categories
@@ -256,13 +301,15 @@ export async function fetchForecast(hass, config) {
           };
 
           if (debug) {
-            console.debug(`[Kleenex] CATEGORY ${configAllergenName} FORECAST DAY ${dayIndex + 1} DATA SET: level=${forecastLevel}, value=${forecastValue}`);
+            console.debug(
+              `[Kleenex] CATEGORY ${configAllergenName} FORECAST DAY ${dayIndex + 1} DATA SET: level=${forecastLevel}, value=${forecastValue}`,
+            );
           }
         });
       } else {
         if (debug) {
           console.debug(
-            `[Kleenex] SKIPPING category sensor ${sensorCategory} -> ${configAllergenName}: not in config.allergens [${config.allergens.join(', ')}]`,
+            `[Kleenex] SKIPPING category sensor ${sensorCategory} -> ${configAllergenName}: not in config.allergens [${allergens.join(", ")}]`,
           );
         }
       }
@@ -270,18 +317,21 @@ export async function fetchForecast(hass, config) {
 
     // Extract individual allergens from current details - only if specific allergen is requested
     if (debug) {
-      console.debug(`[Kleenex] Processing ${details.length} individual allergen details for sensor: ${sensor.entity_id}`);
+      console.debug(
+        `[Kleenex] Processing ${details.length} individual allergen details for sensor: ${sensor.entity_id}`,
+      );
     }
 
     try {
       for (const detail of details) {
-        const allergenName = detail.name?.toLowerCase();
+        const allergenName = (detail.name as string)?.toLowerCase();
         if (!allergenName) continue;
 
-        const canonicalName = KLEENEX_ALLERGEN_MAP[allergenName] || allergenName;
+        const canonicalName =
+          KLEENEX_ALLERGEN_MAP[allergenName] || allergenName;
 
         // Skip if this allergen is not in the config
-        if (!config.allergens.includes(canonicalName)) {
+        if (!allergens.includes(canonicalName)) {
           if (debug && detail.value !== undefined) {
             console.debug(
               `[Kleenex] SKIPPING individual allergen ${canonicalName} (${allergenName}): not in config allergens`,
@@ -304,7 +354,7 @@ export async function fetchForecast(hass, config) {
           });
         }
 
-        const allergenEntry = allergenData.get(canonicalName);
+        const allergenEntry = allergenData.get(canonicalName)!;
 
         // Today's data - prioritize numeric value over level text
         const detailValue = Number(detail.value) || 0;
@@ -331,7 +381,10 @@ export async function fetchForecast(hass, config) {
       }
     } catch (error) {
       if (debug) {
-        console.warn(`[Kleenex] Error processing individual allergens for sensor ${sensor.entity_id}:`, error);
+        console.warn(
+          `[Kleenex] Error processing individual allergens for sensor ${sensor.entity_id}:`,
+          error,
+        );
       }
     }
 
@@ -341,7 +394,8 @@ export async function fetchForecast(hass, config) {
         const forecastDate = new Date(
           today.getTime() + (dayIndex + 1) * 86400000,
         );
-        const forecastDetails = forecastItem.details || [];
+        const forecastDetails: KleenexItem[] =
+          (forecastItem.details as KleenexItem[]) || [];
 
         if (debug && forecastDetails.length > 0) {
           console.debug(
@@ -350,14 +404,14 @@ export async function fetchForecast(hass, config) {
         }
 
         for (const detail of forecastDetails) {
-          const allergenName = detail.name?.toLowerCase();
+          const allergenName = (detail.name as string)?.toLowerCase();
           if (!allergenName) continue;
 
           const canonicalName =
             KLEENEX_ALLERGEN_MAP[allergenName] || allergenName;
 
           // Skip if this allergen is not in the config
-          if (!config.allergens.includes(canonicalName)) continue;
+          if (!allergens.includes(canonicalName)) continue;
 
           if (!allergenData.has(canonicalName)) {
             allergenData.set(canonicalName, {
@@ -367,7 +421,7 @@ export async function fetchForecast(hass, config) {
             });
           }
 
-          const allergenEntry = allergenData.get(canonicalName);
+          const allergenEntry = allergenData.get(canonicalName)!;
           const forecastValue = Number(detail.value) || 0;
           const rawLevel = ppmToLevel(forecastValue, canonicalName); // Calculate raw level (0-4)
           const forecastLevel = testVal(rawLevel); // Validate and clamp level (0-4)
@@ -395,7 +449,10 @@ export async function fetchForecast(hass, config) {
       });
     } catch (error) {
       if (debug) {
-        console.warn(`[Kleenex] Error processing forecast data for sensor ${sensor.entity_id}:`, error);
+        console.warn(
+          `[Kleenex] Error processing forecast data for sensor ${sensor.entity_id}:`,
+          error,
+        );
       }
     }
   }
@@ -407,23 +464,22 @@ export async function fetchForecast(hass, config) {
 
   // Effective last token of an entity_id, accounting for manual-mode
   // entity_suffix (e.g. `..._trees_v2` should resolve to `trees`).
-  const effectiveLastToken = (entityId) => {
+  const effectiveLastToken = (entityId: string): string => {
     let id = entityId;
-    if (
-      config.location === "manual" &&
-      config.entity_suffix &&
-      id.endsWith(config.entity_suffix)
-    ) {
-      id = id.slice(0, -config.entity_suffix.length);
+    const entitySuffix = config.entity_suffix as string | undefined;
+    if (config.location === "manual" && entitySuffix && id.endsWith(entitySuffix)) {
+      id = id.slice(0, -entitySuffix.length);
     }
-    return id.split("_").pop();
+    return id.split("_").pop() as string;
   };
 
   for (const sensor of kleenexSensors) {
     // Only consider sensors that were NOT identified as category sensors.
     const lastToken = effectiveLastToken(sensor.entity_id);
     let isCategorySensor = false;
-    for (const localizedPrefix of Object.keys(KLEENEX_LOCALIZED_CATEGORY_NAMES)) {
+    for (const localizedPrefix of Object.keys(
+      KLEENEX_LOCALIZED_CATEGORY_NAMES,
+    )) {
       if (lastToken.startsWith(localizedPrefix)) {
         isCategorySensor = true;
         break;
@@ -432,7 +488,7 @@ export async function fetchForecast(hass, config) {
     if (isCategorySensor) continue;
 
     // Derive the allergen suffix from the entity_id.
-    let allergenSuffix;
+    let allergenSuffix: string;
     if (config.location === "manual" && config.entity_prefix) {
       // Manual mode: user-supplied entity_prefix already covers the whole prefix
       // up to <allergen>; strip it from the full entity_id.
@@ -441,8 +497,9 @@ export async function fetchForecast(hass, config) {
       allergenSuffix = sensor.entity_id.slice(fullPrefix.length);
       // Discovery builds entity_ids as `${prefix}${aliasSlug}${entity_suffix}` —
       // strip the same trailing suffix here so the alias lookup matches.
-      if (config.entity_suffix && allergenSuffix.endsWith(config.entity_suffix)) {
-        allergenSuffix = allergenSuffix.slice(0, -config.entity_suffix.length);
+      const entitySuffix = config.entity_suffix as string | undefined;
+      if (entitySuffix && allergenSuffix.endsWith(entitySuffix)) {
+        allergenSuffix = allergenSuffix.slice(0, -entitySuffix.length);
       }
     } else {
       // Standard mode: strip domain prefix, then the configured location slug.
@@ -451,7 +508,7 @@ export async function fetchForecast(hass, config) {
         ? sensor.entity_id.slice(domainPrefix.length)
         : sensor.entity_id;
       if (config.location && config.location !== "manual") {
-        const locationSlug = slugify(config.location);
+        const locationSlug = slugify(config.location as string);
         if (allergenSuffix.startsWith(locationSlug + "_")) {
           allergenSuffix = allergenSuffix.slice(locationSlug.length + 1);
         }
@@ -481,7 +538,7 @@ export async function fetchForecast(hass, config) {
     if (!canonicalName) continue;
 
     // Skip allergens not requested in config.
-    if (!config.allergens.includes(canonicalName)) continue;
+    if (!allergens.includes(canonicalName)) continue;
 
     // Only fill slots not already populated by category-sensor pass.
     if (allergenData.has(canonicalName)) continue;
@@ -504,7 +561,7 @@ export async function fetchForecast(hass, config) {
       source: "detail_sensor",
     });
 
-    const allergenEntry = allergenData.get(canonicalName);
+    const allergenEntry = allergenData.get(canonicalName)!;
     const rawLevel = ppmToLevel(parsedState, canonicalName);
     const currentLevel = testVal(rawLevel);
 
@@ -516,13 +573,14 @@ export async function fetchForecast(hass, config) {
 
     // DetailSensor forecast: [{date, value}] — no per-allergen level field.
     // Non-numeric forecast values are treated as missing-day sentinels (-1).
-    const detailForecast = sensor.attributes?.forecast || [];
+    const detailForecast: KleenexItem[] = sensor.attributes?.forecast || [];
     detailForecast.forEach((forecastItem, dayIndex) => {
       const parsedForecast = Number(forecastItem.value);
-      const forecastValue = Number.isFinite(parsedForecast) ? parsedForecast : -1;
-      const fRawLevel = forecastValue < 0
-        ? -1
-        : ppmToLevel(forecastValue, canonicalName);
+      const forecastValue = Number.isFinite(parsedForecast)
+        ? parsedForecast
+        : -1;
+      const fRawLevel =
+        forecastValue < 0 ? -1 : ppmToLevel(forecastValue, canonicalName);
       const forecastLevel = testVal(fRawLevel);
       allergenEntry.levels[dayIndex + 1] = {
         date: new Date(today.getTime() + (dayIndex + 1) * 86400000),
@@ -540,13 +598,17 @@ export async function fetchForecast(hass, config) {
   // adapter — exclude both shapes from the "individual" set so a config like
   // ["trees", "birch"] doesn't treat raw `trees` as individual.
   const categoryAllergenKeys = [
-    "trees_cat", "grass_cat", "weeds_cat",
-    "trees", "grass", "weeds",
+    "trees_cat",
+    "grass_cat",
+    "weeds_cat",
+    "trees",
+    "grass",
+    "weeds",
   ];
   // The recommended set for the warning's suggested fix (NA users should
   // switch to *_cat, not raw category names).
   const recommendedCategoryKeys = ["trees_cat", "grass_cat", "weeds_cat"];
-  const requestedIndividual = (config.allergens || []).filter(
+  const requestedIndividual = (allergens || []).filter(
     (a) => !categoryAllergenKeys.includes(a),
   );
   // Only evaluate when at least one category sensor was actually found (guards
@@ -567,18 +629,18 @@ export async function fetchForecast(hass, config) {
       // Require non-empty forecast to avoid false positives on synthetic/empty fixtures.
       const allDetailsEmpty = categorySensorsFound.every((sensor) => {
         const attrs = sensor.attributes || {};
-        const forecast = attrs.forecast || [];
+        const forecast: KleenexItem[] = attrs.forecast || [];
         if (forecast.length === 0) return false;
         const detailsEmpty = (attrs.details || []).length === 0;
         const forecastDetailsEmpty = forecast.every(
-          (f) => (f.details || []).length === 0,
+          (f) => ((f.details as KleenexItem[]) || []).length === 0,
         );
         return detailsEmpty && forecastDetailsEmpty;
       });
       // Only emit the warning when the user hasn't already configured a recommended
       // category allergen (if they have *_cat, they are already on the right path).
       const hasAnyCategoryConfigured = recommendedCategoryKeys.some((k) =>
-        (config.allergens || []).includes(k),
+        (allergens || []).includes(k),
       );
       if (allDetailsEmpty && !hasAnyCategoryConfigured) {
         const warnKey = `${config.location || ""}|${config.entity_prefix || ""}|${config.entity_suffix || ""}`;
@@ -593,55 +655,76 @@ export async function fetchForecast(hass, config) {
   }
 
   if (debug) {
-    console.debug(
-      `[Kleenex] === ALLERGEN DATA COLLECTION COMPLETE ===`,
-    );
+    console.debug(`[Kleenex] === ALLERGEN DATA COLLECTION COMPLETE ===`);
     console.debug(
       `[Kleenex] Collected data for ${allergenData.size} allergens:`,
       Array.from(allergenData.keys()),
     );
 
     if (allergenData.size === 0) {
-      console.debug("[Kleenex] WARNING: No allergen data collected! This will result in empty sensors array.");
+      console.debug(
+        "[Kleenex] WARNING: No allergen data collected! This will result in empty sensors array.",
+      );
       console.debug("[Kleenex] Checking config:", {
         allergens: config.allergens,
         location: config.location,
-        filteredSensorCount: kleenexSensors.length
+        filteredSensorCount: kleenexSensors.length,
       });
-      console.debug("[Kleenex] Sensor entity IDs processed:", kleenexSensors.map(s => s.entity_id));
-      console.debug("[Kleenex] Was any category sensor found that matches config allergens?");
+      console.debug(
+        "[Kleenex] Sensor entity IDs processed:",
+        kleenexSensors.map((s) => s.entity_id),
+      );
+      console.debug(
+        "[Kleenex] Was any category sensor found that matches config allergens?",
+      );
     } else {
       console.debug("[Kleenex] DETAILED ALLERGEN DATA ANALYSIS:");
       allergenData.forEach((data, allergen) => {
-        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(allergen);
-        console.debug(`[Kleenex] === ${allergen.toUpperCase()} (${isCategory ? 'CATEGORY' : 'INDIVIDUAL'}) ===`);
+        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(
+          allergen,
+        );
+        console.debug(
+          `[Kleenex] === ${allergen.toUpperCase()} (${isCategory ? "CATEGORY" : "INDIVIDUAL"}) ===`,
+        );
         console.debug(`[Kleenex] Source: ${data.source}`);
         console.debug(`[Kleenex] Entity: ${data.entity_id}`);
         console.debug(`[Kleenex] Levels array length: ${data.levels.length}`);
-        console.debug(`[Kleenex] Valid levels count (>= 0): ${data.levels.filter(l => l.level >= 0).length}`);
+        console.debug(
+          `[Kleenex] Valid levels count (>= 0): ${data.levels.filter((l) => l.level >= 0).length}`,
+        );
 
         // Show detailed day-by-day data
         data.levels.forEach((level, i) => {
-          const dayName = i === 0 ? 'TODAY' : `DAY+${i}`;
-          console.debug(`[Kleenex] ${allergen} ${dayName}: date=${level.date?.toISOString().split('T')[0]}, level=${level.level}, value=${level.value}`);
+          const dayName = i === 0 ? "TODAY" : `DAY+${i}`;
+          console.debug(
+            `[Kleenex] ${allergen} ${dayName}: date=${level.date?.toISOString().split("T")[0]}, level=${level.level}, value=${level.value}`,
+          );
         });
 
         // Check if today has valid data
         const todayLevel = data.levels[0]?.level;
         const hasValidToday = todayLevel !== undefined && todayLevel >= 0;
-        console.debug(`[Kleenex] ${allergen} TODAY DATA CHECK: hasValidToday=${hasValidToday}, todayLevel=${todayLevel}`);
+        console.debug(
+          `[Kleenex] ${allergen} TODAY DATA CHECK: hasValidToday=${hasValidToday}, todayLevel=${todayLevel}`,
+        );
       });
     }
   }
 
   // Build sensor data for each allergen
   if (debug) {
-    console.debug(`[Kleenex] === BUILDING SENSORS FROM ${allergenData.size} COLLECTED ALLERGENS ===`);
+    console.debug(
+      `[Kleenex] === BUILDING SENSORS FROM ${allergenData.size} COLLECTED ALLERGENS ===`,
+    );
     console.debug(`[Kleenex] pollen_threshold = ${pollen_threshold}`);
     allergenData.forEach((data, allergen) => {
-      console.debug(`[Kleenex] Building sensor for: ${allergen}, source: ${data.source}, levels_count: ${data.levels.length}`);
+      console.debug(
+        `[Kleenex] Building sensor for: ${allergen}, source: ${data.source}, levels_count: ${data.levels.length}`,
+      );
       if (data.levels[0]) {
-        console.debug(`[Kleenex] ${allergen} today data: level=${data.levels[0].level}, value=${data.levels[0].value}`);
+        console.debug(
+          `[Kleenex] ${allergen} today data: level=${data.levels[0].level}, value=${data.levels[0].value}`,
+        );
       } else {
         console.debug(`[Kleenex] ${allergen} WARNING: No today data found!`);
       }
@@ -649,14 +732,15 @@ export async function fetchForecast(hass, config) {
   }
 
   // Build sensors array in the correct order
-  const allergenKeys = config.sort === "none"
-    ? config.allergens.filter(allergen => allergenData.has(allergen))
-    : Array.from(allergenData.keys());
+  const allergenKeys =
+    config.sort === "none"
+      ? allergens.filter((allergen) => allergenData.has(allergen))
+      : Array.from(allergenData.keys());
 
   if (debug) {
     console.debug(
       `[Kleenex] Building sensors array ${config.sort === "none" ? "in config order" : "in discovery order"}:`,
-      allergenKeys
+      allergenKeys,
     );
   }
 
@@ -665,15 +749,21 @@ export async function fetchForecast(hass, config) {
     if (!allergenInfo) continue;
 
     try {
-      const dict = {};
+      const dict = {} as PollenSensor;
       dict.allergenReplaced = allergenKey;
       dict.entity_id = allergenInfo.entity_id;
       dict.days = []; // Initialize days array
 
       // Allergen name resolution
-      const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergenKey, {
-        fullPhrases, shortPhrases, abbreviated: config.allergens_abbreviated, lang,
-      });
+      const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+        allergenKey,
+        {
+          fullPhrases,
+          shortPhrases,
+          abbreviated: config.allergens_abbreviated as boolean,
+          lang,
+        },
+      );
       dict.allergenCapitalized = allergenCapitalized;
       dict.allergenShort = allergenShort;
 
@@ -708,12 +798,15 @@ export async function fetchForecast(hass, config) {
       let levelNames = levelNamesDefault.slice();
       if (Array.isArray(userLevels)) {
         if (userLevels.length === 7) {
-          levelNames = buildLevelNames(userLevels, lang);
+          levelNames = buildLevelNames(
+            userLevels as Array<string | null | undefined>,
+            lang,
+          );
         } else if (userLevels.length === defaultNumLevels) {
           const map = [0, 1, 3, 5, 6];
           map.forEach((lvl, idx) => {
             const val = userLevels[idx];
-            if (val != null && val !== "") levelNames[lvl] = val;
+            if (val != null && val !== "") levelNames[lvl] = val as string;
           });
         }
       }
@@ -723,14 +816,21 @@ export async function fetchForecast(hass, config) {
       for (let i = 0; i < days_to_show; i++) {
         const dayData = levels[i];
         const d = dayData.date;
-        const diff = Math.round((d - today) / 86400000);
+        const diff = Math.round((d.getTime() - today.getTime()) / 86400000);
 
-        const dayLabel = buildDayLabel(d, diff, { daysRelative, dayAbbrev, daysUppercase, userDays, lang, locale });
+        const dayLabel = buildDayLabel(d, diff, {
+          daysRelative,
+          dayAbbrev,
+          daysUppercase,
+          userDays,
+          lang,
+          locale,
+        });
 
         // Scale level for display (keep raw 0-4 for state, but scale for level names like PEU)
         const level = dayData.level; // Raw level (0-4)
         // Calculate scaled level for level names (like PEU does)
-        let scaledLevel;
+        let scaledLevel: number;
         if (level < 0) {
           scaledLevel = level; // Keep -1 as is
         } else if (level < 2) {
@@ -739,15 +839,14 @@ export async function fetchForecast(hass, config) {
           scaledLevel = Math.ceil((level * 6) / 4);
         }
 
-        const dayObj = {
+        const dayObj: ForecastDay = {
           name: dict.allergenCapitalized,
           day: dayLabel,
           state: level, // Raw level for sorting and threshold checking
           state_text:
             scaledLevel < 0
               ? noInfoLabel
-              : levelNames[scaledLevel] ||
-                t(`card.levels.${scaledLevel}`, lang),
+              : levelNames[scaledLevel] || t(`card.levels.${scaledLevel}`, lang),
           value: dayData.value,
           // Raw ppm measurement, surfaced only when the user opts into
           // numeric_value_raw (resolveNumericValue). state stays the level.
@@ -758,8 +857,7 @@ export async function fetchForecast(hass, config) {
           description:
             scaledLevel < 0
               ? noInfoLabel
-              : levelNames[scaledLevel] ||
-                t(`card.levels.${scaledLevel}`, lang),
+              : levelNames[scaledLevel] || t(`card.levels.${scaledLevel}`, lang),
         };
 
         dict[`day${i}`] = dayObj;
@@ -770,25 +868,37 @@ export async function fetchForecast(hass, config) {
       const shouldAdd = meetsThreshold(dict.days, pollen_threshold);
 
       if (debug) {
-        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(allergenKey);
+        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(
+          allergenKey,
+        );
         console.debug(
-          `[Kleenex] === THRESHOLD CHECK for ${allergenKey} (${isCategory ? 'CATEGORY' : 'INDIVIDUAL'}) ===`,
+          `[Kleenex] === THRESHOLD CHECK for ${allergenKey} (${isCategory ? "CATEGORY" : "INDIVIDUAL"}) ===`,
         );
         console.debug(`[Kleenex] pollen_threshold = ${pollen_threshold}`);
         console.debug(`[Kleenex] days.length = ${dict.days.length}`);
 
         // Show detailed level values for debugging
         dict.days.forEach((day, i) => {
-          console.debug(`[Kleenex] ${allergenKey} day${i}: state=${day.state}, value=${day.value}, day=${day.day}, meets_threshold=${day.state >= pollen_threshold}`);
+          console.debug(
+            `[Kleenex] ${allergenKey} day${i}: state=${day.state}, value=${day.value}, day=${day.day}, meets_threshold=${day.state >= pollen_threshold}`,
+          );
         });
 
-        console.debug(`[Kleenex] shouldAdd = ${shouldAdd} (any day >= ${pollen_threshold}, or threshold===0)`);
+        console.debug(
+          `[Kleenex] shouldAdd = ${shouldAdd} (any day >= ${pollen_threshold}, or threshold===0)`,
+        );
 
         if (isCategory && !shouldAdd) {
-          console.debug(`[Kleenex] ❌ CATEGORY ALLERGEN ${allergenKey} FILTERED OUT BY THRESHOLD!`);
-          console.debug(`[Kleenex] Highest level found: ${Math.max(...dict.days.map(d => d.state))}`);
+          console.debug(
+            `[Kleenex] ❌ CATEGORY ALLERGEN ${allergenKey} FILTERED OUT BY THRESHOLD!`,
+          );
+          console.debug(
+            `[Kleenex] Highest level found: ${Math.max(...dict.days.map((d) => d.state))}`,
+          );
         } else if (isCategory && shouldAdd) {
-          console.debug(`[Kleenex] ✅ CATEGORY ALLERGEN ${allergenKey} PASSES THRESHOLD CHECK`);
+          console.debug(
+            `[Kleenex] ✅ CATEGORY ALLERGEN ${allergenKey} PASSES THRESHOLD CHECK`,
+          );
         }
       }
 
@@ -802,7 +912,7 @@ export async function fetchForecast(hass, config) {
       } else {
         if (debug) {
           console.debug(
-            `[Kleenex] SENSOR FILTERED OUT for ${allergenKey}: threshold not met (highest level: ${Math.max(...dict.days.map(d => d.state))})`,
+            `[Kleenex] SENSOR FILTERED OUT for ${allergenKey}: threshold not met (highest level: ${Math.max(...dict.days.map((d) => d.state))})`,
           );
         }
       }
@@ -821,8 +931,8 @@ export async function fetchForecast(hass, config) {
         (s) =>
           !["trees_cat", "grass_cat", "weeds_cat"].includes(s.allergenReplaced),
       );
-      sortSensors(categoryAllergens, config.sort);
-      sortSensors(individualAllergens, config.sort);
+      sortSensors(categoryAllergens, config.sort as string);
+      sortSensors(individualAllergens, config.sort as string);
       sensors = [...categoryAllergens, ...individualAllergens];
 
       if (debug) {
@@ -831,7 +941,7 @@ export async function fetchForecast(hass, config) {
         );
       }
     } else {
-      sortSensors(sensors, config.sort);
+      sortSensors(sensors, config.sort as string);
 
       if (debug) {
         console.debug(
@@ -853,24 +963,33 @@ export async function fetchForecast(hass, config) {
       console.debug("[Kleenex] ❌ NO SENSORS RETURNED! Checking why:");
       console.debug(`[Kleenex] - allergenData.size: ${allergenData.size}`);
       console.debug(`[Kleenex] - pollen_threshold: ${pollen_threshold}`);
-      console.debug(`[Kleenex] - config.allergens: [${config.allergens.join(', ')}]`);
+      console.debug(`[Kleenex] - config.allergens: [${allergens.join(", ")}]`);
 
       // Check if any allergens were filtered by threshold
       let thresholdFiltered = 0;
       allergenData.forEach((data, allergen) => {
-        const hasValidLevel = data.levels.some(l => l.level >= pollen_threshold);
+        const hasValidLevel = data.levels.some(
+          (l) => l.level >= pollen_threshold,
+        );
         if (!hasValidLevel) {
           thresholdFiltered++;
-          console.debug(`[Kleenex] - ${allergen} filtered by threshold (max level: ${Math.max(...data.levels.map(l => l.level))})`);
+          console.debug(
+            `[Kleenex] - ${allergen} filtered by threshold (max level: ${Math.max(...data.levels.map((l) => l.level))})`,
+          );
         }
       });
-      console.debug(`[Kleenex] - allergens filtered by threshold: ${thresholdFiltered}`);
-
+      console.debug(
+        `[Kleenex] - allergens filtered by threshold: ${thresholdFiltered}`,
+      );
     } else {
       console.debug("[Kleenex] ✅ SENSORS FOUND:");
       sensors.forEach((sensor, i) => {
-        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(sensor.allergenReplaced);
-        console.debug(`[Kleenex] ${i+1}. ${sensor.allergenReplaced} (${isCategory ? 'CATEGORY' : 'INDIVIDUAL'}): day0_state=${sensor.day0?.state}, entity_id=${sensor.entity_id}`);
+        const isCategory = ["trees_cat", "grass_cat", "weeds_cat"].includes(
+          sensor.allergenReplaced,
+        );
+        console.debug(
+          `[Kleenex] ${i + 1}. ${sensor.allergenReplaced} (${isCategory ? "CATEGORY" : "INDIVIDUAL"}): day0_state=${sensor.day0?.state}, entity_id=${sensor.entity_id}`,
+        );
       });
     }
 

--- a/src/adapters/kleenex/index.ts
+++ b/src/adapters/kleenex/index.ts
@@ -1,6 +1,13 @@
-// src/adapters/kleenex/index.js
+// src/adapters/kleenex/index.ts
 // Public facade: re-exports all named exports from sub-modules.
-export { stubConfigKleenex, KLEENEX_ALLERGEN_MAP, KLEENEX_ALLERGEN_CATEGORIES, INDIVIDUAL_TO_CATEGORY, DOMAIN, capitalize } from "./constants.js";
+export {
+  stubConfigKleenex,
+  KLEENEX_ALLERGEN_MAP,
+  KLEENEX_ALLERGEN_CATEGORIES,
+  INDIVIDUAL_TO_CATEGORY,
+  DOMAIN,
+  capitalize,
+} from "./constants.js";
 export { ppmToLevel } from "./levels.js";
 export { resolveEntityIds } from "./discovery.js";
 export { fetchForecast } from "./forecast.js";

--- a/src/adapters/kleenex/levels.ts
+++ b/src/adapters/kleenex/levels.ts
@@ -1,9 +1,9 @@
-// src/adapters/kleenex/levels.js
+// src/adapters/kleenex/levels.ts
 import { KLEENEX_ALLERGEN_CATEGORIES } from "./constants.js";
 
 // Convert numeric ppm values to level (0-4) using category-specific thresholds
 // Based on kleenex integration thresholds: trees [95, 207, 703], weeds [20, 77, 266], grass [29, 60, 341]
-export function ppmToLevel(value, allergenName) {
+export function ppmToLevel(value: unknown, allergenName: string): number {
   const numVal = Number(value);
   if (isNaN(numVal) || numVal < 0) return -1;
   if (numVal === 0) return 0;
@@ -12,7 +12,7 @@ export function ppmToLevel(value, allergenName) {
   const category = KLEENEX_ALLERGEN_CATEGORIES[allergenName] || "trees"; // Default to trees
 
   // Category-specific thresholds: [low, moderate, high] -> levels 1, 2, 3, with 4 being very-high
-  let thresholds;
+  let thresholds: number[];
   switch (category) {
     case "trees":
       thresholds = [95, 207, 703];

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -1,4 +1,4 @@
-// src/adapters/msw.js
+// src/adapters/msw.ts
 // MeteoSwiss / hass-swissweather adapter.
 //
 // Reads current pollen level from SwissPollenLevelSensor entities created by
@@ -13,7 +13,17 @@
 //     (sensor.<device-slug>_pollen_<allergen>_level_at_<station>) is handled.
 //   - Stale config_entry_id values fall back to the first discovered location,
 //     mirroring DWD/GPL/GP/SILAM/Atmo recovery behavior.
+//
+// MSW keeps its own resolveEntityIds and fetchForecast rather than the shared
+// base helpers: its discovery-only resolveEntityIds falls back to the first
+// location for ANY unmatched key (not just config-entry ids as
+// createEntityResolver's recoverStaleConfig does) and has no manual/template
+// path, and its fetchForecast emits a single current-day row rather than the
+// multi-day window runForecastScaffold is built around.
 
+import type { HomeAssistant } from "../types/home-assistant.js";
+import type { CardConfig, AdapterStubConfig } from "../types/config.js";
+import type { PollenSensor, ForecastDay } from "../types/sensor.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import {
@@ -25,11 +35,16 @@ import {
   resolveAllergenNames,
   discoverEntitiesByDevice,
   resolveLocationByKey,
+  type DiscoveryContext,
+  type DiscoveredLocation,
 } from "../utils/adapter-helpers.js";
+
+// The subset of the discovery result msw uses (config-entry keyed locations).
+type MswDiscovery = { locations: Map<string, DiscoveredLocation> };
 
 // hass-swissweather entity slug -> canonical allergen key.
 // "grasses" is the slug used in entity IDs by hass-swissweather.
-const MSW_POLLEN_TYPES = {
+const MSW_POLLEN_TYPES: Record<string, string> = {
   birch: "birch",
   grasses: "grass",
   alder: "alder",
@@ -44,7 +59,8 @@ const MSW_POLLEN_TYPES = {
 // level count for editor phrases, level circles, and color mapping; we do
 // not stretch native counts onto a shared 0-6 gradient. Same shape as
 // DWD (0-3, four levels) and GPL/GP (0-5, six levels).
-const MSW_LEVEL_MAP = {
+// TODO(#259-normalize): preserve this native 0-4 scale.
+const MSW_LEVEL_MAP: Record<string, number> = {
   none: 0,
   low: 1,
   medium: 2,
@@ -59,14 +75,14 @@ const MSW_LEVEL_MAP = {
 const MSW_LEVEL_RE =
   /(?:^sensor\.|_)pollen_(birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
 
-function classifyMswEntity(eid) {
+function classifyMswEntity(eid: string): string | null {
   if (typeof eid !== "string") return null;
   const m = MSW_LEVEL_RE.exec(eid);
   if (!m) return null;
   return MSW_POLLEN_TYPES[m[1]] || null;
 }
 
-export const stubConfigMSW = {
+export const stubConfigMSW: AdapterStubConfig = {
   integration: "msw",
   location: "",
   allergens: ["birch", "grass", "alder", "hazel", "beech", "ash", "oak"],
@@ -122,18 +138,16 @@ export const stubConfigMSW = {
  *   "MeteoSwiss at 8000-KLO" -> "8000-KLO"
  *   "Bern"                   -> "Bern"   (user-renamed via name_by_user)
  *   "Zürich"                 -> "Zürich" (custom device.name set elsewhere)
- *
- * @param {{ device?: { name?: string, name_by_user?: string }, state?: { attributes?: { friendly_name?: string } } }} ctx
- * @returns {string}
  */
-function resolveMswLabel(ctx) {
+function resolveMswLabel(ctx: DiscoveryContext): string {
   const device = ctx?.device;
   if (device?.name_by_user) return device.name_by_user;
   if (device?.name) {
     const stripped = device.name.replace(/^MeteoSwiss at\s+/i, "");
     return stripped || device.name;
   }
-  if (ctx?.state?.attributes?.friendly_name) return ctx.state.attributes.friendly_name;
+  if (ctx?.state?.attributes?.friendly_name)
+    return ctx.state.attributes.friendly_name;
   return "Auto";
 }
 
@@ -144,17 +158,17 @@ function resolveMswLabel(ctx) {
  *   1. Device registry: hass.devices with identifiers ["swissweather", ...].
  *   2. Entity registry: hass.entities filtered by platform === "swissweather".
  *   3. Regex fallback: hass.states scanned for the level-entity pattern.
- *
- * @param {Object} hass
- * @param {boolean} [debug]
- * @returns {{ locations: Map<string, { label: string, entities: Map<string, string>, deviceId?: string }> }}
  */
-export function discoverMswSensors(hass, debug = false) {
+export function discoverMswSensors(
+  hass: HomeAssistant,
+  debug = false,
+): MswDiscovery {
   if (!hass) return { locations: new Map() };
 
   // Tier 3 fallback: device-name prefix (\w+_)* covers slugified
   // "meteoswiss_at_8000_klo_" and friendly renames like "bern_".
-  const fallbackRe = /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
+  const fallbackRe =
+    /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
 
   const { locations } = discoverEntitiesByDevice(hass, {
     platform: "swissweather",
@@ -173,13 +187,12 @@ export function discoverMswSensors(hass, debug = false) {
  * resolved location. Falls back to the first discovered location when the
  * configured location key does not match (auto-recovery from stale
  * config_entry_id).
- *
- * @param {Object} cfg
- * @param {Object} hass
- * @param {boolean} [debug]
- * @returns {Map<string, string>} allergen -> entity_id
  */
-export function resolveEntityIds(cfg, hass, debug = false) {
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
   if (!hass?.states) return new Map();
 
   const discovery = discoverMswSensors(hass, debug);
@@ -188,7 +201,7 @@ export function resolveEntityIds(cfg, hass, debug = false) {
     return new Map();
   }
 
-  let resolved = resolveLocationByKey(discovery, cfg?.location);
+  let resolved = resolveLocationByKey(discovery, cfg?.location as string);
   if (!resolved) {
     // Stale or unknown location key: fall back to first discovered location
     // (sorted lex/numeric inside resolveLocationByKey when cfgLocation empty).
@@ -202,14 +215,16 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   if (!resolved) return new Map();
 
   const [, location] = resolved;
-  const map = new Map();
-  for (const allergen of cfg?.allergens || []) {
+  const map = new Map<string, string>();
+  for (const allergen of (cfg?.allergens as string[] | undefined) || []) {
     const eid = location.entities.get(allergen);
     if (eid) {
       map.set(allergen, eid);
       if (debug) console.debug(`[MSW:resolveEntityIds] ${allergen} -> ${eid}`);
     } else if (debug) {
-      console.debug(`[MSW:resolveEntityIds] No entity for '${allergen}' in resolved location`);
+      console.debug(
+        `[MSW:resolveEntityIds] No entity for '${allergen}' in resolved location`,
+      );
     }
   }
   return map;
@@ -218,26 +233,39 @@ export function resolveEntityIds(cfg, hass, debug = false) {
 /**
  * Fetch current pollen levels from hass-swissweather entities.
  * Returns one day (today) per allergen.
- *
- * @param {Object} hass
- * @param {Object} config
- * @returns {Promise<Array>} Sensor dicts compatible with pollenprognos-card renderer
  */
-export async function fetchForecast(hass, config) {
-  if (!hass?.states || !config.allergens?.length) return [];
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
+  if (!hass?.states || !(config.allergens as string[] | undefined)?.length)
+    return [];
   const debug = Boolean(config.debug);
 
   const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
-    getLangAndLocale(hass, config, stubConfigMSW.date_locale);
-  const { fullPhrases, shortPhrases, userLevels, userDays } =
-    mergePhrases(config, lang);
+    getLangAndLocale(
+      hass,
+      config,
+      stubConfigMSW.date_locale as string | undefined,
+    );
+  const { fullPhrases, shortPhrases, userLevels, userDays } = mergePhrases(
+    config,
+    lang,
+  );
   // Five-level scale: defaults from card.levels5.0..4, native-indexed.
-  const levelNames = buildLevelNamesForScale(5, userLevels, lang);
-  const pollen_threshold = config.pollen_threshold ?? stubConfigMSW.pollen_threshold;
+  const levelNames = buildLevelNamesForScale(
+    5,
+    userLevels as Array<string | null | undefined>,
+    lang,
+  );
+  const pollen_threshold =
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigMSW.pollen_threshold as number);
 
-  if (debug) console.debug("MSW adapter: start fetchForecast", { config, lang });
+  if (debug)
+    console.debug("MSW adapter: start fetchForecast", { config, lang });
 
-  const sensors = [];
+  const sensors: PollenSensor[] = [];
   const entityMap = resolveEntityIds(config, hass, debug);
 
   const today = new Date();
@@ -251,7 +279,7 @@ export async function fetchForecast(hass, config) {
     locale,
   });
 
-  for (const allergen of config.allergens) {
+  for (const allergen of config.allergens as string[]) {
     try {
       const entityId = entityMap.get(allergen);
       if (!entityId) continue;
@@ -259,23 +287,25 @@ export async function fetchForecast(hass, config) {
       const stateObj = hass.states[entityId];
       if (!stateObj) continue;
 
-      const rawState = typeof stateObj.state === "string"
-        ? stateObj.state.toLowerCase()
-        : "";
+      const rawState =
+        typeof stateObj.state === "string" ? stateObj.state.toLowerCase() : "";
       const level = MSW_LEVEL_MAP[rawState];
       if (level === undefined) continue; // unavailable / unknown / unexpected value
 
-      const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergen, {
-        fullPhrases,
-        shortPhrases,
-        abbreviated: config.allergens_abbreviated,
-        lang,
-        configKey: allergen,
-      });
+      const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+        allergen,
+        {
+          fullPhrases,
+          shortPhrases,
+          abbreviated: config.allergens_abbreviated as boolean,
+          lang,
+          configKey: allergen,
+        },
+      );
 
       const stateText = levelNames[level] ?? rawState;
 
-      const day0 = {
+      const day0: ForecastDay = {
         name: allergenCapitalized,
         day: dayLabel,
         state: level,
@@ -283,7 +313,7 @@ export async function fetchForecast(hass, config) {
         state_text: stateText,
       };
 
-      const dict = {
+      const dict: PollenSensor = {
         allergenReplaced: allergen,
         allergenCapitalized,
         allergenShort,
@@ -298,7 +328,7 @@ export async function fetchForecast(hass, config) {
     }
   }
 
-  sortSensors(sensors, config.sort);
+  sortSensors(sensors, config.sort as string);
 
   if (debug) console.debug("MSW adapter complete sensors:", sensors);
   return sensors;

--- a/src/types/sensor.ts
+++ b/src/types/sensor.ts
@@ -33,6 +33,10 @@ export interface ForecastDay {
   raw_value?: number | string | null;
   /** Per-day icon key: peu, silam. */
   icon?: string;
+  /** kleenex-specific: raw ppm measurement carried alongside the level. */
+  value?: number | string;
+  /** kleenex-specific: localized level description (mirrors state_text). */
+  description?: string;
   /** plu-specific: category thresholds carried through for display. */
   thresholds?: unknown;
   /** plu-specific: raw level string from the source. */
@@ -81,6 +85,8 @@ export interface PollenSensor {
   topPollen?: unknown;
   /** In-season plant list: gpl. */
   plantsInSeasonList?: unknown;
+  /** kleenex-specific: per-sensor 0-6 level-name array carried to the render path. */
+  levelNames?: string[];
   /** Raw entity attributes carried through: plu. */
   attributes?: Record<string, any>;
 }


### PR DESCRIPTION
Seventh PR of the v4.0.0 migration (#259): second adapter batch to TypeScript — msw, irmkmi and the kleenex/ directory. Golden snapshots byte-identical throughout; no behaviour changes.

## What

- **msw** and **irmkmi**: TypeScript conversions kept deliberately adapter-local. Their discovery-only `resolveEntityIds` falls back to the first location for any unmatched key (a laxer semantic than the shared resolver's stale-config recovery) and their `fetchForecast` emits a single current-day row rather than the multi-day window the shared scaffold models — forcing either onto the base would change semantics or bloat it with hooks nothing else needs. Native 0-4 scales preserved, marked `TODO(#259-normalize)`.
- **kleenex/**: all five modules converted (constants, levels, discovery, forecast, index barrel). The NA-zone warning dedup and its `_resetNaWarningsForTest` hook are preserved exactly; the multi-pass category/detail collection and two-level sort stay adapter-local.
- **`src/types/sensor.ts`**: three additive fields the kleenex goldens already carry (`ForecastDay.value`, `ForecastDay.description`, `PollenSensor.levelNames`) are now declared in the contract, following the existing pattern for plu-specific fields. Type-only; no export surface touched.

## Verification

- Golden snapshots byte-identical after each adapter (diff against dev over test/ is empty).
- 1317/1317 tests green, test files untouched; `tsc --noEmit` clean; eslint 0 errors; build within budget.
