### PR TITLE
(rendering) Replace Chart.js with a hand-written SVG level ring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "pollenprognos-card",
       "version": "3.1.0",
       "dependencies": {
-        "chart.js": "^4.5.0",
         "intl-messageformat": "^10.7.16",
         "lit": "^3.3.3"
       },
@@ -2278,12 +2277,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
@@ -3244,18 +3237,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
-      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "chart.js": "^4.5.0",
     "intl-messageformat": "^10.7.16",
     "lit": "^3.3.3"
   }

--- a/src/pollenprognos-badge.js
+++ b/src/pollenprognos-badge.js
@@ -714,9 +714,8 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       /*
        * .ring-icon, .ring-icon svg, .level-value-text and the no-data icon
        * rules live in the shared ringIconStyles fragment (spliced above), so
-       * they stay byte-identical to the card. _rebuildCharts injects
-       * .ring-icon / .level-value-text into this element's renderRoot, which
-       * the fragment covers. The rules below are badge-specific and
+       * they stay byte-identical to the card; the ring markup rendered by
+       * the mixin's declarative template is covered by the fragment. The rules below are badge-specific and
        * intentionally differ from the card.
        */
 

--- a/src/pollenprognos-card.js
+++ b/src/pollenprognos-card.js
@@ -72,17 +72,14 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       this._subscribeForecastIfNeeded();
     }
 
-    // Chart lifecycle delegated to LevelCircleMixin via super.updated().
     super.updated(changedProps);
   }
 
-  // Recreate charts when element is connected, useful after DOM cloning.
   connectedCallback() {
-    // Chart rebuild delegated to LevelCircleMixin via super.connectedCallback().
     super.connectedCallback();
   }
 
-  // Clean up forecast subscription and charts when component is disconnected.
+  // Clean up forecast subscription when component is disconnected.
   disconnectedCallback() {
     // Clean up forecast subscription
     if (this._forecastUnsub) {
@@ -94,7 +91,6 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       this._forecastSubType = null;
     }
 
-    // Chart cache destruction delegated to LevelCircleMixin via super.disconnectedCallback().
     super.disconnectedCallback();
   }
 
@@ -745,8 +741,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     // Only update reactive properties when values actually changed.
     // Lit's auto-generated accessor triggers requestUpdate on every
     // assignment (new object ref ≠ old ref), which causes a full render
-    // cycle including _rebuildCharts() DOM mutations on every HA state
-    // change — the root cause of iOS scroll position jumps.
+    // cycle with DOM mutations on every HA state change — the root cause
+    // of iOS scroll position jumps.
     if (!deepEqual(this.config, cfg)) {
       this.config = cfg;
     }

--- a/src/rendering/donut.ts
+++ b/src/rendering/donut.ts
@@ -22,7 +22,10 @@
 // report; the dominant visual (band width, segment count, colors, gap) is
 // reproduced exactly.
 
-import { buildRingNoiseSvgPattern } from "../utils/no-data-pattern.js";
+import {
+  buildRingNoiseSvgPattern,
+  escapeXmlAttr,
+} from "../utils/no-data-pattern.js";
 
 export interface DonutParams {
   /** Number of filled segments (clamped to [0, segments]). */
@@ -122,6 +125,9 @@ export function buildDonutSvg(params: DonutParams): string {
   const seg = 360 / segments;
   const safeLevel = Math.max(0, Math.min(level, segments));
 
+  // noiseSeed is a 32-bit hash of the cell id; a cross-cell collision would
+  // make two no-data patterns share one <def>. With tens of cells per view
+  // the birthday odds are negligible -- accepted.
   const patternId = `ppd-noise-${noiseSeed}`;
   let paths = "";
   for (let i = 0; i < segments; i++) {
@@ -134,7 +140,10 @@ export function buildDonutSvg(params: DonutParams): string {
     // fill via style, not the presentation attribute: colors may be CSS
     // custom-property references (var(--divider-color)), and style="" is the
     // only placement where var() is guaranteed to resolve in every engine.
-    paths += `<path d="${d}" style="fill:${fill}"/>`;
+    // Colors are user-editable YAML strings rendered through unsafeSVG, so
+    // they MUST be attribute-escaped to keep them from breaking out of the
+    // style attribute (SVG is script-capable).
+    paths += `<path d="${d}" style="fill:${escapeXmlAttr(fill)}"/>`;
   }
 
   // Gap: one stroked outline layer over the fills (drawn once per segment path
@@ -145,7 +154,7 @@ export function buildDonutSvg(params: DonutParams): string {
     for (let i = 0; i < segments; i++) {
       const d = sectorPath(cx, cy, ri, ro, i * seg, (i + 1) * seg);
       strokes +=
-        `<path d="${d}" style="fill:none;stroke:${gapColor};` +
+        `<path d="${d}" style="fill:none;stroke:${escapeXmlAttr(gapColor)};` +
         `stroke-width:${n(gap)}"/>`;
     }
   }

--- a/src/rendering/donut.ts
+++ b/src/rendering/donut.ts
@@ -131,7 +131,10 @@ export function buildDonutSvg(params: DonutParams): string {
         ? (colors[i] ?? emptyColor)
         : emptyColor;
     const d = sectorPath(cx, cy, ri, ro, i * seg, (i + 1) * seg);
-    paths += `<path d="${d}" fill="${fill}"/>`;
+    // fill via style, not the presentation attribute: colors may be CSS
+    // custom-property references (var(--divider-color)), and style="" is the
+    // only placement where var() is guaranteed to resolve in every engine.
+    paths += `<path d="${d}" style="fill:${fill}"/>`;
   }
 
   // Gap: one stroked outline layer over the fills (drawn once per segment path
@@ -142,8 +145,8 @@ export function buildDonutSvg(params: DonutParams): string {
     for (let i = 0; i < segments; i++) {
       const d = sectorPath(cx, cy, ri, ro, i * seg, (i + 1) * seg);
       strokes +=
-        `<path d="${d}" fill="none" stroke="${gapColor}" ` +
-        `stroke-width="${n(gap)}"/>`;
+        `<path d="${d}" style="fill:none;stroke:${gapColor};` +
+        `stroke-width:${n(gap)}"/>`;
     }
   }
 

--- a/src/rendering/donut.ts
+++ b/src/rendering/donut.ts
@@ -1,0 +1,159 @@
+// src/rendering/donut.ts
+//
+// Self-contained SVG level-ring renderer. Replaces the Chart.js doughnut that
+// LevelCircleMixin used to draw imperatively into a <canvas>. Given already-
+// resolved colors (the mixin owns all color/inherit-mode logic), this produces
+// the ring markup deterministically, so the ring can be rendered declaratively
+// inside a lit template with no cache / destroy / recreate lifecycle.
+//
+// Geometry parity with the old Chart.js doughnut:
+//   - N equal segments (data: Array(N).fill(1)), one per non-empty level step.
+//   - Start at 12 o'clock and run clockwise (Chart.js rotation: -Math.PI/2).
+//   - Ring band from innerRadius to outerRadius where
+//     innerRadius = outerRadius * (100 - thickness) / 100  (Chart.js
+//     cutout: `${100 - thickness}%`, outerRadius = size / 2).
+//   - Per-segment stroke of `gap` px in gapColor reproduces Chart.js's
+//     per-arc borderWidth/borderColor (borderAlign "center" == SVG's
+//     centered stroke), giving the thin gap between and around segments.
+//   - Filled segments (index < level) use their level color; the rest use
+//     emptyColor. No-data fills every segment with a noise <pattern>.
+//
+// Known sub-pixel deviations from the canvas output are documented in the PR
+// report; the dominant visual (band width, segment count, colors, gap) is
+// reproduced exactly.
+
+import { buildRingNoiseSvgPattern } from "../utils/no-data-pattern.js";
+
+export interface DonutParams {
+  /** Number of filled segments (clamped to [0, segments]). */
+  level: number;
+  /** Total segment count N (per-integration max level). */
+  segments: number;
+  /** Per-segment fill colors; colors[i] fills segment i when i < level. */
+  colors: string[];
+  /** Fill for unfilled segments. */
+  emptyColor: string;
+  /** Stroke color drawn around every segment (the gap). */
+  gapColor: string;
+  /** Ring band width as a percentage of the radius (0-100). */
+  thickness: number;
+  /** Gap / border width in px. */
+  gap: number;
+  /** Rendered size in px; sets the viewBox so 1 user unit == 1 px. */
+  size: number;
+  /** No-data state: fill every segment with the noise pattern. */
+  noData?: boolean;
+  /** Dot/scratch color for the no-data noise pattern. */
+  noiseColor?: string;
+  /** Per-circle seed so adjacent no-data rings don't repeat identically. */
+  noiseSeed?: number;
+}
+
+/** Point on a circle, angle measured clockwise from 12 o'clock (screen y-down). */
+function polar(
+  cx: number,
+  cy: number,
+  r: number,
+  deg: number,
+): [number, number] {
+  const a = (deg * Math.PI) / 180;
+  return [cx + r * Math.sin(a), cy - r * Math.cos(a)];
+}
+
+function n(v: number): string {
+  // Trim to 3 decimals; drop trailing ".000" noise for smaller markup.
+  return Number(v.toFixed(3)).toString();
+}
+
+/** Path for one ring sector (donut wedge) between radii ri..ro, angles d0..d1. */
+function sectorPath(
+  cx: number,
+  cy: number,
+  ri: number,
+  ro: number,
+  d0: number,
+  d1: number,
+): string {
+  const [ox0, oy0] = polar(cx, cy, ro, d0);
+  const [ox1, oy1] = polar(cx, cy, ro, d1);
+  const large = d1 - d0 > 180 ? 1 : 0;
+  if (ri <= 0.0001) {
+    // Full-thickness ring (cutout 0) degenerates into a pie wedge.
+    return (
+      `M${n(cx)} ${n(cy)} L${n(ox0)} ${n(oy0)} ` +
+      `A${n(ro)} ${n(ro)} 0 ${large} 1 ${n(ox1)} ${n(oy1)} Z`
+    );
+  }
+  const [ix1, iy1] = polar(cx, cy, ri, d1);
+  const [ix0, iy0] = polar(cx, cy, ri, d0);
+  return (
+    `M${n(ox0)} ${n(oy0)} A${n(ro)} ${n(ro)} 0 ${large} 1 ${n(ox1)} ${n(oy1)} ` +
+    `L${n(ix1)} ${n(iy1)} A${n(ri)} ${n(ri)} 0 ${large} 0 ${n(ix0)} ${n(iy0)} Z`
+  );
+}
+
+/**
+ * Build the SVG markup for a level ring. Returns a complete `<svg>` string
+ * (inject with lit's unsafeSVG). Deterministic: identical params yield an
+ * identical string, so lit skips re-parsing when nothing changed.
+ */
+export function buildDonutSvg(params: DonutParams): string {
+  const {
+    level,
+    segments,
+    colors,
+    emptyColor,
+    gapColor,
+    thickness,
+    gap,
+    size,
+    noData = false,
+    noiseColor = "#888888",
+    noiseSeed = 13,
+  } = params;
+
+  const cx = size / 2;
+  const cy = size / 2;
+  // Inset the outer radius by half the stroke so the gap outline stays inside
+  // the box (Chart.js clipped the outer half of the border at the canvas edge;
+  // insetting keeps neighbours from overlapping and is visually equivalent).
+  const ro = size / 2 - gap / 2;
+  const ri = (size / 2) * ((100 - thickness) / 100);
+  const seg = 360 / segments;
+  const safeLevel = Math.max(0, Math.min(level, segments));
+
+  const patternId = `ppd-noise-${noiseSeed}`;
+  let paths = "";
+  for (let i = 0; i < segments; i++) {
+    const fill = noData
+      ? `url(#${patternId})`
+      : i < safeLevel
+        ? (colors[i] ?? emptyColor)
+        : emptyColor;
+    const d = sectorPath(cx, cy, ri, ro, i * seg, (i + 1) * seg);
+    paths += `<path d="${d}" fill="${fill}"/>`;
+  }
+
+  // Gap: one stroked outline layer over the fills (drawn once per segment path
+  // so inner/outer arcs and radial edges all get the gapColor line, matching
+  // the per-arc border Chart.js drew). Skipped when gap is 0.
+  let strokes = "";
+  if (gap > 0) {
+    for (let i = 0; i < segments; i++) {
+      const d = sectorPath(cx, cy, ri, ro, i * seg, (i + 1) * seg);
+      strokes +=
+        `<path d="${d}" fill="none" stroke="${gapColor}" ` +
+        `stroke-width="${n(gap)}"/>`;
+    }
+  }
+
+  const defs = noData
+    ? `<defs>${buildRingNoiseSvgPattern(patternId, noiseColor, { seed: noiseSeed })}</defs>`
+    : "";
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" ` +
+    `viewBox="0 0 ${n(size)} ${n(size)}" style="display:block" aria-hidden="true">` +
+    `${defs}${paths}${strokes}</svg>`
+  );
+}

--- a/src/rendering/level-circle-mixin.js
+++ b/src/rendering/level-circle-mixin.js
@@ -12,18 +12,9 @@ import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { getSvgContent } from "../pollenprognos-svgs.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { ringSegmentsForIntegration } from "../utils/level-counts.js";
-import { buildNoiseCanvasPattern, buildNoiseSvgUri, hashStringSeed } from "../utils/no-data-pattern.js";
+import { buildNoiseSvgUri, hashStringSeed } from "../utils/no-data-pattern.js";
+import { buildDonutSvg } from "./donut.js";
 import { ALLERGEN_ICON_FALLBACK, toCanonicalAllergenKey } from "../constants.js";
-import {
-  Chart,
-  ArcElement,
-  DoughnutController,
-  Tooltip,
-  Legend,
-} from "chart.js/auto";
-
-// Register Chart.js components once at module load time.
-Chart.register(ArcElement, DoughnutController, Tooltip, Legend);
 
 // The tap_action types the shared handler knows how to perform.
 const TAP_ACTION_TYPES = ["more-info", "navigate", "call-service"];
@@ -87,23 +78,22 @@ export function resolveTapActionType(tapAction) {
  * LevelCircleMixin — adds the level-circle / icon-in-ring rendering engine
  * to any LitElement subclass.
  *
+ * The level ring is rendered declaratively as an inline SVG (see donut.js), so
+ * there is no chart cache, no destroy/recreate lifecycle, and no post-render
+ * DOM patching: the whole circle (ring + centered icon + numeric value) comes
+ * out of _renderLevelCircle in one lit template.
+ *
  * Contributes:
- *   - _chartCache field
  *   - _noDataDotColor(), _getSvgKey(), _colorForLevel(), _levelColorForLevel(),
  *     _getGapColor(), _getEffectiveSvgKey(), _iconInRingColor()
  *   - _renderLevelCircle(), _buildLevelRingConfig()
  *   - _openEntity()
- *   - _rebuildCharts()
- *   - Lifecycle hooks: updated(), connectedCallback(), disconnectedCallback()
- *     (all call super so the chain reaches LitElement).
  *
  * @param {typeof LitElement} Base
  * @returns {typeof LitElement}
  */
 export const LevelCircleMixin = (Base) =>
   class extends Base {
-    _chartCache = new Map();
-
     // ---------------------------------------------------------------------------
     // Color helpers
     // ---------------------------------------------------------------------------
@@ -268,21 +258,75 @@ export const LevelCircleMixin = (Base) =>
       entityId = null,
       clickable = true,
     ) {
-      // Create a unique key for this chart configuration. `size` is part of the
-      // key so a size change (e.g. the badge's badge_scale live-preview) forces
-      // a fresh canvas at the new dimensions instead of reusing a cached Chart
-      // whose canvas width/height was fixed at the old size.
-      const chartId = `chart-${allergen}-${dayIndex}-${level}-${size}`;
+      // Stable id per cell (allergen + day + level + size). Kept for theme /
+      // card-mod targeting and as the no-data noise seed source, so adjacent
+      // no-data rings get distinct textures.
+      const circleId = `chart-${allergen}-${dayIndex}-${level}-${size}`;
 
-      // Use attributes instead of properties so values persist if DOM is cloned
       const noDataDistinct = this.config?.show_no_data_distinct !== false;
       // `level < 0` rather than `=== -1` so per-integration scaling doesn't
       // hide the no-data sentinel. E.g. DWD scales raw state by 2 in the
       // daily-row path, so an adapter-emitted -1 reaches here as -2.
-      const stateAttr = noDataDistinct && level < 0 ? "no_data" : "ok";
+      const isNoData = noDataDistinct && level < 0;
+      const stateAttr = isNoData ? "no_data" : "ok";
+
+      const numSegments = colors.length;
+      const donutSvg = buildDonutSvg({
+        level,
+        segments: numSegments,
+        colors,
+        emptyColor,
+        gapColor,
+        thickness,
+        gap,
+        size,
+        noData: isNoData,
+        noiseColor: isNoData ? this._noDataDotColor() : undefined,
+        noiseSeed: hashStringSeed(circleId),
+      });
+
+      // Centered ring icon (#227): only when a key is set and its SVG exists.
+      const svgForIcon = iconKey ? getSvgContent(iconKey) : null;
+      const hasRingIcon = !!svgForIcon;
+      let ringIcon = "";
+      if (hasRingIcon) {
+        const innerHole = size * (1 - thickness / 100);
+        const iconDiameter = Math.max(1, Math.round(innerHole * iconSizeRatio));
+        // aria-hidden: the numeric level (data-display-level) is the SR signal.
+        ringIcon = html`
+          <div
+            class="ring-icon"
+            aria-hidden="true"
+            style="width: ${iconDiameter}px; height: ${iconDiameter}px; color: ${iconColor};"
+          >
+            ${unsafeSVG(svgForIcon)}
+          </div>
+        `;
+      }
+
+      // Numeric value overlay: suppressed when a ring icon occupies the hole
+      // (they'd collide) and for negative/no-data values.
+      const showValue = !!this.config?.show_value_numeric_in_circle;
+      const fontWeight = this.config?.levels_text_weight || "normal";
+      const fontSizeRatio = this.config?.levels_text_size || 0.2;
+      const textColor =
+        this.config?.levels_text_color || "var(--primary-text-color)";
+      let valueText = "";
+      if (showValue && displayLevel >= 0 && !hasRingIcon) {
+        valueText = html`
+          <div
+            class="level-value-text"
+            style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; line-height: 1; font-size: ${size *
+            fontSizeRatio}px; font-weight: ${fontWeight}; color: ${textColor};"
+          >
+            ${displayLevel}
+          </div>
+        `;
+      }
+
       return html`
         <div
-          id="${chartId}"
+          id="${circleId}"
           class="level-circle"
           style="display: inline-block; width: ${size}px; height: ${size}px; position: relative;${clickable &&
           entityId
@@ -291,28 +335,15 @@ export const LevelCircleMixin = (Base) =>
           data-level="${level}"
           data-display-level="${displayLevel}"
           data-state="${stateAttr}"
-          data-colors="${JSON.stringify(colors)}"
-          data-empty-color="${emptyColor}"
-          data-gap-color="${gapColor}"
-          data-thickness="${thickness}"
-          data-gap="${gap}"
-          data-size="${size}"
-          data-show-value="${this.config &&
-          this.config.show_value_numeric_in_circle}"
-          data-font-weight="${this.config?.levels_text_weight || "normal"}"
-          data-font-size-ratio="${this.config?.levels_text_size || 0.2}"
-          data-text-color="${this.config?.levels_text_color ||
-          "var(--primary-text-color)"}"
-          data-icon-key="${iconKey}"
-          data-icon-color="${iconColor}"
-          data-icon-size-ratio="${iconSizeRatio}"
           @click=${(e) => {
             if (clickable && entityId) {
               e.stopPropagation();
               this._openEntity(entityId);
             }
           }}
-        ></div>
+        >
+          ${unsafeSVG(donutSvg)}${ringIcon}${valueText}
+        </div>
       `;
     }
 
@@ -549,316 +580,15 @@ export const LevelCircleMixin = (Base) =>
     }
 
     // ---------------------------------------------------------------------------
-    // Chart lifecycle
+    // Chart lifecycle (removed)
     // ---------------------------------------------------------------------------
-
-    /**
-     * Build or refresh all level-circle charts in the current DOM.
-     * Chart options are stored as data attributes so charts can be
-     * reconstructed after the DOM is cloned or replaced.
-     */
-    _rebuildCharts() {
-      const containers = this.renderRoot?.querySelectorAll(".level-circle") || [];
-      const activeIds = new Set();
-
-      // Resolve the no-data dot color once per rebuild. _noDataDotColor() reads
-      // getComputedStyle which is non-trivial; caching here both saves work
-      // when many circles are no-data AND lets the update branch detect a
-      // theme-color change (chart._noDataColor !== noDataColor) so stale
-      // patterns get rebuilt instead of reused indefinitely.
-      const noDataColor = this._noDataDotColor();
-
-      containers.forEach((container) => {
-        activeIds.add(container.id);
-
-        // Extract values from data attributes
-        const level = Number(container.dataset.level || 0);
-        const displayLevel = Number(container.dataset.displayLevel ?? level);
-        const colors = JSON.parse(container.dataset.colors || "[]");
-        const numSegments = colors.length;
-        const safeLevel = Math.min(level, numSegments);
-        const emptyColor = container.dataset.emptyColor;
-        const gapColor = container.dataset.gapColor;
-        const thickness = Number(container.dataset.thickness);
-        const gap = Number(container.dataset.gap);
-        const size = Number(container.dataset.size);
-        const showValue = container.dataset.showValue === "true";
-        const isNoData = container.dataset.state === "no_data";
-
-        // Get custom styling from data attributes
-        const fontWeight = container.dataset.fontWeight || "normal";
-        const fontSizeRatio = parseFloat(container.dataset.fontSizeRatio) || 0.2;
-        const textColor =
-          container.dataset.textColor || "var(--primary-text-color)";
-
-        // Retrieve existing chart if it exists
-        let chart = this._chartCache.get(container.id);
-
-        // Recreate chart if missing or detached
-        if (!chart || !container.contains(chart.canvas)) {
-          if (chart) chart.destroy();
-          container.innerHTML = "";
-          const canvas = document.createElement("canvas");
-          canvas.width = size;
-          canvas.height = size;
-          container.appendChild(canvas);
-
-          const canvasCtx = canvas.getContext("2d");
-          // No-data: fill every segment with the noise tile pattern so the
-          // ring looks visibly distinct from a real "level 0" (which is just
-          // the empty color repeated). Each chart gets its own seed derived
-          // from the container id (allergen+dayIndex+level) so adjacent
-          // no-data circles don't display identical clumps. Falls back to
-          // emptyColor if pattern creation fails (e.g. headless ctx with no
-          // createPattern).
-          const noisePattern = isNoData
-            ? buildNoiseCanvasPattern(canvasCtx, noDataColor, {
-                seed: hashStringSeed(container.id),
-              })
-            : null;
-          const fill = noisePattern ?? emptyColor;
-          const data = Array(numSegments).fill(1);
-          const bg = isNoData
-            ? Array(numSegments).fill(fill)
-            : Array(numSegments)
-                .fill(emptyColor)
-                .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
-          const bc = Array(numSegments).fill(gapColor);
-
-          chart = new Chart(canvasCtx, {
-            type: "doughnut",
-            data: {
-              labels: Array(numSegments).fill(""),
-              datasets: [
-                {
-                  data,
-                  backgroundColor: bg,
-                  borderColor: bc,
-                  borderWidth: gap,
-                },
-              ],
-            },
-            options: {
-              rotation: -Math.PI / 2,
-              cutout: `${100 - thickness}%`,
-              responsive: false,
-              maintainAspectRatio: false,
-              animation: {
-                duration: 0,
-                animateRotate: false,
-                animateScale: false,
-                easing: "linear",
-              },
-              transitions: {
-                active: {
-                  animation: {
-                    duration: 0,
-                    animateRotate: false,
-                    animateScale: false,
-                    easing: "linear",
-                  },
-                },
-                show: {
-                  animations: {
-                    numbers: { duration: 0, easing: "linear" },
-                    colors: { duration: 0, easing: "linear" },
-                  },
-                },
-                hide: {
-                  animations: {
-                    numbers: { duration: 0, easing: "linear" },
-                    colors: { duration: 0, easing: "linear" },
-                  },
-                },
-              },
-              plugins: {
-                legend: { display: false },
-                tooltip: { enabled: false },
-              },
-            },
-          });
-
-          // Tag the chart with the dot color used to build this pattern so
-          // a later theme-color change can invalidate the cached pattern.
-          if (isNoData) chart._noDataColor = noDataColor;
-          // Cache the geometry that the chart was actually built with so
-          // the update branch can detect when thickness/gap change (e.g.
-          // the icon_in_ring auto-toggle swaps thickness 60 ↔ 35).
-          chart._thicknessApplied = thickness;
-          chart._gapApplied = gap;
-
-          this._chartCache.set(container.id, chart);
-        } else {
-          // Update existing chart only if colors actually changed
-          const datasets = chart.data.datasets;
-          if (datasets && datasets[0]) {
-            // Geometry change (thickness/gap) doesn't show up under the
-            // colors-only update path. The chartId is keyed by allergen +
-            // dayIndex + level, so a thickness flip on toggle keeps the
-            // same id and the cached Chart instance survives. Detect and
-            // propagate before computing colors so cutout matches.
-            const geometryChanged =
-              chart._thicknessApplied !== thickness ||
-              chart._gapApplied !== gap;
-            if (geometryChanged) {
-              chart.options.cutout = `${100 - thickness}%`;
-              datasets[0].borderWidth = gap;
-              chart._thicknessApplied = thickness;
-              chart._gapApplied = gap;
-            }
-            const oldBg = datasets[0].backgroundColor;
-            let bg;
-            if (isNoData) {
-              // Reuse the cached pattern if the chart already has one in oldBg
-              // AND the theme dot color hasn't changed since it was built.
-              // Otherwise rebuild so a theme switch propagates through.
-              const existingPattern = oldBg.find(
-                (c) => typeof c === "object" && c !== null,
-              );
-              const colorChanged = chart._noDataColor !== noDataColor;
-              let pattern;
-              if (existingPattern && !colorChanged) {
-                pattern = existingPattern;
-              } else {
-                pattern =
-                  buildNoiseCanvasPattern(
-                    chart.canvas.getContext("2d"),
-                    noDataColor,
-                    { seed: hashStringSeed(container.id) },
-                  ) ?? emptyColor;
-                chart._noDataColor = noDataColor;
-              }
-              bg = Array(oldBg.length).fill(pattern);
-            } else {
-              bg = Array(oldBg.length)
-                .fill(emptyColor)
-                .map((c, i) => (i < safeLevel ? colors[i] : emptyColor));
-            }
-
-            const colorsChanged =
-              bg.length !== oldBg.length || bg.some((c, i) => c !== oldBg[i]);
-            if (colorsChanged || geometryChanged) {
-              datasets[0].backgroundColor = bg;
-              chart.update("none");
-            }
-          }
-        }
-
-        // Add or update the centered allergen icon (#227 icon-in-ring).
-        // Data attributes drive everything; the chart canvas was just
-        // (re)created above so we always re-append at the end if needed.
-        const iconKey = container.dataset.iconKey || "";
-        const iconColor = container.dataset.iconColor || "";
-        const iconSizeRatio =
-          parseFloat(container.dataset.iconSizeRatio) ||
-          LEVELS_DEFAULTS.icon_in_ring_size_ratio;
-        let ringIcon = container.querySelector(".ring-icon");
-        // Resolve the SVG once; if missing, fall back to the no-icon
-        // path so the numeric overlay below can render instead of an
-        // empty .ring-icon shell.
-        const svgForIcon =
-          iconKey && ringIcon?.dataset.iconKey === iconKey
-            ? null // already mounted with this key; skip refetch
-            : iconKey
-              ? getSvgContent(iconKey)
-              : null;
-        const hasRenderableIcon =
-          iconKey &&
-          (ringIcon?.dataset.iconKey === iconKey || svgForIcon !== null);
-        if (hasRenderableIcon) {
-          const innerHole = size * (1 - thickness / 100);
-          const iconDiameter = Math.max(1, Math.round(innerHole * iconSizeRatio));
-          if (!ringIcon) {
-            ringIcon = document.createElement("div");
-            ringIcon.className = "ring-icon";
-            // Mark as decorative — the level value (data-display-level on
-            // the parent .level-circle) is the screen-reader signal; the
-            // centered SVG is duplicate visual information.
-            ringIcon.setAttribute("aria-hidden", "true");
-            container.appendChild(ringIcon);
-          }
-          ringIcon.style.width = `${iconDiameter}px`;
-          ringIcon.style.height = `${iconDiameter}px`;
-          ringIcon.style.color = iconColor;
-          if (svgForIcon !== null && ringIcon.dataset.iconKey !== iconKey) {
-            ringIcon.innerHTML = svgForIcon;
-            ringIcon.dataset.iconKey = iconKey;
-          }
-        } else if (ringIcon) {
-          ringIcon.remove();
-          ringIcon = null;
-        }
-
-        // Add or update numeric text overlay (suppress negative values).
-        // Only mutate DOM when the displayed value actually changed.
-        // Suppressed when a renderable ring-icon occupies the donut hole,
-        // to avoid the icon and the number colliding. When iconKey is
-        // set but the SVG is missing, hasRenderableIcon is false above
-        // and we fall back to the numeric overlay.
-        const existingText = container.querySelector(".level-value-text");
-        if (showValue && displayLevel >= 0 && !hasRenderableIcon) {
-          if (existingText && existingText.textContent === String(displayLevel)) {
-            // Value unchanged — skip DOM mutation.
-          } else {
-            if (existingText) existingText.remove();
-            const valueText = document.createElement("div");
-            valueText.className = "level-value-text";
-            valueText.textContent = displayLevel;
-            // Fill the ring box and flex-centre the digit, so it is centred
-            // optically rather than anchored to the text baseline (which made
-            // the number read slightly high). line-height:1 keeps the line box
-            // tight; explicit edges (not the `inset` shorthand) for the legacy
-            // browser build.
-            valueText.style.position = "absolute";
-            valueText.style.top = "0";
-            valueText.style.left = "0";
-            valueText.style.right = "0";
-            valueText.style.bottom = "0";
-            valueText.style.display = "flex";
-            valueText.style.alignItems = "center";
-            valueText.style.justifyContent = "center";
-            valueText.style.lineHeight = "1";
-            valueText.style.fontSize = `${size * fontSizeRatio}px`;
-            valueText.style.fontWeight = fontWeight;
-            valueText.style.color = textColor;
-            container.appendChild(valueText);
-          }
-        } else if (existingText) {
-          existingText.remove();
-        }
-      });
-
-      // Remove charts whose containers disappeared
-      this._chartCache.forEach((cachedChart, id) => {
-        if (!activeIds.has(id)) {
-          cachedChart.destroy();
-          this._chartCache.delete(id);
-        }
-      });
-    }
-
-    // ---------------------------------------------------------------------------
-    // Lifecycle hooks (chart subset only — card-specific logic stays on card)
-    // ---------------------------------------------------------------------------
-
-    updated(changedProps) {
-      if (super.updated) super.updated(changedProps);
-      // After rendering, ensure all charts exist.
-      this.updateComplete.then(() => this._rebuildCharts());
-    }
-
-    // Recreate charts when element is connected, useful after DOM cloning.
-    connectedCallback() {
-      super.connectedCallback();
-      Promise.resolve().then(() => this._rebuildCharts());
-    }
-
-    // Clean up charts when component is disconnected.
-    disconnectedCallback() {
-      this._chartCache.forEach((chart) => {
-        chart.destroy();
-      });
-      this._chartCache.clear();
-      super.disconnectedCallback();
-    }
+    //
+    // The level ring is now inline SVG rendered declaratively in
+    // _renderLevelCircle, so the former _rebuildCharts() / _chartCache /
+    // destroy-recreate lifecycle and the updated()/connectedCallback()/
+    // disconnectedCallback() overrides are gone: lit re-renders the ring, the
+    // centered icon and the numeric value together on every update, and there
+    // is nothing imperative left to tear down. The card and badge keep their
+    // own lifecycle hooks (subscriptions etc.) untouched.
   };
+

--- a/src/utils/no-data-pattern.ts
+++ b/src/utils/no-data-pattern.ts
@@ -32,7 +32,7 @@ const DEFAULT_SEED = 13;
  * The order matters: `&` first, so we don't double-encode entity refs we
  * introduce in later replacements.
  */
-function escapeXmlAttr(value: unknown): string {
+export function escapeXmlAttr(value: unknown): string {
   return String(value)
     .replace(/&/g, "&amp;")
     .replace(/"/g, "&quot;")

--- a/src/utils/no-data-pattern.ts
+++ b/src/utils/no-data-pattern.ts
@@ -154,6 +154,80 @@ export function buildNoiseTileCanvas(
 }
 
 /**
+ * Build the inner markup of an SVG `<pattern>` reproducing the ring noise tile
+ * (pixel static + sparse scratches) as vector shapes instead of a canvas tile.
+ * Mirrors buildNoiseTileCanvas element-for-element and consumes the seeded RNG
+ * in the same order, so a given seed yields the same visual density. Returns a
+ * full `<pattern id="...">...</pattern>` string ready to drop into an SVG
+ * `<defs>`; pure string building, so it works in headless/Node contexts where
+ * the canvas variant returns null.
+ *
+ * @param id      DOM id for the pattern (referenced via url(#id))
+ * @param color   dot/scratch color
+ */
+export function buildRingNoiseSvgPattern(
+  id: string,
+  color = "#888888",
+  opts: {
+    tile?: number;
+    seed?: number;
+    pixDensity?: number;
+    scratchDensity?: number;
+    maxPx?: number;
+  } = {},
+): string {
+  const tile = opts.tile ?? RING_TILE;
+  const seed = opts.seed ?? DEFAULT_SEED;
+  const pixDensity = opts.pixDensity ?? RING_PIX_DENSITY;
+  const scratchFactor = opts.scratchDensity ?? RING_SCRATCH_DENSITY_FACTOR;
+  const maxPx = opts.maxPx ?? RING_MAX_PIX_SIZE;
+  const rng = mulberry32(seed);
+  const safeColor = escapeXmlAttr(color);
+  const pixArea = tile * tile;
+
+  let body = "";
+
+  // Layer 1: pixel static. Mostly 1px squares, ~15% 2px; the bigger squares
+  // get dimmer so they don't visually clump. (Mirror of buildNoiseTileCanvas.)
+  const pixCount = Math.round(pixArea * pixDensity);
+  for (let i = 0; i < pixCount; i++) {
+    const x = Math.floor(rng() * tile);
+    const y = Math.floor(rng() * tile);
+    const r = rng();
+    let dotSz;
+    if (maxPx === 2) dotSz = r < 0.85 ? 1 : 2;
+    else dotSz = r < 0.7 ? 1 : r < 0.96 ? 2 : 3;
+    const opBase = 0.35 + rng() * 0.55;
+    const alpha = dotSz === 1 ? opBase : opBase * 0.6;
+    body +=
+      `<rect x="${x}" y="${y}" width="${dotSz}" height="${dotSz}" ` +
+      `fill="${safeColor}" fill-opacity="${alpha.toFixed(2)}"/>`;
+  }
+
+  // Layer 2: sparse short scratches — thin, dim, short directional accents.
+  const scratchCount = Math.round(pixArea * 0.06 * scratchFactor);
+  for (let i = 0; i < scratchCount; i++) {
+    const x = rng() * tile;
+    const y = rng() * tile;
+    const angle = rng() * Math.PI;
+    const len = 1.5 + rng() * 2.5;
+    const alpha = 0.25 + rng() * 0.35;
+    const x2 = x + Math.cos(angle) * len;
+    const y2 = y + Math.sin(angle) * len;
+    body +=
+      `<line x1="${x.toFixed(1)}" y1="${y.toFixed(1)}" ` +
+      `x2="${x2.toFixed(1)}" y2="${y2.toFixed(1)}" ` +
+      `stroke="${safeColor}" stroke-width="0.6" stroke-linecap="round" ` +
+      `stroke-opacity="${alpha.toFixed(2)}"/>`;
+  }
+
+  return (
+    `<pattern id="${escapeXmlAttr(id)}" patternUnits="userSpaceOnUse" ` +
+    `width="${tile}" height="${tile}">${body}</pattern>`
+  );
+}
+
+/**
  * Build a Chart.js-compatible CanvasPattern for the ring. Pass the
  * destination chart's 2D context so the pattern is allocated in the right
  * rendering context.

--- a/test/rendering/donut.test.js
+++ b/test/rendering/donut.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { buildDonutSvg } from "../../src/rendering/donut.ts";
+
+const base = {
+  level: 3,
+  segments: 6,
+  colors: ["#a", "#b", "#c", "#d", "#e", "#f"],
+  emptyColor: "#eee",
+  gapColor: "#fff",
+  thickness: 60,
+  gap: 1,
+  size: 48,
+};
+
+// Fill layer only: stroke paths carry `fill:none;stroke:...` in the same
+// style attribute, so require the style to be a single fill declaration.
+const fillPaths = (svg) =>
+  [...svg.matchAll(/<path d="[^"]*" style="fill:([^";]*)"\/>/g)].map(
+    (m) => m[1],
+  );
+
+describe("buildDonutSvg", () => {
+  it("renders one fill path per segment and a square viewBox", () => {
+    const svg = buildDonutSvg(base);
+    expect(fillPaths(svg)).toHaveLength(6);
+    expect(svg).toContain('viewBox="0 0 48 48"');
+  });
+
+  it("fills the first `level` segments with their colors, the rest empty", () => {
+    const fills = fillPaths(buildDonutSvg(base));
+    expect(fills.slice(0, 3)).toEqual(["#a", "#b", "#c"]);
+    expect(fills.slice(3)).toEqual(["#eee", "#eee", "#eee"]);
+  });
+
+  it("clamps level below 0 to all-empty and above segments to all-filled", () => {
+    const none = fillPaths(buildDonutSvg({ ...base, level: -1, noData: false }));
+    expect(none).toEqual(Array(6).fill("#eee"));
+    const all = fillPaths(buildDonutSvg({ ...base, level: 99 }));
+    expect(all).toEqual(base.colors);
+  });
+
+  it("degenerates to pie wedges at thickness 100 (sectors start at the center)", () => {
+    const svg = buildDonutSvg({ ...base, thickness: 100 });
+    // Pie wedges start with a move-to at the center point (cx == cy == size/2).
+    expect(svg).toContain('d="M24 24 L');
+  });
+
+  it("skips the stroke layer entirely when gap is 0", () => {
+    const svg = buildDonutSvg({ ...base, gap: 0 });
+    expect(svg).not.toContain("stroke");
+  });
+
+  it("uses the noise pattern for every segment in no-data mode", () => {
+    const svg = buildDonutSvg({
+      ...base,
+      noData: true,
+      noiseColor: "#888",
+      noiseSeed: 42,
+    });
+    expect(svg).toContain("<pattern");
+    expect(fillPaths(svg)).toEqual(Array(6).fill("url(#ppd-noise-42)"));
+  });
+
+  it("attribute-escapes color strings so YAML config cannot inject markup", () => {
+    const hostile = 'red" onmouseover="alert(1)';
+    const svg = buildDonutSvg({
+      ...base,
+      colors: [hostile, "#b", "#c", "#d", "#e", "#f"],
+      gapColor: '</svg><script>alert(2)</script>',
+    });
+    expect(svg).not.toContain('" onmouseover="');
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain("&quot; onmouseover=&quot;");
+    expect(svg).toContain("&lt;script&gt;");
+  });
+});


### PR DESCRIPTION
Tenth PR of the v4.0.0 migration (#259): Chart.js is replaced by a hand-written SVG level ring. This removes the card's largest dependency: **the bundle drops from 1241 kB to 949 kB raw, 291 kB to 209 kB gzip (−28 %).**

## What

- **`src/rendering/donut.ts`** (new, TypeScript): a pure `buildDonutSvg()` that reproduces the Chart.js doughnut geometry exactly — N segments clockwise from 12 o'clock (rotation −90°), inner radius from the cutout percentage, per-segment gap strokes matching the old border rendering, filled/empty/gap colors passed in resolved (color logic stays in the mixin). Colors are set via `style=""` rather than presentation attributes so CSS custom-property references (`var(--divider-color)`) resolve in every engine.
- **No-data pattern**: an SVG `<pattern>` generated with the same constants and RNG order as the old canvas noise tile — identical density, per-cell seed preserved.
- **The mixin sheds its imperative rendering** (865 → 594 lines): the SVG renders declaratively in the lit template, which deletes the chart cache, the destroy/recreate lifecycle, the post-render rebuild pass and the monkey-patched instance fields. Public surface toward card/badge unchanged; tap-action logic untouched.
- **chart.js dropped from dependencies.** No animation replacement: the Chart.js animation was fully disabled in the old config.
- The old canvas noise helpers stay exported for their unit tests; they are removed together with the test adjustment in the upcoming rendering-TS PR.

## Parity verification

Same-time A/B against a dev-baseline bundle on the HA test instance (same data, minutes apart): pp card, atmo card with a forced *Indisponible* day (exercises the no-data pattern), kleenex card and the badge row. Pixel diffs are 0.9–2.6 % weak sub-pixel deviations confined to the segment-gap hairlines and ring edges (anti-aliasing), with no visible difference at any zoom; the no-data noise ring is visually equivalent. Declared deviations: the outer radius sits ~gap/2 inside the old canvas clipping, and the noise is vector-rasterized rather than canvas-rasterized.

Interaction suite (navigate-away/return, resize, modes view) clean with zero console/page errors. 1320/1320 tests green; typecheck and lint clean.
