### PR TITLE
(adapters) Convert gp, gpl, plu and the adapter registry to TypeScript

### DIFF
--- a/src/adapter-registry.ts
+++ b/src/adapter-registry.ts
@@ -1,7 +1,9 @@
-// src/adapter-registry.js
+// src/adapter-registry.ts
 // Thin alias layer: maps integration ID → { module, stub }.
 // Replaces scattered if/else chains in card and editor.
 
+import type { AdapterModule } from "./types/adapter.js";
+import type { AdapterStubConfig } from "./types/config.js";
 import * as PP from "./adapters/pp.js";
 import * as DWD from "./adapters/dwd.js";
 import * as PEU from "./adapters/peu.js";
@@ -14,7 +16,12 @@ import * as GP from "./adapters/gp/index.js";
 import * as MSW from "./adapters/msw.js";
 import * as IRMKMI from "./adapters/irmkmi.js";
 
-const registry = {
+interface RegistryEntry {
+  module: AdapterModule;
+  stub: AdapterStubConfig;
+}
+
+const registry: Record<string, RegistryEntry> = {
   pp: { module: PP, stub: PP.stubConfigPP },
   dwd: { module: DWD, stub: DWD.stubConfigDWD },
   peu: { module: PEU, stub: PEU.stubConfigPEU },
@@ -28,14 +35,16 @@ const registry = {
   irmkmi: { module: IRMKMI, stub: IRMKMI.stubConfigIRMKMI },
 };
 
-export function getAdapter(id) {
-  return registry[id]?.module;
+export function getAdapter(id: string | undefined): AdapterModule | undefined {
+  return id ? registry[id]?.module : undefined;
 }
 
-export function getStubConfig(id) {
-  return registry[id]?.stub;
+export function getStubConfig(
+  id: string | undefined,
+): AdapterStubConfig | undefined {
+  return id ? registry[id]?.stub : undefined;
 }
 
-export function getAllAdapterIds() {
+export function getAllAdapterIds(): string[] {
   return Object.keys(registry);
 }

--- a/src/adapters/gp/constants.ts
+++ b/src/adapters/gp/constants.ts
@@ -1,4 +1,5 @@
-// src/adapters/gp/constants.js
+// src/adapters/gp/constants.ts
+import type { AdapterStubConfig } from "../../types/config.js";
 import { LEVELS_DEFAULTS } from "../../utils/levels-defaults.js";
 
 // Domain used by svenove/home-assistant-google-pollen
@@ -9,7 +10,7 @@ export const GP_DOMAIN = "google_pollen";
 // by scripts/fetch-gp-translations.js. Uses direct string lookup instead of
 // slugify, so no transliteration dependency is needed at runtime.
 // 478 entries across 35 languages (+ manual additions for rare plant types)
-export const GP_DISPLAY_NAME_MAP = {
+export const GP_DISPLAY_NAME_MAP: Record<string, string> = {
   // Manual additions: English display_names for plant types not returned by
   // the API for Berlin/Tokyo (the script's query locations), but present in
   // svenove's PLANT_TYPES list and potentially returned for other regions.
@@ -497,7 +498,7 @@ export const GP_DISPLAY_NAME_MAP = {
 // display_name string. When a collision is detected during sensor discovery,
 // classifySensorAsPlant uses this map to get the plant interpretation.
 // 17 entries where GRASS category and GRAMINALES plant share display_name
-export const GP_COLLISION_PLANTS = {
+export const GP_COLLISION_PLANTS: Record<string, string> = {
   "cỏ": "graminales",
   "fű": "graminales",
   "grama": "graminales",
@@ -520,7 +521,7 @@ export const GP_COLLISION_PLANTS = {
 // Base allergens (categories) always available
 export const GP_BASE_ALLERGENS = ["grass_cat", "trees_cat", "weeds_cat"];
 
-export const stubConfigGP = {
+export const stubConfigGP: AdapterStubConfig = {
   integration: "gp",
   location: "",
   entity_prefix: "",

--- a/src/adapters/gp/discovery.ts
+++ b/src/adapters/gp/discovery.ts
@@ -1,7 +1,27 @@
-// src/adapters/gp/discovery.js
-import { normalizeManualPrefix, discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
+// src/adapters/gp/discovery.ts
+import type {
+  HomeAssistant,
+  HassEntity,
+  EntityRegistryDisplayEntry,
+} from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
+import {
+  normalizeManualPrefix,
+  discoverEntitiesByDevice,
+  resolveLocationByKey,
+  isConfigEntryId,
+  type DiscoveredLocation,
+} from "../../utils/adapter-helpers.js";
 import { cleanDeviceLabel } from "../../utils/device-label.js";
-import { GP_DOMAIN, GP_DISPLAY_NAME_MAP, GP_COLLISION_PLANTS, GP_BASE_ALLERGENS } from "./constants.js";
+import {
+  GP_DOMAIN,
+  GP_DISPLAY_NAME_MAP,
+  GP_COLLISION_PLANTS,
+  GP_BASE_ALLERGENS,
+} from "./constants.js";
+
+// The subset of the discovery result gp uses (config-entry keyed locations).
+type GpDiscovery = { locations: Map<string, DiscoveredLocation> };
 
 // Regex to extract pollen code from unique_id.
 // Format: google_pollen_{code}_{lat}_{lon}
@@ -12,14 +32,18 @@ const UNIQUE_ID_RE = /^google_pollen_(.+?)_-?\d/;
  * Extract the pollen code from a unique_id string.
  * Returns the lowercase code (e.g. "birch", "tree") or null.
  */
-function codeFromUniqueId(uniqueId) {
+function codeFromUniqueId(uniqueId: string | undefined): string | null {
   if (!uniqueId) return null;
   const m = UNIQUE_ID_RE.exec(uniqueId);
   return m ? m[1].toLowerCase() : null;
 }
 
 // Category codes used in unique_id for the three base category sensors.
-const CATEGORY_CODES = { grass: "grass_cat", tree: "trees_cat", weed: "weeds_cat" };
+const CATEGORY_CODES: Record<string, string> = {
+  grass: "grass_cat",
+  tree: "trees_cat",
+  weed: "weeds_cat",
+};
 
 /**
  * Map a raw pollen code (from unique_id) to an allergen key.
@@ -27,7 +51,7 @@ const CATEGORY_CODES = { grass: "grass_cat", tree: "trees_cat", weed: "weeds_cat
  * Plant codes are kept as-is, since canonicalization for display/icons happens
  * later via resolveAllergenNames/ALLERGEN_ICON_FALLBACK.
  */
-function classifyCode(code) {
+function classifyCode(code: string | null): string | null {
   if (!code) return null;
   return CATEGORY_CODES[code] || code;
 }
@@ -37,7 +61,10 @@ function classifyCode(code) {
  * Used when a collision is detected and we need the plant interpretation.
  * Returns the raw pollen code (not canonicalized) to match GPL behavior.
  */
-function classifySensorAsPlant(state, entityEntry) {
+function classifySensorAsPlant(
+  state: HassEntity | undefined,
+  entityEntry: EntityRegistryDisplayEntry | null | undefined,
+): string | null {
   const code = codeFromUniqueId(entityEntry?.unique_id);
   if (code) return code;
 
@@ -58,7 +85,10 @@ function classifySensorAsPlant(state, entityEntry) {
  * 2. display_name direct lookup in GP_DISPLAY_NAME_MAP (trimmed, lowercased)
  * 3. Returns null if unclassifiable
  */
-export function classifySensor(state, entityEntry) {
+export function classifySensor(
+  state: HassEntity | undefined,
+  entityEntry: EntityRegistryDisplayEntry | null | undefined,
+): string | null {
   // 1. unique_id (best: always English pollen code)
   const code = codeFromUniqueId(entityEntry?.unique_id);
   if (code) {
@@ -88,7 +118,10 @@ export function classifySensor(state, entityEntry) {
  *
  * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
  */
-export function discoverGpSensors(hass, debug = false) {
+export function discoverGpSensors(
+  hass: HomeAssistant,
+  debug = false,
+): GpDiscovery {
   if (!hass) return { locations: new Map() };
 
   const { locations } = discoverEntitiesByDevice(hass, {
@@ -109,17 +142,33 @@ export function discoverGpSensors(hass, debug = false) {
     onCollision: (ctx, { existingKey, locEntities }) => {
       const alt = classifySensorAsPlant(ctx.state, ctx.entry);
       if (alt && alt !== existingKey && !locEntities.has(alt)) {
-        if (debug) console.debug("[GP] Collision on", existingKey, "-> reclassified as", alt, "for", ctx.entityId);
+        if (debug)
+          console.debug(
+            "[GP] Collision on",
+            existingKey,
+            "-> reclassified as",
+            alt,
+            "for",
+            ctx.entityId,
+          );
         return alt;
       }
-      if (debug) console.debug("[GP] Collision: duplicate key", existingKey, "for", ctx.entityId, "(skipped)");
+      if (debug)
+        console.debug(
+          "[GP] Collision: duplicate key",
+          existingKey,
+          "for",
+          ctx.entityId,
+          "(skipped)",
+        );
       return null;
     },
 
     // Fallback: prefix scan for tier 3.
-    fallbackSelector: (h) => Object.keys(h.states).filter((eid) =>
-      eid.startsWith("sensor.google_pollen_")
-    ),
+    fallbackSelector: (h) =>
+      Object.keys(h.states).filter((eid) =>
+        eid.startsWith("sensor.google_pollen_"),
+      ),
 
     /**
      * resolveLabel for GP — same shape as GPL: user override wins,
@@ -129,7 +178,7 @@ export function discoverGpSensors(hass, debug = false) {
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
-      const cleaned = cleanDeviceLabel(ctx.device?.name);
+      const cleaned = cleanDeviceLabel(ctx.device?.name as string);
       if (typeof cleaned === "string" && cleaned.trim()) return cleaned;
       if (ctx.state?.attributes?.friendly_name) {
         return cleanDeviceLabel(ctx.state.attributes.friendly_name);
@@ -148,11 +197,15 @@ export function discoverGpSensors(hass, debug = false) {
  * Get available allergen keys for a given location.
  * Returns sorted array: categories first, then plants alphabetically.
  */
-export function discoverGpAllergens(hass, configEntryId, debug = false) {
+export function discoverGpAllergens(
+  hass: HomeAssistant,
+  configEntryId: string,
+  debug = false,
+): string[] {
   const discovery = discoverGpSensors(hass, debug);
   if (!discovery.locations.size) return [];
 
-  let location;
+  let location: DiscoveredLocation | undefined;
   if (configEntryId && discovery.locations.has(configEntryId)) {
     location = discovery.locations.get(configEntryId);
   } else {
@@ -170,21 +223,29 @@ export function discoverGpAllergens(hass, configEntryId, debug = false) {
 /**
  * Resolve entity ID for a single allergen, using discovery or manual mode.
  */
-function resolveEntityId(allergen, hass, config, discoveredEntities, debug) {
+function resolveEntityId(
+  allergen: string,
+  hass: HomeAssistant,
+  config: CardConfig,
+  discoveredEntities: Map<string, string> | null,
+  debug: boolean,
+): string | null {
   if (config.location === "manual") {
-    const prefix = normalizeManualPrefix(config.entity_prefix || "");
-    const suffix = config.entity_suffix || "";
+    const prefix = normalizeManualPrefix((config.entity_prefix as string) || "");
+    const suffix = (config.entity_suffix as string) || "";
 
     // Collect candidate entity IDs
-    let candidateIds = [];
+    let candidateIds: string[] = [];
     if (hass.entities) {
       candidateIds = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === GP_DOMAIN && !entry.entity_category)
+        .filter(
+          ([, entry]) => entry.platform === GP_DOMAIN && !entry.entity_category,
+        )
         .map(([eid]) => eid);
     }
     if (!candidateIds.length) {
       candidateIds = Object.keys(hass.states || {}).filter((eid) =>
-        eid.startsWith("sensor.google_pollen_")
+        eid.startsWith("sensor.google_pollen_"),
       );
     }
 
@@ -201,25 +262,33 @@ function resolveEntityId(allergen, hass, config, discoveredEntities, debug) {
       if (key === allergen) return eid;
     }
 
-    if (debug) console.debug(`[GP] Manual mode: no sensor found for allergen "${allergen}"`);
+    if (debug)
+      console.debug(
+        `[GP] Manual mode: no sensor found for allergen "${allergen}"`,
+      );
     return null;
   }
 
   // Discovery-based lookup
   if (discoveredEntities && discoveredEntities.has(allergen)) {
-    return discoveredEntities.get(allergen);
+    return discoveredEntities.get(allergen) as string;
   }
 
-  if (debug) console.debug(`[GP] Sensor not found for allergen "${allergen}"`);
+  if (debug)
+    console.debug(`[GP] Sensor not found for allergen "${allergen}"`);
   return null;
 }
 
-export function resolveEntityIds(cfg, hass, debug = false) {
-  const map = new Map();
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
+  const map = new Map<string, string>();
   const discovery = discoverGpSensors(hass, debug);
-  const configEntryId = cfg.location || "";
+  const configEntryId = (cfg.location as string) || "";
 
-  let discoveredEntities = null;
+  let discoveredEntities: Map<string, string> | null = null;
   if (configEntryId !== "manual") {
     let match = resolveLocationByKey(discovery, configEntryId);
     // Stale-config recovery: a saved ULID that no longer matches any
@@ -232,8 +301,14 @@ export function resolveEntityIds(cfg, hass, debug = false) {
     if (match) discoveredEntities = match[1].entities;
   }
 
-  for (const allergen of cfg.allergens || []) {
-    const sensorId = resolveEntityId(allergen, hass, cfg, discoveredEntities, debug);
+  for (const allergen of (cfg.allergens as string[] | undefined) || []) {
+    const sensorId = resolveEntityId(
+      allergen,
+      hass,
+      cfg,
+      discoveredEntities,
+      debug,
+    );
     if (sensorId && hass.states[sensorId]) {
       map.set(allergen, sensorId);
     }

--- a/src/adapters/gp/forecast.ts
+++ b/src/adapters/gp/forecast.ts
@@ -1,42 +1,82 @@
-// src/adapters/gp/forecast.js
+// src/adapters/gp/forecast.ts
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
+import type { PollenSensor, ForecastDay } from "../../types/sensor.js";
 import { buildLevelNames } from "../../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames } from "../../utils/adapter-helpers.js";
+import {
+  getLangAndLocale,
+  mergePhrases,
+  buildDayLabel,
+  clampLevel,
+  sortSensors,
+  meetsThreshold,
+  resolveAllergenNames,
+} from "../../utils/adapter-helpers.js";
+import { scaleUpi0_5To0_6 } from "../base.js";
 import { stubConfigGP, capitalize } from "./constants.js";
 import { resolveEntityIds } from "./discovery.js";
 
 // Forecast attribute keys used by svenove/home-assistant-google-pollen
 const FORECAST_ATTRS = ["tomorrow", "day 3", "day 4"];
 
-export async function fetchForecast(hass, config) {
-  const debug = Boolean(config.debug);
-  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } = getLangAndLocale(hass, config, stubConfigGP.date_locale);
+interface GpLevelDay {
+  date: Date;
+  level: number;
+}
 
-  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } = mergePhrases(config, lang);
-  const levelNames = buildLevelNames(userLevels, lang);
-  const days_to_show = config.days_to_show ?? stubConfigGP.days_to_show;
-  const pollen_threshold = config.pollen_threshold ?? stubConfigGP.pollen_threshold;
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
+  const debug = Boolean(config.debug);
+  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
+    getLangAndLocale(
+      hass,
+      config,
+      stubConfigGP.date_locale as string | undefined,
+    );
+
+  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } =
+    mergePhrases(config, lang);
+  const levelNames = buildLevelNames(
+    userLevels as Array<string | null | undefined>,
+    lang,
+  );
+  const days_to_show =
+    (config.days_to_show as number | undefined) ??
+    (stubConfigGP.days_to_show as number);
+  const pollen_threshold =
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigGP.pollen_threshold as number);
 
   // google_pollen uses UPI 0-5
-  const testVal = (v) => clampLevel(v, 5, -1);
+  const testVal = (v: unknown): number => clampLevel(v, 5, -1);
 
-  if (debug) console.debug("[GP] Adapter: start fetchForecast", { config, lang });
+  if (debug)
+    console.debug("[GP] Adapter: start fetchForecast", { config, lang });
 
   const entityMap = resolveEntityIds(config, hass, debug);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  let sensors = [];
+  let sensors: PollenSensor[] = [];
 
-  for (const allergen of config.allergens) {
+  for (const allergen of config.allergens as string[]) {
     try {
-      const dict = { days: [] };
+      const dict = { days: [] as ForecastDay[] } as PollenSensor;
       dict.allergenReplaced = allergen;
 
-      const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergen, {
-        fullPhrases, shortPhrases, abbreviated: config.allergens_abbreviated, lang,
-        capitalize: (s) => capitalize(s.replace(/_/g, " ")),
-      });
+      const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+        allergen,
+        {
+          fullPhrases,
+          shortPhrases,
+          abbreviated: config.allergens_abbreviated as boolean,
+          lang,
+          capitalize: (s) => capitalize(s.replace(/_/g, " ")),
+        },
+      );
       dict.allergenCapitalized = allergenCapitalized;
       dict.allergenShort = allergenShort;
 
@@ -57,13 +97,16 @@ export async function fetchForecast(hass, config) {
       const todayVal = testVal(sensor.attributes?.index_value);
 
       // Build levels: today + flat forecast attributes
-      const levels = [{ date: today, level: todayVal }];
+      const levels: GpLevelDay[] = [{ date: today, level: todayVal }];
 
       for (let i = 0; i < FORECAST_ATTRS.length; i++) {
         if (levels.length >= days_to_show) break;
         const attrKey = FORECAST_ATTRS[i];
         const val = sensor.attributes?.[attrKey];
-        const offset = attrKey === "tomorrow" ? 1 : parseInt(attrKey.replace("day ", ""), 10) - 1;
+        const offset =
+          attrKey === "tomorrow"
+            ? 1
+            : parseInt(attrKey.replace("day ", ""), 10) - 1;
         levels.push({
           date: new Date(today.getTime() + offset * 86400000),
           level: testVal(val),
@@ -84,25 +127,25 @@ export async function fetchForecast(hass, config) {
         const entry = levels[i];
         if (!entry) continue;
 
-        const diff = Math.round((entry.date - today) / 86400000);
-        const dayLabel = buildDayLabel(entry.date, diff, { daysRelative, dayAbbrev, daysUppercase, userDays, lang, locale });
+        const diff = Math.round(
+          (entry.date.getTime() - today.getTime()) / 86400000,
+        );
+        const dayLabel = buildDayLabel(entry.date, diff, {
+          daysRelative,
+          dayAbbrev,
+          daysUppercase,
+          userDays,
+          lang,
+          locale,
+        });
 
         const level = entry.level;
-        let scaledLevel;
-        if (level < 0) {
-          scaledLevel = level;
-        } else if (level < 2) {
-          scaledLevel = Math.floor((level * 6) / 5);
-        } else {
-          scaledLevel = Math.ceil((level * 6) / 5);
-        }
+        const scaledLevel = scaleUpi0_5To0_6(level);
 
         const stateText =
-          scaledLevel < 0
-            ? noInfoLabel
-            : levelNames[scaledLevel] || noInfoLabel;
+          scaledLevel < 0 ? noInfoLabel : levelNames[scaledLevel] || noInfoLabel;
 
-        const dayObj = {
+        const dayObj: ForecastDay = {
           name: dict.allergenCapitalized,
           day: dayLabel,
           state: entry.level,
@@ -132,11 +175,11 @@ export async function fetchForecast(hass, config) {
         (s) =>
           !["trees_cat", "grass_cat", "weeds_cat"].includes(s.allergenReplaced),
       );
-      sortSensors(categoryAllergens, config.sort);
-      sortSensors(individualAllergens, config.sort);
+      sortSensors(categoryAllergens, config.sort as string);
+      sortSensors(individualAllergens, config.sort as string);
       sensors = [...categoryAllergens, ...individualAllergens];
     } else {
-      sortSensors(sensors, config.sort);
+      sortSensors(sensors, config.sort as string);
     }
   }
 

--- a/src/adapters/gp/index.ts
+++ b/src/adapters/gp/index.ts
@@ -1,4 +1,4 @@
-// src/adapters/gp/index.js
+// src/adapters/gp/index.ts
 // Adapter for svenove/home-assistant-google-pollen (domain: google_pollen)
 
 export { fetchForecast } from "./forecast.js";

--- a/src/adapters/gpl/constants.ts
+++ b/src/adapters/gpl/constants.ts
@@ -1,11 +1,12 @@
-// src/adapters/gpl/constants.js
+// src/adapters/gpl/constants.ts
+import type { AdapterStubConfig } from "../../types/config.js";
 import { LEVELS_DEFAULTS } from "../../utils/levels-defaults.js";
 
 // Attribution string used by pollenlevels integration
 export const GPL_ATTRIBUTION = "Data provided by Google Maps Pollen API";
 
 // Map pollenlevels TYPE_ICONS to our canonical allergen keys
-export const GPL_TYPE_ICON_MAP = {
+export const GPL_TYPE_ICON_MAP: Record<string, string> = {
   "mdi:grass": "grass_cat",
   "mdi:tree": "trees_cat",
   "mdi:flower-tulip": "weeds_cat",
@@ -14,7 +15,7 @@ export const GPL_TYPE_ICON_MAP = {
 // Base allergens always available (categories)
 export const GPL_BASE_ALLERGENS = ["grass_cat", "trees_cat", "weeds_cat"];
 
-export const stubConfigGPL = {
+export const stubConfigGPL: AdapterStubConfig = {
   integration: "gpl",
   location: "",
   entity_prefix: "",

--- a/src/adapters/gpl/discovery.ts
+++ b/src/adapters/gpl/discovery.ts
@@ -1,19 +1,36 @@
-// src/adapters/gpl/discovery.js
+// src/adapters/gpl/discovery.ts
+import type {
+  HomeAssistant,
+  HassEntity,
+  EntityRegistryDisplayEntry,
+} from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
 import { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS } from "./constants.js";
-import { discoverEntitiesByDevice, resolveLocationByKey, isConfigEntryId } from "../../utils/adapter-helpers.js";
+import {
+  discoverEntitiesByDevice,
+  resolveLocationByKey,
+  isConfigEntryId,
+  type DiscoveredLocation,
+} from "../../utils/adapter-helpers.js";
 import { cleanDeviceLabel } from "../../utils/device-label.js";
+
+// The subset of the discovery result gpl uses (config-entry keyed locations).
+type GplDiscovery = { locations: Map<string, DiscoveredLocation> };
 
 /**
  * Classify a GPL sensor by its attributes / registry entry.
  * Returns the allergen key (e.g. "birch", "grass_cat", "allergy_risk")
  * or null.
  *
- * @param {object} state - hass.states entry (attributes carry the data).
- * @param {object} [entry] - hass.entities registry entry (carries
- *   unique_id and translation_key; needed for v2.1.0 summary sensors
- *   which don't expose either via state.attributes).
+ * @param state - hass.states entry (attributes carry the data).
+ * @param entry - hass.entities registry entry (carries unique_id and
+ *   translation_key; needed for v2.1.0 summary sensors which don't expose
+ *   either via state.attributes).
  */
-export function classifySensor(state, entry) {
+export function classifySensor(
+  state: HassEntity | undefined,
+  entry?: EntityRegistryDisplayEntry | null,
+): string | null {
   const attrs = state?.attributes || {};
   // Plant sensors have a code attribute (always English, e.g. "birch").
   if (attrs.code) {
@@ -41,7 +58,8 @@ export function classifySensor(state, entry) {
   const uniqueId = entry?.unique_id;
   const translationKey = entry?.translation_key;
   if (
-    (typeof uniqueId === "string" && uniqueId.endsWith("_overall_pollen_risk_today")) ||
+    (typeof uniqueId === "string" &&
+      uniqueId.endsWith("_overall_pollen_risk_today")) ||
     translationKey === "overall_pollen_risk_today"
   ) {
     return "allergy_risk";
@@ -84,7 +102,7 @@ export function classifySensor(state, entry) {
 /**
  * Check if an entity is a GPL sensor (not a diagnostic/meta sensor).
  */
-export function isGplDataSensor(state) {
+export function isGplDataSensor(state: HassEntity | undefined): boolean {
   const attrs = state?.attributes || {};
   const dc = attrs.device_class;
   return dc !== "date" && dc !== "timestamp";
@@ -99,7 +117,10 @@ export function isGplDataSensor(state) {
  * Tier 2: entity registry scan filtering by entry.platform === "pollenlevels".
  * Tier 3: attribution scan -- filters states by GPL_ATTRIBUTION attribute.
  */
-export function discoverGplSensors(hass, debug = false) {
+export function discoverGplSensors(
+  hass: HomeAssistant,
+  debug = false,
+): GplDiscovery {
   if (!hass) return { locations: new Map() };
 
   const { locations } = discoverEntitiesByDevice(hass, {
@@ -109,25 +130,27 @@ export function discoverGplSensors(hass, debug = false) {
     // or icon, and falls through to the registry entry for v2.1.0 summary
     // sensors which only expose their identity via unique_id /
     // translation_key.
-    classify: (eid, { state, entry }) => {
+    classify: (_eid, { state, entry }) => {
       if (!isGplDataSensor(state)) return null;
       return classifySensor(state, entry);
     },
 
     // classifyRelaxed used in tier 1 -- same logic, no relaxation needed for GPL.
-    classifyRelaxed: (eid, { state, entry }) => {
+    classifyRelaxed: (_eid, { state, entry }) => {
       if (!isGplDataSensor(state)) return null;
       return classifySensor(state, entry);
     },
 
     // isRelevant: additional pre-classification filter (device_class check handled in classify)
-    isRelevant: (eid, { state }) => isGplDataSensor(state),
+    isRelevant: (_eid, { state }) => isGplDataSensor(state),
 
     // fallbackSelector: tier 3 uses attribution attribute instead of entity ID regex
     fallbackSelector: (h) =>
       Object.keys(h.states).filter((eid) => {
         const s = h.states[eid];
-        return s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s);
+        return (
+          s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s)
+        );
       }),
 
     /**
@@ -142,7 +165,7 @@ export function discoverGplSensors(hass, debug = false) {
      */
     resolveLabel: (ctx) => {
       if (ctx.device?.name_by_user) return ctx.device.name_by_user;
-      const cleaned = cleanDeviceLabel(ctx.device?.name);
+      const cleaned = cleanDeviceLabel(ctx.device?.name as string);
       if (typeof cleaned === "string" && cleaned.trim()) return cleaned;
       if (ctx.state?.attributes?.friendly_name) {
         return cleanDeviceLabel(ctx.state.attributes.friendly_name);
@@ -162,11 +185,15 @@ export function discoverGplSensors(hass, debug = false) {
  * If configEntryId is empty/null, uses the first discovered location.
  * Returns sorted array of allergen keys (e.g. ["grass_cat", "trees_cat", "birch", "oak"]).
  */
-export function discoverGplAllergens(hass, configEntryId, debug = false) {
+export function discoverGplAllergens(
+  hass: HomeAssistant,
+  configEntryId: string,
+  debug = false,
+): string[] {
   const discovery = discoverGplSensors(hass, debug);
   if (!discovery.locations.size) return [];
 
-  let location;
+  let location: DiscoveredLocation | undefined;
   if (configEntryId && discovery.locations.has(configEntryId)) {
     location = discovery.locations.get(configEntryId);
   } else {
@@ -187,26 +214,37 @@ export function discoverGplAllergens(hass, configEntryId, debug = false) {
  * Resolve entity ID for a given allergen and config, using discovery or manual mode.
  * Returns entity ID string or null.
  */
-function resolveEntityId(allergen, hass, config, discoveredEntities, debug) {
+function resolveEntityId(
+  allergen: string,
+  hass: HomeAssistant,
+  config: CardConfig,
+  discoveredEntities: Map<string, string> | null,
+  debug: boolean,
+): string | null {
   if (config.location === "manual") {
     // Manual mode: search by platform (primary) or attribution (fallback) + prefix/suffix filter
-    let prefix = config.entity_prefix || "";
+    let prefix = (config.entity_prefix as string) || "";
     // Remove 'sensor.' prefix if user included it
     if (prefix.startsWith("sensor.")) prefix = prefix.substring(7);
-    const suffix = config.entity_suffix || "";
+    const suffix = (config.entity_suffix as string) || "";
 
     // Collect candidate entity IDs: primary via hass.entities, fallback via attribution
-    let candidateIds = [];
+    let candidateIds: string[] = [];
     if (hass.entities) {
       candidateIds = Object.entries(hass.entities)
-        .filter(([, entry]) => entry.platform === "pollenlevels" && !entry.entity_category)
+        .filter(
+          ([, entry]) =>
+            entry.platform === "pollenlevels" && !entry.entity_category,
+        )
         .map(([eid]) => eid);
     }
     if (!candidateIds.length) {
       // Fallback: attribution scan
       candidateIds = Object.keys(hass.states || {}).filter((eid) => {
         const s = hass.states[eid];
-        return s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s);
+        return (
+          s?.attributes?.attribution === GPL_ATTRIBUTION && isGplDataSensor(s)
+        );
       });
     }
 
@@ -227,25 +265,33 @@ function resolveEntityId(allergen, hass, config, discoveredEntities, debug) {
       if (key === allergen) return eid;
     }
 
-    if (debug) console.debug(`[GPL] Manual mode: no sensor found for allergen "${allergen}"`);
+    if (debug)
+      console.debug(
+        `[GPL] Manual mode: no sensor found for allergen "${allergen}"`,
+      );
     return null;
   }
 
   // Discovery-based lookup
   if (discoveredEntities && discoveredEntities.has(allergen)) {
-    return discoveredEntities.get(allergen);
+    return discoveredEntities.get(allergen) as string;
   }
 
-  if (debug) console.debug(`[GPL] Sensor not found for allergen "${allergen}"`);
+  if (debug)
+    console.debug(`[GPL] Sensor not found for allergen "${allergen}"`);
   return null;
 }
 
-export function resolveEntityIds(cfg, hass, debug = false) {
-  const map = new Map();
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
+  const map = new Map<string, string>();
   const discovery = discoverGplSensors(hass, debug);
-  const configEntryId = cfg.location || "";
+  const configEntryId = (cfg.location as string) || "";
 
-  let discoveredEntities = null;
+  let discoveredEntities: Map<string, string> | null = null;
   if (configEntryId !== "manual") {
     let resolved = resolveLocationByKey(discovery, configEntryId);
     // Stale-config recovery: a saved ULID that no longer matches any
@@ -258,8 +304,14 @@ export function resolveEntityIds(cfg, hass, debug = false) {
     if (resolved) discoveredEntities = resolved[1].entities;
   }
 
-  for (const allergen of cfg.allergens || []) {
-    const sensorId = resolveEntityId(allergen, hass, cfg, discoveredEntities, debug);
+  for (const allergen of (cfg.allergens as string[] | undefined) || []) {
+    const sensorId = resolveEntityId(
+      allergen,
+      hass,
+      cfg,
+      discoveredEntities,
+      debug,
+    );
     if (sensorId && hass.states[sensorId]) {
       map.set(allergen, sensorId);
     }

--- a/src/adapters/gpl/forecast.ts
+++ b/src/adapters/gpl/forecast.ts
@@ -1,12 +1,36 @@
-// src/adapters/gpl/forecast.js
+// src/adapters/gpl/forecast.ts
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type { CardConfig } from "../../types/config.js";
+import type { PollenSensor, ForecastDay } from "../../types/sensor.js";
 import { buildLevelNames } from "../../utils/level-names.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, clampLevel, sortSensors, meetsThreshold, resolveAllergenNames, coerceBool, deviceLocationKey, parseLocalDate } from "../../utils/adapter-helpers.js";
+import {
+  getLangAndLocale,
+  mergePhrases,
+  buildDayLabel,
+  clampLevel,
+  sortSensors,
+  meetsThreshold,
+  resolveAllergenNames,
+  coerceBool,
+  deviceLocationKey,
+  parseLocalDate,
+} from "../../utils/adapter-helpers.js";
+import { scaleUpi0_5To0_6 } from "../base.js";
 import { stubConfigGPL, capitalize } from "./constants.js";
 import { resolveEntityIds } from "./discovery.js";
 import { t } from "../../i18n.js";
 
 // Google Pollen API top-type codes -> our canonical category keys.
-const TOP_CODE_TO_KEY = { TREE: "trees_cat", GRASS: "grass_cat", WEED: "weeds_cat" };
+const TOP_CODE_TO_KEY: Record<string, string> = {
+  TREE: "trees_cat",
+  GRASS: "grass_cat",
+  WEED: "weeds_cat",
+};
+
+interface GplLevelDay {
+  date: Date;
+  level: number;
+}
 
 /**
  * Localize a pollen code to the CARD's language (issue #222). The pollenlevels
@@ -15,11 +39,16 @@ const TOP_CODE_TO_KEY = { TREE: "trees_cat", GRASS: "grass_cat", WEED: "weeds_ca
  * via our own translations and only fall back to the integration's name when
  * we have no translation for that code.
  */
-function localizeAllergenLabel(key, fallbackName, lang) {
+function localizeAllergenLabel(
+  key: string,
+  fallbackName: unknown,
+  lang: string,
+): string {
   const tk = `card.allergen.${key}`;
   const tr = t(tk, lang);
   if (typeof tr === "string" && tr && tr !== tk) return tr;
-  if (typeof fallbackName === "string" && fallbackName.trim()) return fallbackName.trim();
+  if (typeof fallbackName === "string" && fallbackName.trim())
+    return fallbackName.trim();
   return capitalize(String(key).replace(/_/g, " "));
 }
 
@@ -34,7 +63,7 @@ function localizeAllergenLabel(key, fallbackName, lang) {
  * per location) and v3 (subentry per location) both scope correctly. Returns
  * the location key, or null when the entity has no resolvable device.
  */
-function entityLocationKey(hass, eid) {
+function entityLocationKey(hass: HomeAssistant, eid: string): string | null {
   const entry = hass?.entities?.[eid];
   const dev = entry?.device_id ? hass?.devices?.[entry.device_id] : null;
   if (!dev) return null;
@@ -51,56 +80,85 @@ function entityLocationKey(hass, eid) {
  * expose unique_id, so translation_key is the primary signal). Returns the
  * sibling entity_id or null.
  */
-function findSiblingEntityId(hass, summaryEntityId, translationKey, uidSuffix) {
+function findSiblingEntityId(
+  hass: HomeAssistant,
+  summaryEntityId: string,
+  translationKey: string,
+  uidSuffix: string,
+): string | null {
   const entities = hass?.entities;
   if (!entities) return null;
   const summaryKey = entityLocationKey(hass, summaryEntityId);
   for (const [eid, entry] of Object.entries(entities)) {
     const matches =
       entry?.translation_key === translationKey ||
-      (typeof entry?.unique_id === "string" && entry.unique_id.endsWith(uidSuffix));
+      (typeof entry?.unique_id === "string" &&
+        entry.unique_id.endsWith(uidSuffix));
     if (!matches) continue;
     // When the summary has a resolvable location, only accept a sibling from
     // the same location. A candidate without a resolvable key can't be proven
     // same-location, so skip it.
-    if (summaryKey !== null && entityLocationKey(hass, eid) !== summaryKey) continue;
+    if (summaryKey !== null && entityLocationKey(hass, eid) !== summaryKey)
+      continue;
     return eid;
   }
   return null;
 }
 
-export async function fetchForecast(hass, config) {
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
   const debug = Boolean(config.debug);
-  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } = getLangAndLocale(hass, config, stubConfigGPL.date_locale);
+  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
+    getLangAndLocale(
+      hass,
+      config,
+      stubConfigGPL.date_locale as string | undefined,
+    );
 
-  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } = mergePhrases(config, lang);
-  const levelNames = buildLevelNames(userLevels, lang);
-  const days_to_show = config.days_to_show ?? stubConfigGPL.days_to_show;
+  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } =
+    mergePhrases(config, lang);
+  const levelNames = buildLevelNames(
+    userLevels as Array<string | null | undefined>,
+    lang,
+  );
+  const days_to_show =
+    (config.days_to_show as number | undefined) ??
+    (stubConfigGPL.days_to_show as number);
   const pollen_threshold =
-    config.pollen_threshold ?? stubConfigGPL.pollen_threshold;
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigGPL.pollen_threshold as number);
 
   // GPL uses 6-level system (0-5)
-  const testVal = (v) => clampLevel(v, 5, -1);
+  const testVal = (v: unknown): number => clampLevel(v, 5, -1);
 
-  if (debug) console.debug("[GPL] Adapter: start fetchForecast", { config, lang });
+  if (debug)
+    console.debug("[GPL] Adapter: start fetchForecast", { config, lang });
 
   const entityMap = resolveEntityIds(config, hass, debug);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  let sensors = [];
+  let sensors: PollenSensor[] = [];
 
-  for (const allergen of config.allergens) {
+  for (const allergen of config.allergens as string[]) {
     try {
-      const dict = { days: [] };
+      const dict = { days: [] as ForecastDay[] } as PollenSensor;
       dict.allergenReplaced = allergen;
 
       // Allergen name resolution
-      const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergen, {
-        fullPhrases, shortPhrases, abbreviated: config.allergens_abbreviated, lang,
-        capitalize: (s) => capitalize(s.replace(/_/g, " ")),
-      });
+      const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+        allergen,
+        {
+          fullPhrases,
+          shortPhrases,
+          abbreviated: config.allergens_abbreviated as boolean,
+          lang,
+          capitalize: (s) => capitalize(s.replace(/_/g, " ")),
+        },
+      );
       dict.allergenCapitalized = allergenCapitalized;
       dict.allergenShort = allergenShort;
 
@@ -121,14 +179,20 @@ export async function fetchForecast(hass, config) {
         // Top types: localize from the canonical category codes in the CARD's
         // language (TREE -> trees_cat -> "Träd"). The integration's *_names may
         // be in another language, so they are only a per-item fallback.
-        const topCodes = Array.isArray(attrs.top_pollen_codes) ? attrs.top_pollen_codes : [];
-        const topNames = Array.isArray(attrs.top_pollen_names) ? attrs.top_pollen_names : [];
+        const topCodes = Array.isArray(attrs.top_pollen_codes)
+          ? attrs.top_pollen_codes
+          : [];
+        const topNames = Array.isArray(attrs.top_pollen_names)
+          ? attrs.top_pollen_names
+          : [];
         const topList = topCodes
-          .map((code, i) => {
-            const key = TOP_CODE_TO_KEY[String(code).toUpperCase()] || String(code).toLowerCase();
+          .map((code: unknown, i: number) => {
+            const key =
+              TOP_CODE_TO_KEY[String(code).toUpperCase()] ||
+              String(code).toLowerCase();
             return localizeAllergenLabel(key, topNames[i], lang);
           })
-          .filter((n) => typeof n === "string" && n.trim());
+          .filter((n: unknown) => typeof n === "string" && n.trim());
         if (topList.length) dict.topPollen = topList;
 
         // Plants in season: list + count from the sibling
@@ -143,15 +207,23 @@ export async function fetchForecast(hass, config) {
         );
         const plantsState = plantsId ? hass.states[plantsId] : null;
         const pAttrs = plantsState?.attributes ?? {};
-        const plantCodes = Array.isArray(pAttrs.plant_codes) ? pAttrs.plant_codes : [];
-        const plantNames = Array.isArray(pAttrs.plant_names) ? pAttrs.plant_names : [];
-        let plantList;
+        const plantCodes = Array.isArray(pAttrs.plant_codes)
+          ? pAttrs.plant_codes
+          : [];
+        const plantNames = Array.isArray(pAttrs.plant_names)
+          ? pAttrs.plant_names
+          : [];
+        let plantList: string[];
         if (plantCodes.length) {
           plantList = plantCodes
-            .map((code, i) => localizeAllergenLabel(String(code).toLowerCase(), plantNames[i], lang))
-            .filter((n) => typeof n === "string" && n.trim());
+            .map((code: unknown, i: number) =>
+              localizeAllergenLabel(String(code).toLowerCase(), plantNames[i], lang),
+            )
+            .filter((n: unknown) => typeof n === "string" && n.trim());
         } else {
-          plantList = plantNames.filter((n) => typeof n === "string" && n.trim());
+          plantList = plantNames.filter(
+            (n: unknown) => typeof n === "string" && n.trim(),
+          );
         }
         if (plantList.length) dict.plantsInSeasonList = plantList;
       }
@@ -182,7 +254,7 @@ export async function fetchForecast(hass, config) {
       const forecastData = Array.isArray(sensor.attributes?.forecast)
         ? sensor.attributes.forecast
         : [];
-      const addDays = (date, n) => {
+      const addDays = (date: Date, n: number): Date => {
         const d = new Date(date);
         d.setDate(d.getDate() + n);
         d.setHours(0, 0, 0, 0);
@@ -198,19 +270,26 @@ export async function fetchForecast(hass, config) {
         }
       }
 
-      const entries = [{ date: stateDate, level: todayVal }];
+      const entries: GplLevelDay[] = [{ date: stateDate, level: todayVal }];
       for (const forecastItem of forecastData) {
         const off = Number.isFinite(Number(forecastItem.offset))
           ? Number(forecastItem.offset)
           : entries.length;
-        const date = parseLocalDate(forecastItem.date) ?? addDays(stateDate, off);
+        const date =
+          parseLocalDate(forecastItem.date) ?? addDays(stateDate, off);
         // Same calendar day already present: first entry wins (the state for
         // the fetch day, or an earlier item).
-        if (entries.some((e) => e.date.toDateString() === date.toDateString())) {
+        if (
+          entries.some((e) => e.date.toDateString() === date.toDateString())
+        ) {
           continue;
         }
         const hasIndex = forecastItem.has_index !== false;
-        const val = forecastItem.value ?? forecastItem.state ?? forecastItem.level ?? forecastItem;
+        const val =
+          forecastItem.value ??
+          forecastItem.state ??
+          forecastItem.level ??
+          forecastItem;
         entries.push({ date, level: hasIndex ? testVal(val) : -1 });
       }
 
@@ -218,9 +297,9 @@ export async function fetchForecast(hass, config) {
       // known data starts after today (e.g. viewing a location whose local day
       // is ahead of the browser's), keep day 0 as an honest empty "today".
       const levels = entries
-        .filter((e) => e.date - today >= 0)
-        .sort((a, b) => a.date - b.date);
-      if (!levels.length || levels[0].date - today > 0) {
+        .filter((e) => e.date.getTime() - today.getTime() >= 0)
+        .sort((a, b) => a.date.getTime() - b.date.getTime());
+      if (!levels.length || levels[0].date.getTime() - today.getTime() > 0) {
         levels.unshift({ date: today, level: -1 });
       }
       levels.splice(days_to_show);
@@ -240,26 +319,26 @@ export async function fetchForecast(hass, config) {
         const entry = levels[i];
         if (!entry) continue;
 
-        const diff = Math.round((entry.date - today) / 86400000);
-        const dayLabel = buildDayLabel(entry.date, diff, { daysRelative, dayAbbrev, daysUppercase, userDays, lang, locale });
+        const diff = Math.round(
+          (entry.date.getTime() - today.getTime()) / 86400000,
+        );
+        const dayLabel = buildDayLabel(entry.date, diff, {
+          daysRelative,
+          dayAbbrev,
+          daysUppercase,
+          userDays,
+          lang,
+          locale,
+        });
 
         // Scale level 0-5 to level name index 0-6 (like Kleenex does for 0-4)
         const level = entry.level;
-        let scaledLevel;
-        if (level < 0) {
-          scaledLevel = level;
-        } else if (level < 2) {
-          scaledLevel = Math.floor((level * 6) / 5);
-        } else {
-          scaledLevel = Math.ceil((level * 6) / 5);
-        }
+        const scaledLevel = scaleUpi0_5To0_6(level);
 
         const stateText =
-          scaledLevel < 0
-            ? noInfoLabel
-            : levelNames[scaledLevel] || noInfoLabel;
+          scaledLevel < 0 ? noInfoLabel : levelNames[scaledLevel] || noInfoLabel;
 
-        const dayObj = {
+        const dayObj: ForecastDay = {
           name: dict.allergenCapitalized,
           day: dayLabel,
           state: entry.level,
@@ -292,15 +371,13 @@ export async function fetchForecast(hass, config) {
       );
       const individualAllergens = sensors.filter(
         (s) =>
-          !["trees_cat", "grass_cat", "weeds_cat"].includes(
-            s.allergenReplaced,
-          ),
+          !["trees_cat", "grass_cat", "weeds_cat"].includes(s.allergenReplaced),
       );
-      sortSensors(categoryAllergens, config.sort);
-      sortSensors(individualAllergens, config.sort);
+      sortSensors(categoryAllergens, config.sort as string);
+      sortSensors(individualAllergens, config.sort as string);
       sensors = [...categoryAllergens, ...individualAllergens];
     } else {
-      sortSensors(sensors, config.sort);
+      sortSensors(sensors, config.sort as string);
     }
   }
 

--- a/src/adapters/gpl/index.ts
+++ b/src/adapters/gpl/index.ts
@@ -1,4 +1,4 @@
-// src/adapters/gpl/index.js
+// src/adapters/gpl/index.ts
 // Public facade: re-exports all named exports from sub-modules.
 export { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS, stubConfigGPL, capitalize } from "./constants.js";
 export { classifySensor, isGplDataSensor, discoverGplSensors, discoverGplAllergens, resolveEntityIds } from "./discovery.js";

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -1,15 +1,29 @@
-// src/adapters/plu.js
+// src/adapters/plu.ts
+import type { HomeAssistant } from "../types/home-assistant.js";
+import type { CardConfig, AdapterStubConfig } from "../types/config.js";
+import type { PollenSensor, ForecastDay } from "../types/sensor.js";
 import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
 import { slugify } from "../utils/slugify.js";
-import { getLangAndLocale, mergePhrases, buildDayLabel, meetsThreshold, resolveAllergenNames, discoverEntitiesByDevice, normalizeManualPrefix, resolveManualEntity } from "../utils/adapter-helpers.js";
+import {
+  getLangAndLocale,
+  mergePhrases,
+  buildDayLabel,
+  meetsThreshold,
+  resolveAllergenNames,
+  discoverEntitiesByDevice,
+  normalizeManualPrefix,
+  resolveManualEntity,
+  type DeviceDiscovery,
+} from "../utils/adapter-helpers.js";
+import { PLU_LEVEL_INDICES } from "./base.js";
 
 const SENSOR_PREFIX = "sensor.pollen_";
 
 // Raw alias names (before slugification) grouped by canonical allergen name
 // This is the single source of truth for supported allergens
-const RAW_ALIAS_NAMES = {
+const RAW_ALIAS_NAMES: Record<string, string[]> = {
   sorrel: ["Rumex", "Sorrel", "Ampfer", "Oseille"],
   mugwort: ["Artemisia", "Mugwort", "Beifuß", "Beifuss", "Armoise"],
   birch: ["Betula", "Birch", "Birke", "Bouleau"],
@@ -17,8 +31,24 @@ const RAW_ALIAS_NAMES = {
   oak: ["Quercus", "Oak", "Eiche", "Chêne", "Chene"],
   alder: ["Alnus", "Alder", "Erle", "Aulne"],
   ash: ["Fraxinus", "Ash", "Esche", "Frêne", "Frene"],
-  goosefoot: ["Chenopodium", "Goosefoot", "Gänsefuß", "Gaensefuss", "Gansefuss", "Chénopode", "Chenopode"],
-  poaceae: ["Poacea", "Poaceae", "Grasses", "Gräser", "Graeser", "Graminées", "Graminees"],
+  goosefoot: [
+    "Chenopodium",
+    "Goosefoot",
+    "Gänsefuß",
+    "Gaensefuss",
+    "Gansefuss",
+    "Chénopode",
+    "Chenopode",
+  ],
+  poaceae: [
+    "Poacea",
+    "Poaceae",
+    "Grasses",
+    "Gräser",
+    "Graeser",
+    "Graminées",
+    "Graminees",
+  ],
   hazel: ["Corylus", "Hazel", "Hasel", "Haselnussstrauch", "Noisetier"],
   plantain: ["Plantago", "Plantain", "Wegerich"],
 };
@@ -27,11 +57,11 @@ const RAW_ALIAS_NAMES = {
 export const PLU_SUPPORTED_ALLERGENS = Object.keys(RAW_ALIAS_NAMES).sort();
 
 // Slugified alias map exported for sensor discovery helpers
-export const PLU_ALIAS_MAP = Object.entries(RAW_ALIAS_NAMES).reduce(
-  (acc, [canonical, names]) => {
-    const slugged = Array.from(
-      new Set(names.map((name) => slugify(name))),
-    );
+export const PLU_ALIAS_MAP: Record<string, string[]> = Object.entries(
+  RAW_ALIAS_NAMES,
+).reduce(
+  (acc: Record<string, string[]>, [canonical, names]) => {
+    const slugged = Array.from(new Set(names.map((name) => slugify(name))));
     // Ensure canonical slug is present as alias
     if (!slugged.includes(canonical)) slugged.push(canonical);
     acc[canonical] = slugged;
@@ -44,8 +74,8 @@ export const PLU_ALIAS_MAP = Object.entries(RAW_ALIAS_NAMES).reduce(
 // Built once at module load from PLU_ALIAS_MAP.
 // Allows classifyPluEntity to identify both canonical ("birch") and alias
 // ("betula", "bouleau") entity ID suffixes.
-const PLU_REVERSE_ALIAS = (() => {
-  const map = {};
+const PLU_REVERSE_ALIAS: Record<string, string> = (() => {
+  const map: Record<string, string> = {};
   for (const [canonical, aliases] of Object.entries(PLU_ALIAS_MAP)) {
     for (const alias of aliases) map[alias] = canonical;
     // Ensure canonical itself is covered (already in aliases, but explicit is safer)
@@ -60,11 +90,8 @@ const PLU_REVERSE_ALIAS = (() => {
  * PLU sensors follow the pattern sensor.pollen_{alias}.
  * The alias can be the canonical English key ("birch"), a slugified Latin name
  * ("betula"), a slugified French name ("bouleau"), etc.
- *
- * @param {string} eid - Entity ID.
- * @returns {string|null} - Canonical allergen key or null if unrecognized.
  */
-function classifyPluEntity(eid) {
+function classifyPluEntity(eid: string): string | null {
   if (!eid.startsWith(SENSOR_PREFIX)) return null;
   const rest = eid.substring(SENSOR_PREFIX.length);
   return PLU_REVERSE_ALIAS[rest] || null;
@@ -81,12 +108,11 @@ function classifyPluEntity(eid) {
  * location key. The platform name is assumed to be "pollen_lu" based on the
  * typical HA custom-integration naming convention. "pollenlu" is included as a
  * defensive alternative.
- *
- * @param {object}  hass
- * @param {boolean} [debug=false]
- * @returns {{ locations: Map<string, { label: string, entities: Map<string, string> }>, tierUsed: number }}
  */
-export function discoverPluSensors(hass, debug = false) {
+export function discoverPluSensors(
+  hass: HomeAssistant,
+  debug = false,
+): DeviceDiscovery {
   if (!hass) return { locations: new Map(), tierUsed: 0 };
 
   return discoverEntitiesByDevice(hass, {
@@ -94,7 +120,8 @@ export function discoverPluSensors(hass, debug = false) {
     classify: classifyPluEntity,
     classifyRelaxed: classifyPluEntity,
     isRelevant: (eid) => eid.startsWith(SENSOR_PREFIX),
-    resolveLabel: (ctx) => ctx.device?.name_by_user || ctx.device?.name || "Pollen.lu",
+    resolveLabel: (ctx) =>
+      ctx.device?.name_by_user || ctx.device?.name || "Pollen.lu",
     resolveLocationKey: () => "default",
     fallbackRegex: null,
     debug,
@@ -103,7 +130,7 @@ export function discoverPluSensors(hass, debug = false) {
 }
 
 // Default thresholds per allergen (fallback when sensor attributes are missing)
-const DEFAULT_THRESHOLDS = {
+const DEFAULT_THRESHOLDS: Record<string, { moderate: number; high: number }> = {
   alder: { moderate: 11, high: 51 },
   mugwort: { moderate: 3, high: 7 },
   birch: { moderate: 11, high: 51 },
@@ -117,7 +144,7 @@ const DEFAULT_THRESHOLDS = {
   sorrel: { moderate: 4, high: 16 },
 };
 
-export const stubConfigPLU = {
+export const stubConfigPLU: AdapterStubConfig = {
   integration: "plu",
   // location: "" -> autodetect; "manual" -> use entity_prefix/_suffix.
   // PLU historically had no location field (single-instance integration),
@@ -154,13 +181,19 @@ export const stubConfigPLU = {
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },
 };
 
-function resolveSensorId(hass, canonical, debug) {
+function resolveSensorId(
+  hass: HomeAssistant,
+  canonical: string,
+  debug: boolean,
+): string | null {
   const aliases = PLU_ALIAS_MAP[canonical] || [canonical];
   for (const alias of aliases) {
     const sensorId = `${SENSOR_PREFIX}${alias}`;
     if (hass.states[sensorId]) {
       if (debug) {
-        console.debug(`[PLU] Using sensor '${sensorId}' for allergen '${canonical}'`);
+        console.debug(
+          `[PLU] Using sensor '${sensorId}' for allergen '${canonical}'`,
+        );
       }
       return sensorId;
     }
@@ -176,21 +209,22 @@ function resolveSensorId(hass, canonical, debug) {
  * pollen.lu instances, renamed entities, etc.) point the card at the
  * right sensor set. Iterates aliases because the same canonical
  * allergen can be exposed under English, Latin, French, or German names.
- *
- * @param {object}  hass
- * @param {string}  canonical    - Canonical allergen key (e.g. "birch").
- * @param {string}  prefix       - Already normalized via normalizeManualPrefix.
- * @param {string}  suffix       - Raw entity_suffix from config (may be "").
- * @param {boolean} debug
- * @returns {string|null}
  */
-function resolveSensorIdManual(hass, canonical, prefix, suffix, debug) {
+function resolveSensorIdManual(
+  hass: HomeAssistant,
+  canonical: string,
+  prefix: string,
+  suffix: string,
+  debug: boolean,
+): string | null {
   const aliases = PLU_ALIAS_MAP[canonical] || [canonical];
   for (const alias of aliases) {
     const sensorId = resolveManualEntity(hass, prefix, alias, suffix);
     if (sensorId) {
       if (debug) {
-        console.debug(`[PLU] Manual mode: using sensor '${sensorId}' for allergen '${canonical}'`);
+        console.debug(
+          `[PLU] Manual mode: using sensor '${sensorId}' for allergen '${canonical}'`,
+        );
       }
       return sensorId;
     }
@@ -198,7 +232,12 @@ function resolveSensorIdManual(hass, canonical, prefix, suffix, debug) {
   return null;
 }
 
-export function resolveEntityIds(cfg, hass, debug = false) {
+export function resolveEntityIds(
+  cfg: CardConfig,
+  hass: HomeAssistant,
+  debug = false,
+): Map<string, string> {
+  const allergens = (cfg.allergens as string[] | undefined) || [];
   // --- Path 0: Manual mode -- prefix-driven alias probe ---
   // Mirrors the manual-mode pattern used by PP/DWD/PEU/SILAM/Atmo/GPL: when
   // location === "manual" AND entity_prefix is set, use cfg.entity_prefix
@@ -211,12 +250,18 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   // for PLU, so empty-prefix manual configs always auto-discovered.
   if (cfg.location === "manual") {
     const prefix = normalizeManualPrefix(cfg.entity_prefix);
-    const suffix = cfg.entity_suffix || "";
+    const suffix = (cfg.entity_suffix as string) || "";
     if (prefix) {
-      const map = new Map();
-      for (const allergen of cfg.allergens || []) {
+      const map = new Map<string, string>();
+      for (const allergen of allergens) {
         if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;
-        const sensorId = resolveSensorIdManual(hass, allergen, prefix, suffix, debug);
+        const sensorId = resolveSensorIdManual(
+          hass,
+          allergen,
+          prefix,
+          suffix,
+          debug,
+        );
         if (sensorId) map.set(allergen, sensorId);
       }
       if (map.size > 0) return map;
@@ -246,14 +291,19 @@ export function resolveEntityIds(cfg, hass, debug = false) {
     const first = discovery.locations.entries().next();
     if (!first.done) {
       const [, location] = first.value;
-      const map = new Map();
-      for (const allergen of cfg.allergens || []) {
+      const map = new Map<string, string>();
+      for (const allergen of allergens) {
         if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;
         const eid = location.entities.get(allergen);
         if (eid) map.set(allergen, eid);
       }
       if (map.size > 0) {
-        if (debug) console.debug("[PLU] resolveEntityIds via discovery:", map.size, "entities");
+        if (debug)
+          console.debug(
+            "[PLU] resolveEntityIds via discovery:",
+            map.size,
+            "entities",
+          );
         return map;
       }
     }
@@ -262,8 +312,8 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   // --- Path 2: Alias-probe fallback ---
   // Iterates PLU_ALIAS_MAP to find sensor.pollen_{alias} in hass.states.
   // Preserves multilingual alias support (Latin, French, German, English names).
-  const map = new Map();
-  for (const allergen of cfg.allergens || []) {
+  const map = new Map<string, string>();
+  for (const allergen of allergens) {
     if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;
     const sensorId = resolveSensorId(hass, allergen, debug);
     if (sensorId) map.set(allergen, sensorId);
@@ -271,12 +321,15 @@ export function resolveEntityIds(cfg, hass, debug = false) {
   return map;
 }
 
-function parseThreshold(value, fallback) {
+function parseThreshold(value: unknown, fallback: number): number {
   const num = Number(value);
   return Number.isFinite(num) ? num : fallback;
 }
 
-function valueToLevel(value, thresholds) {
+function valueToLevel(
+  value: unknown,
+  thresholds: { moderate: number; high: number },
+): number {
   const amount = Number(value);
   if (!Number.isFinite(amount) || amount < 0) return -1;
   if (amount === 0) return 0;
@@ -286,44 +339,63 @@ function valueToLevel(value, thresholds) {
   return 3;
 }
 
-export async function fetchForecast(hass, config) {
+export async function fetchForecast(
+  hass: HomeAssistant,
+  config: CardConfig,
+): Promise<PollenSensor[]> {
   const debug = Boolean(config.debug);
-  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } = getLangAndLocale(hass, config);
+  const { lang, locale, daysRelative, dayAbbrev, daysUppercase } =
+    getLangAndLocale(hass, config);
 
-  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } = mergePhrases(config, lang);
+  const { fullPhrases, shortPhrases, userLevels, userDays, noInfoLabel } =
+    mergePhrases(config, lang);
 
   // Build level names. Allow users to supply 4 or 7 custom labels.
-  const fullLevelNames = buildLevelNames(userLevels, lang);
-  const levelIndices = [0, 1, 3, 5];
+  // PLU is a four-level (0-3) integration; its level names come from palette
+  // positions PLU_LEVEL_INDICES ([0,1,3,5]) of the seven-level defaults.
+  // TODO(#259-normalize): retire the seven-level palette borrowing.
+  const fullLevelNames = buildLevelNames(
+    userLevels as Array<string | null | undefined>,
+    lang,
+  );
+  const levelIndices = PLU_LEVEL_INDICES;
   const levelNames = levelIndices.map((idx, pos) => {
     const custom = Array.isArray(userLevels) ? userLevels[pos] : undefined;
-    if (custom != null && custom !== "") return custom;
+    if (custom != null && custom !== "") return custom as string;
     return fullLevelNames[idx] || t(`card.levels.${idx}`, lang);
   });
 
   const pollen_threshold =
-    config.pollen_threshold ?? stubConfigPLU.pollen_threshold;
+    (config.pollen_threshold as number | undefined) ??
+    (stubConfigPLU.pollen_threshold as number);
 
   const days_to_show = Math.max(
     1,
-    config.days_to_show ?? stubConfigPLU.days_to_show,
+    (config.days_to_show as number | undefined) ??
+      (stubConfigPLU.days_to_show as number),
   );
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  const sensors = [];
+  const sensors: PollenSensor[] = [];
   const entityMap = resolveEntityIds(config, hass, debug);
 
-  for (const allergen of config.allergens || []) {
+  for (const allergen of (config.allergens as string[] | undefined) || []) {
     if (!PLU_SUPPORTED_ALLERGENS.includes(allergen)) continue;
 
-    const dict = { days: [] };
+    const dict = { days: [] as ForecastDay[] } as PollenSensor;
     dict.allergenReplaced = allergen;
 
-    const { allergenCapitalized, allergenShort } = resolveAllergenNames(allergen, {
-      fullPhrases, shortPhrases, abbreviated: config.allergens_abbreviated, lang,
-    });
+    const { allergenCapitalized, allergenShort } = resolveAllergenNames(
+      allergen,
+      {
+        fullPhrases,
+        shortPhrases,
+        abbreviated: config.allergens_abbreviated as boolean,
+        lang,
+      },
+    );
     dict.allergenCapitalized = allergenCapitalized;
     dict.allergenShort = allergenShort;
 
@@ -362,12 +434,19 @@ export async function fetchForecast(hass, config) {
       ? new Date(dict.attributes.last_update)
       : today;
 
-    const label = buildDayLabel(referenceDate, 0, { daysRelative, dayAbbrev, daysUppercase, userDays, lang, locale });
+    const label = buildDayLabel(referenceDate, 0, {
+      daysRelative,
+      dayAbbrev,
+      daysUppercase,
+      userDays,
+      lang,
+      locale,
+    });
 
     const stateText =
       level < 0 ? noInfoLabel : levelNames[level] || noInfoLabel;
 
-    const dayObj = {
+    const dayObj: ForecastDay = {
       name: dict.allergenCapitalized,
       day: label,
       state: level,
@@ -377,6 +456,8 @@ export async function fetchForecast(hass, config) {
       display_state: level,
       raw_value: Number.isFinite(rawValue) ? rawValue : null,
       state_text: stateText,
+      // TODO(#259-normalize): thresholds/level_string/last_update/next_poll are
+      // PLU-only day fields carried through for display.
       thresholds: { moderate, high },
       level_string: dict.attributes?.level || null,
       last_update: dict.attributes?.last_update || null,
@@ -403,27 +484,29 @@ export async function fetchForecast(hass, config) {
   }
 
   if (config.sort !== "none") {
+    const sortFns: Record<
+      string,
+      (a: PollenSensor, b: PollenSensor) => number
+    > = {
+      value_ascending: (a, b) => (a.day0?.state ?? 0) - (b.day0?.state ?? 0),
+      value_descending: (a, b) => (b.day0?.state ?? 0) - (a.day0?.state ?? 0),
+      name_ascending: (a, b) =>
+        (a.allergenCapitalized || "").localeCompare(
+          b.allergenCapitalized || "",
+          lang,
+        ),
+      name_descending: (a, b) =>
+        (b.allergenCapitalized || "").localeCompare(
+          a.allergenCapitalized || "",
+          lang,
+        ),
+      none: () => 0,
+    };
     sensors.sort(
-      {
-        value_ascending: (a, b) =>
-          (a.day0?.state ?? 0) - (b.day0?.state ?? 0),
-        value_descending: (a, b) =>
-          (b.day0?.state ?? 0) - (a.day0?.state ?? 0),
-        name_ascending: (a, b) =>
-          (a.allergenCapitalized || "").localeCompare(
-            b.allergenCapitalized || "",
-            lang,
-          ),
-        name_descending: (a, b) =>
-          (b.allergenCapitalized || "").localeCompare(
-            a.allergenCapitalized || "",
-            lang,
-          ),
-        none: () => 0,
-      }[config.sort] || ((a, b) => (a.day0?.state ?? 0) - (b.day0?.state ?? 0)),
+      sortFns[config.sort as string] ||
+        ((a, b) => (a.day0?.state ?? 0) - (b.day0?.state ?? 0)),
     );
   }
 
   return sensors;
 }
-

--- a/src/utils/sensors.ts
+++ b/src/utils/sensors.ts
@@ -1,6 +1,5 @@
 // src/utils/sensors.ts
 import { getAdapter } from "../adapter-registry.js";
-import type { AdapterModule } from "../types/adapter.js";
 import type { CardConfig } from "../types/config.js";
 import type { HomeAssistant } from "../types/home-assistant.js";
 
@@ -14,9 +13,7 @@ export function findAvailableSensors(
   hass: HomeAssistant,
   debug = false,
 ): string[] {
-  // adapter-registry is still untyped JS; cast the returned module to the
-  // adapter contract until the adapters themselves migrate to TypeScript.
-  const adapter = getAdapter(cfg.integration) as AdapterModule | undefined;
+  const adapter = getAdapter(cfg.integration);
   if (!adapter?.resolveEntityIds) return [];
 
   const map = adapter.resolveEntityIds(cfg, hass, debug);


### PR DESCRIPTION
Eighth PR of the v4.0.0 migration (#259): the final adapter batch — gp/, gpl/, plu and the adapter registry. After this PR every adapter and the registry are TypeScript; no .js remains under src/adapters/. Golden snapshots byte-identical throughout.

## What

- **plu**: TypeScript on its adapter-local flow, with the shared `PLU_LEVEL_INDICES` constant replacing the inline array. Its integration-specific day fields and attribute pass-through are preserved and marked `TODO(#259-normalize)`.
- **gp** and **gpl**: the duplicated inline 0-5→0-6 scaling formula in both forecast modules is replaced by the shared `scaleUpi0_5To0_6` (verified identical, golden-gated). GPL's summary block and the per-calendar-day anchoring from the #271 fix are preserved exactly. GP's generated display-name maps are untouched apart from type annotations.
- **adapter-registry.ts**: typed against `AdapterModule`/`AdapterStubConfig`; `getAdapter`/`getStubConfig` now return real types, which also removes the last registry-related type assertion in `utils/sensors.ts`.
- Date subtraction in gpl rewritten as explicit `.getTime()` calls (TS does not allow `Date - Date`; behaviour unchanged).

## Verification

- Golden snapshots byte-identical after each module (diff against dev over test/ is empty); 1317/1317 tests green; `tsc --noEmit` clean; eslint 0 errors; build within budget.
- Combined multi-integration pass on the HA test instance: all 17 QA cards across the 11 integrations render, ring-canvas count and error-card count identical to a dev-baseline bundle measured at the same time, zero console/page errors, reconnect/resize/modes clean.

## Review note

During conversion, a first draft of gp/discovery dropped a collision-guard condition; it was caught in self-review against the original before commit. The golden suite has no gp collision fixture, so a fixture for that path is on the follow-up list.
