### PR TITLE
(config) Normalize and freeze card config at the setConfig boundary

### DIFF
--- a/src/editor/sections/appearance.ts
+++ b/src/editor/sections/appearance.ts
@@ -59,7 +59,7 @@ export function renderAppearanceSection(
                   style="width: 120px;"
                 ></ha-slider>
                 ${editor._renderNumberField({
-                  value: (c.icon_size as number) ?? 48,
+                  value: (c.icon_size as unknown as number) ?? 48,
                   min: 16,
                   max: 128,
                   step: 1,

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -34,6 +34,12 @@ import {
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
 import { deepEqual } from "./utils/confcompare.js";
+import {
+  normalizeCardConfig,
+  mergeCardConfig,
+  finalizeCardConfig,
+  cardAllowedFields,
+} from "./utils/config-normalize.js";
 import { computeGridOptions } from "./utils/grid-options.js";
 import {
   detectIntegrationStates,
@@ -641,40 +647,21 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     // this.config.integration is never undefined.
     if (!integration) integration = stub.integration as string | undefined;
 
-    // Only keep allowed fields from user config
-    const allowedFields = Object.keys(stub).concat([
-      "type",
-      "card_mod",
-      "allergens",
-      "icon_size",
-      "icon_color_mode",
-      "icon_color",
-      "city",
-      "location",
-      "region_id",
-      "tap_action",
-      "debug",
-      "show_version",
-      "title",
-      "days_to_show",
-      "date_locale",
-    ]);
-    const cleanedUserConfig: Record<string, unknown> = {};
-    for (const k of allowedFields) {
-      if (k in config) cleanedUserConfig[k] = config[k];
-    }
-
-    // Build final config from stub + cleaned user params
-    const nextConfig = {
-      ...stub,
-      ...cleanedUserConfig,
+    // Single validation/coercion boundary: keep allowed fields, merge onto the
+    // stub, coerce known-typed YAML fields, freeze (see config-normalize.ts).
+    const nextConfig = normalizeCardConfig(config, stub, {
       integration,
-    } as CardConfig;
+      filter: true,
+    });
 
     // --- Detect cosmetic-only updates (e.g. icon_size, text_size_ratio) ---
+    // Compare the *coerced* next values against the (also coerced) current
+    // config over exactly the user-provided allowed fields, so a value that
+    // only re-canonicalises (e.g. "4" -> 4) is not mistaken for a change.
     const prevConfig = this.config || {};
-    const changedKeys = Object.keys(cleanedUserConfig).filter(
-      (k) => !deepEqual(cleanedUserConfig[k], prevConfig[k]),
+    const userKeys = cardAllowedFields(stub).filter((k) => k in config);
+    const changedKeys = userKeys.filter(
+      (k) => !deepEqual(nextConfig[k], prevConfig[k]),
     );
     const onlyCosmetic =
       changedKeys.length > 0 &&
@@ -767,24 +754,29 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       baseStub = getStubConfig("pp");
     }
 
-    // Sätt config rätt — utan allergens
+    // Build config mutation-free through the shared boundary. set hass keeps
+    // the historical full-spread merge (filter:false) — unlike setConfig it does
+    // NOT strip unknown keys — then layers the hass-driven derivations
+    // (PLU location stripping, allergens, date_locale, autodetected location) by
+    // constructing new objects, never mutating in place. The coerce+freeze tail
+    // is shared via finalizeCardConfig, so the final cfg is frozen like
+    // setConfig's nextConfig.
     const { allergens, ...userConfigWithoutAllergens } = this._userConfig;
-    const cfg = {
-      ...baseStub,
-      ...userConfigWithoutAllergens,
-      integration, // Use the normalized integration value
-    } as CardConfig;
+    let assembled = mergeCardConfig(userConfigWithoutAllergens, baseStub!, {
+      integration,
+      filter: false,
+    });
 
     if (integration === "plu") {
-      // cfg keys come from CardConfig's (non-optional) index signature, so the
-      // delete operand isn't statically optional; cast for the delete. The
-      // mutation itself is unchanged and slated for cleanup in the config
-      // boundary work.
-      delete (cfg as Record<string, unknown>).city;
-      delete (cfg as Record<string, unknown>).region_id;
-      // Preserve cfg.location: "manual" is a meaningful value that signals
-      // the adapter's manual-mode branch (entity_prefix-based lookup).
-      // Dropping it silently disabled PLU manual mode entirely.
+      // PLU always reports Luxembourg: drop city/region_id so they can't leak
+      // into the adapter. location is preserved ("manual" is a meaningful value
+      // that signals the adapter's manual-mode branch, entity_prefix lookup);
+      // dropping it silently disabled PLU manual mode entirely.
+      assembled = Object.fromEntries(
+        Object.entries(assembled).filter(
+          ([k]) => k !== "city" && k !== "region_id",
+        ),
+      );
     }
 
     if (
@@ -801,7 +793,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           allergens,
         );
       }
-      cfg.allergens = allergens;
+      assembled = { ...assembled, allergens };
     } else {
       if (this.debug) {
         console.debug(
@@ -810,34 +802,48 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         );
       }
       // Om integrationen INTE är explicit (autodetect): använd stubben
-      cfg.allergens = (getStubConfig(integration) ||
-        getStubConfig("pp"))!.allergens;
+      assembled = {
+        ...assembled,
+        allergens: (getStubConfig(integration) || getStubConfig("pp"))!
+          .allergens,
+      };
     }
 
-    // Fyll date_locale
-    if (!cfg.hasOwnProperty("date_locale")) {
+    // Fyll date_locale. Every stub carries a date_locale key (value undefined),
+    // so this branch is inert today; kept faithful in case a stub ever omits it.
+    if (!Object.prototype.hasOwnProperty.call(assembled, "date_locale")) {
       const detectedLangCode = detectLang(hass, null as unknown as string);
       const localeTag =
         this._hass?.locale?.language ||
         this._hass?.language ||
         `${detectedLangCode}-${detectedLangCode.toUpperCase()}`;
-      cfg.date_locale = localeTag;
+      assembled = { ...assembled, date_locale: localeTag };
       if (this.debug) {
-        console.debug("[Card] auto-filling date_locale:", cfg.date_locale);
+        console.debug(
+          "[Card] auto-filling date_locale:",
+          assembled.date_locale,
+        );
       }
     }
 
     // Automatic region/city/location detection unless manual mode is selected.
     // Shared autoSelectLocation() returns { key, value } for the integration;
     // the "manual"/already-set guard stays here so PLU's earlier city/region
-    // deletion and explicit "manual" mode keep their meaning. (The card element
+    // stripping and explicit "manual" mode keep their meaning. (The card element
     // now also auto-selects GP/MSW locations, matching the editor.)
-    const autoLoc = autoSelectLocation(integration, cfg, hass, detection);
-    if (autoLoc && cfg[autoLoc.key] !== "manual" && !cfg[autoLoc.key]) {
-      cfg[autoLoc.key] = autoLoc.value;
+    const autoLoc = autoSelectLocation(integration, assembled, hass, detection);
+    if (
+      autoLoc &&
+      assembled[autoLoc.key] !== "manual" &&
+      !assembled[autoLoc.key]
+    ) {
+      assembled = { ...assembled, [autoLoc.key]: autoLoc.value };
       if (this.debug)
         console.debug(`[Card] Auto-set ${autoLoc.key}:`, autoLoc.value);
     }
+
+    // Coerce known-typed fields and freeze (shared boundary tail).
+    const cfg = finalizeCardConfig(assembled, baseStub!);
 
     // Only update reactive properties when values actually changed.
     // Lit's auto-generated accessor triggers requestUpdate on every
@@ -880,9 +886,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // the cached discovery from set hass() to avoid a second registry scan.
         const dwdDiscovery = getDwdDiscovery();
         const wantedLocation =
-          cfg.region_id && cfg.region_id !== "manual"
-            ? (cfg.region_id as string)
-            : "";
+          cfg.region_id && cfg.region_id !== "manual" ? cfg.region_id : "";
         const match = resolveLocationByKey(dwdDiscovery, wantedLocation, {
           slugExtractor: (eid) => {
             const m = eid.match(/_(\d+)$/);
@@ -900,9 +904,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // Reuses cached discovery from set hass() to avoid a second scan.
         const peuDiscovery = getPeuDiscovery();
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? (cfg.location as string)
-            : "";
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const peuMatch = resolveLocationByKey(peuDiscovery, wantedLocation, {
           slugExtractor: extractPeuLocationSlugFromEntityId,
         });
@@ -967,13 +969,13 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
               attr.friendly_name?.match(/\((.*?)\)/)?.[1] ||
               "";
           }
-          loc = wantedSlug ? title || (cfg.location as string) || "" : title;
+          loc = wantedSlug ? title || cfg.location || "" : title;
         }
       } else if (integration === "silam") {
         // Primärt: discovery-baserad title
         let title = "";
         const configLocation =
-          cfg.location === "manual" ? "" : (cfg.location as string) || "";
+          cfg.location === "manual" ? "" : cfg.location || "";
         if (cfg.location !== "manual") {
           const discoveredLoc = resolveDiscoveredLocation(
             silamDiscovery,
@@ -1046,7 +1048,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
 
         loc =
           cfg.location && cfg.location !== "manual"
-            ? title || (cfg.location as string) || ""
+            ? title || cfg.location || ""
             : title;
       } else if (integration === "kleenex") {
         // Kleenex pollen radar: extract location from sensor attributes
@@ -1070,7 +1072,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         let match = null;
         if (cfg.location === "manual") {
           // In manual mode, use entity_prefix to find matching sensor
-          let prefix = (cfg.entity_prefix as string) || "";
+          let prefix = cfg.entity_prefix || "";
           // Remove 'sensor.' prefix if user included it
           if (prefix.startsWith("sensor.")) {
             prefix = prefix.substring(7);
@@ -1112,19 +1114,17 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
               )
               .trim() ||
             (cfg.location
-              ? (cfg.location as string).charAt(0).toUpperCase() +
+              ? cfg.location.charAt(0).toUpperCase() +
                 (cfg.location as string).slice(1)
               : "");
         }
 
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "atmo") {
         // Atmo France: reuse the discovery result computed earlier in set hass()
         // for sensor detection, to avoid a second registry/regex scan.
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? (cfg.location as string)
-            : "";
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
 
         let title = "";
         if (wantedLocation) {
@@ -1147,7 +1147,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           title = title.charAt(0).toUpperCase() + title.slice(1);
         }
 
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "gpl") {
         // Google Pollen Levels: resolve via shared discovery so config_entry_id
         // keys and legacy label slugs both produce the friendly location name.
@@ -1161,7 +1161,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           // adapter would discard, mislabeling the rendered data.
           const rawPrefix = String(cfg.entity_prefix).replace(/^sensor\./, "");
           const wantedPrefix = `sensor.${rawPrefix}`;
-          const wantedSuffix = (cfg.entity_suffix as string) || "";
+          const wantedSuffix = cfg.entity_suffix || "";
           for (const [key, loc2] of gplDiscovery?.locations || []) {
             const entities = loc2?.entities;
             if (!entities) continue;
@@ -1183,9 +1183,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           // Non-manual (or manual with no prefix / no match): fall back to
           // key-based lookup. Empty key picks first deterministically.
           const wantedLocation =
-            cfg.location && cfg.location !== "manual"
-              ? (cfg.location as string)
-              : "";
+            cfg.location && cfg.location !== "manual" ? cfg.location : "";
           gplMatch = resolveLocationByKey(gplDiscovery, wantedLocation);
         }
         // Defensive: discovery already calls cleanDeviceLabel, but apply again
@@ -1194,41 +1192,35 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         let title = gplMatch ? cleanDeviceLabel(gplMatch[1].label) : "";
         if (title) title = title.charAt(0).toUpperCase() + title.slice(1);
 
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "gp") {
         // Google Pollen (svenove): resolve via shared discovery so
         // config_entry_id keys and legacy label slugs both produce the
         // friendly location name. Reuses gpDiscovery computed in set hass().
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? (cfg.location as string)
-            : "";
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const gpMatch = resolveLocationByKey(gpDiscovery, wantedLocation);
         // Defensive: same rationale as the GPL branch above.
         const title = gpMatch ? cleanDeviceLabel(gpMatch[1].label) : "";
 
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "msw") {
         // MeteoSwiss / hass-swissweather: resolve via shared device discovery
         // so config_entry_id keys, friendly device names, and renamed devices
         // (name_by_user) all surface the right station label in the header.
         const mswDiscovery = getMswDiscovery();
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? (cfg.location as string)
-            : "";
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const mswMatch = resolveLocationByKey(mswDiscovery, wantedLocation);
         const title = mswMatch ? mswMatch[1].label : "";
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "irmkmi") {
         // IRM KMI / meteo.be: resolve via shared device discovery so
         // config_entry_id keys, device names (the location), and renamed
         // devices (name_by_user) all surface the right location label.
         const irmkmiDiscovery = getIrmkmiDiscovery();
         const wantedLocation =
-          cfg.location && cfg.location !== "manual"
-            ? (cfg.location as string)
-            : "";
+          cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const irmkmiMatch = resolveLocationByKey(
           irmkmiDiscovery,
           wantedLocation,
@@ -1237,7 +1229,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           },
         );
         const title = irmkmiMatch ? irmkmiMatch[1].label : "";
-        loc = title || (cfg.location as string) || "";
+        loc = title || cfg.location || "";
       } else if (integration === "plu") {
         // Pollen.lu always reports Luxembourg as its location
         const translated = this._t("card.location.plu");
@@ -1249,7 +1241,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // from set hass() to avoid a second scan.
         const ppDiscovery = getPpDiscovery();
         const wantedLocation =
-          cfg.city && cfg.city !== "manual" ? (cfg.city as string) : "";
+          cfg.city && cfg.city !== "manual" ? cfg.city : "";
         const ppMatch = resolveLocationByKey(ppDiscovery, wantedLocation, {
           slugExtractor: extractPpCitySlugFromEntityId,
         });
@@ -1457,7 +1449,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
   }
 
   _renderMinimalHtml(): TemplateResult {
-    const textSizeRatio = (this.config?.text_size_ratio as number) ?? 1;
+    const textSizeRatio = this.config?.text_size_ratio ?? 1;
     const iconInRing = this.config?.icon_in_ring === true;
     const ringConfig = iconInRing ? this._buildLevelRingConfig() : null;
     const ringIconRatio =
@@ -1645,7 +1637,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       );
     }
 
-    const textSizeRatio = (this.config?.text_size_ratio as number) ?? 1;
+    const textSizeRatio = this.config?.text_size_ratio ?? 1;
     const daysBold = Boolean(this.config.days_boldfaced);
     // Compute column count from the displayed row set, not the full sensor list.
     // When standalone summary mode is active (show_summary_block on,
@@ -1975,8 +1967,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                 sIdx > 0 &&
                 rowSensors[sIdx - 1]?.isSummary &&
                 !sensor.isSummary &&
-                this.config.show_summary_separator !== false &&
-                this.config.show_summary_separator !== "false"
+                this.config.show_summary_separator !== false
                   ? html`<tr class="block-separator-row">
                       <td colspan="${totalCols}">
                         <hr class="block-separator" />
@@ -2045,7 +2036,6 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
 
     if (
       this.config.show_summary_top_types !== false &&
-      this.config.show_summary_top_types !== "false" &&
       Array.isArray(sensor.topPollen) &&
       sensor.topPollen.length > 0
     ) {
@@ -2056,7 +2046,6 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
 
     if (
       this.config.show_summary_plants_in_season !== false &&
-      this.config.show_summary_plants_in_season !== "false" &&
       Array.isArray(sensor.plantsInSeasonList) &&
       sensor.plantsInSeasonList.length > 0
     ) {

--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -381,7 +381,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
       // 11. Om användaren inte explicit satt pollen_threshold, ta stub-värdet
       if (!this._userConfig.hasOwnProperty("pollen_threshold")) {
-        merged.pollen_threshold = baseStub.pollen_threshold;
+        merged.pollen_threshold = baseStub.pollen_threshold as number;
         if (this.debug)
           console.debug(
             "[Editor] reset pollen_threshold to stub:",
@@ -391,9 +391,11 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
       // 12. Alltid använd explicit userConfig.allergens om det finns, annars stub
       
-      merged.allergens = Array.isArray(this._userConfig.allergens)
-        ? this._userConfig.allergens
-        : baseStub.allergens;
+      merged.allergens = (
+        Array.isArray(this._userConfig.allergens)
+          ? this._userConfig.allergens
+          : baseStub.allergens
+      ) as string[];
       //
       // 13. Lägg till typ och integration
       merged.integration = integration;
@@ -408,7 +410,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
       // 14. Återställ days_to_show om inte explicit
       if (!this._daysExplicit) {
-        this._config.days_to_show = baseStub.days_to_show;
+        this._config.days_to_show = baseStub.days_to_show as number;
         if (this.debug)
           console.debug(
             "[Editor] reset days_to_show to stub:",
@@ -529,7 +531,9 @@ class PollenPrognosCardEditor extends PollenEditorBase {
           !this._userConfig.location &&
           this.installedLocations!.length
         ) {
-          this._config.location = this.installedLocations![0];
+          // installedLocations is declared [string, string][] but the SILAM
+          // branch stores the location value; preserve the runtime assignment.
+          this._config.location = this.installedLocations![0] as unknown as string;
         }
       }
 
@@ -715,7 +719,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
     // --- återställ pollen_threshold om användaren inte explicit satt det ---
     if (!this._userConfig.hasOwnProperty("pollen_threshold")) {
-      merged.pollen_threshold = base.pollen_threshold;
+      merged.pollen_threshold = base.pollen_threshold as number;
       if (this.debug)
         console.debug(
           "[Editor][hass] reset pollen_threshold to stub:",
@@ -1247,7 +1251,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       // Sätt nytt språk och nollställ sort och mode tillfälligt för att trigga omritning
       this._config = {
         ...this._config,
-        date_locale: value,
+        date_locale: value as string,
         sort: "",
         mode: "",
       };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,28 +1,147 @@
 import type { LovelaceCardConfig } from "./home-assistant.js";
 
 /**
+ * An element-level tap action (shared by card and badge). YAML can carry either
+ * the HA `action` key or the card's legacy `type` key; both are read through the
+ * mixin's unknown-tolerant resolver, so the shape stays loose.
+ */
+export interface TapActionConfig {
+  action?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+/**
  * User-facing card configuration.
  *
  * YAML is the reality here: a value declared as a boolean in the editor can
- * arrive as the string "true"/"false" (or a number) from a hand-written YAML
- * config, which is why the code coerces via `coerceBool` and friends. The value
- * union reflects that. A full key inventory is deferred; the index signature
- * keeps the type open until keys are enumerated in a later PR.
+ * arrive as the string "true"/"false" (or a number) from a hand-written config.
+ * As of the config boundary (src/utils/config-normalize.ts) those values are
+ * coerced to their canonical types once at setConfig / set hass, so the known
+ * fields below are typed as their *normalized* runtime type. `title` and
+ * `date_locale` keep a widened type because they legitimately carry more than
+ * one form (title = string label or `false`/`""` to hide; date_locale absent).
+ *
+ * The index signature stays open so unknown / adapter-added keys (and the
+ * render-only cosmetic keys the editor never persists) remain accessible.
  */
 export interface CardConfig extends LovelaceCardConfig {
-  /** Selected integration id (pp, dwd, silam, ...). */
+  /** Selected integration id (pp, dwd, silam, ...). Always set after setConfig. */
   integration?: string;
+
+  // --- Location selection (one per integration; strings, "manual" is special) ---
+  city?: string;
+  location?: string;
+  region_id?: string;
+  entity_prefix?: string;
+  entity_suffix?: string;
+  entity_weather?: string;
+
+  // --- Allergen selection + display ---
+  allergens?: string[];
+  allergens_abbreviated?: boolean;
+  allergy_risk_top?: boolean;
+  index_top?: boolean;
+  pollen_threshold?: number;
+  sort?: string;
+  mode?: string;
+
+  // --- Day columns ---
+  days_to_show?: number;
+  days_relative?: boolean;
+  days_abbreviated?: boolean;
+  days_uppercase?: boolean;
+  days_boldfaced?: boolean;
+  show_empty_days?: boolean;
+
+  // --- Value / text toggles ---
+  minimal?: boolean;
+  minimal_gap?: number;
+  show_text_allergen?: boolean;
+  show_value_text?: boolean;
+  show_value_numeric?: boolean;
+  show_value_numeric_in_circle?: boolean;
+  numeric_value_raw?: boolean;
+  /** Legacy PEU alias of numeric_value_raw. */
+  numeric_state_raw_risk?: boolean;
+  text_size_ratio?: number;
+  show_allergen_column?: boolean;
+  show_block_separator?: boolean;
+
+  // --- Summary block (#222) ---
+  show_summary_block?: boolean;
+  show_summary_row?: boolean;
+  show_summary_separator?: boolean;
+  show_summary_top_types?: boolean;
+  show_summary_plants_in_season?: boolean;
+
+  // --- Icons ---
+  icon_size?: string;
+  icon_color_mode?: string;
+  icon_color?: string;
+  icon_in_ring?: boolean;
+  icon_in_ring_color_mode?: string;
+  icon_in_ring_static_color?: string;
+  icon_in_ring_size_ratio?: number;
+
+  // --- Allergen icon styling ---
+  allergen_colors?: string[];
+  allergen_stroke_width?: number;
+  allergen_stroke_color_synced?: boolean;
+  allergen_levels_gap_synced?: boolean;
+
+  // --- Level ring styling ---
+  levels_colors?: string[];
+  levels_empty_color?: string;
+  levels_gap_color?: string;
+  levels_gap?: number;
+  levels_thickness?: number;
+  levels_text_color?: string;
+  levels_text_size?: number;
+  levels_text_weight?: string;
+  levels_icon_ratio?: number;
+
+  // --- Misc appearance / behaviour ---
+  background_color?: string;
+  no_allergens_color?: string;
+  show_no_data_distinct?: boolean;
+  link_to_sensors?: boolean;
+  show_version?: boolean;
+  debug?: boolean;
+
+  // --- Adapter-specific ---
+  pollution_block_position?: string;
+  sort_pollution_block?: boolean;
+  sort_category_allergens_first?: boolean;
+
+  // --- Widened / non-uniform ---
+  /** Header: a string label, or `false`/`""` to hide the header. */
+  title?: string | boolean;
+  /** BCP-47 locale tag; absent by default (auto-detected from HA). */
+  date_locale?: string;
+  /** Per-allergen phrase overrides (full/short/levels/days). */
+  phrases?: Record<string, unknown>;
+  /** Element-level tap action. */
+  tap_action?: TapActionConfig;
+  /** card-mod pass-through. */
+  card_mod?: unknown;
+
   [key: string]: boolean | string | number | unknown;
 }
 
 /**
- * Badge configuration. Shares the same YAML-value reality as {@link CardConfig};
- * kept as a distinct alias so badge-specific keys can be enumerated separately
- * later.
+ * Badge configuration. Shares the card's YAML-value reality plus the badge's
+ * own display keys (badge_content / badge_visual / ...). The badge coerces its
+ * bespoke fields in {@link file://../pollenprognos-badge.ts} `_buildConfig`.
  */
-export interface BadgeConfig extends LovelaceCardConfig {
-  integration?: string;
-  [key: string]: boolean | string | number | unknown;
+export interface BadgeConfig extends CardConfig {
+  badge_content?: string;
+  badge_single_allergen?: string;
+  badge_show_label?: boolean;
+  badge_visual?: string;
+  badge_scale?: number;
+  badge_icon_scale?: number;
+  badge_label_position?: string;
 }
 
 /**

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -1,0 +1,181 @@
+// src/utils/config-normalize.ts
+//
+// The single validation/coercion boundary for card configuration.
+//
+// YAML is the reality: a value the editor writes as a boolean can arrive as the
+// string "true"/"false" from a hand-written config, and a numeric field can
+// arrive as a numeric string ("4"). Historically each read-site coped on its
+// own (coerceBool, Number(), typeof guards) scattered across the card, badge,
+// mixin and editor sections. This module folds that into one place so setConfig
+// (and the card's set hass) produce a config whose known fields already carry
+// their canonical runtime types.
+//
+// Coercion is intentionally minimal and directed by the cross-stub field-type
+// union (see buildFieldTypeSets):
+//   - a field that is boolean in any stub coerces the exact strings
+//     "true"/"false" to booleans (everything else is left untouched);
+//   - a field that is a number in any stub coerces a finite numeric string to
+//     a number;
+//   - `allergens` is guaranteed to be an array (falls back to the stub default
+//     when a malformed non-array slips through).
+// Fields no stub types as boolean/number (title, city/location/region_id,
+// icon_size, date_locale, tap_action, ...) are never coerced, so title="false"
+// stays the string the header logic expects and entity-id slugs stay strings.
+//
+// The result is frozen: nothing downstream mutates the card's config in place
+// (verified across card, badge, mixin, adapters and utils), so freezing turns a
+// stray future mutation into a loud error instead of a silent config drift.
+
+import type {
+  AdapterStubConfig,
+  CardConfig,
+  RawCardConfig,
+} from "../types/config.js";
+import { getAllAdapterIds, getStubConfig } from "../adapter-registry.js";
+
+/**
+ * Known field types, unioned across *all* adapter stubs. Coercion is driven by
+ * these sets rather than the single resolved stub so a field is coerced
+ * consistently regardless of which integration is active — critical for set
+ * hass, which spreads the full (unfiltered) user config: a field the active
+ * stub omits (e.g. show_summary_top_types on SILAM/ATMO, defined only in the
+ * GPL stub) still coerces to its canonical type. Every field carries a single
+ * type across stubs (verified), so the union is unambiguous.
+ */
+function buildFieldTypeSets(): {
+  booleanFields: Set<string>;
+  numberFields: Set<string>;
+} {
+  const booleanFields = new Set<string>();
+  const numberFields = new Set<string>();
+  for (const id of getAllAdapterIds()) {
+    const stub = getStubConfig(id);
+    if (!stub) continue;
+    for (const [key, value] of Object.entries(stub)) {
+      if (typeof value === "boolean") booleanFields.add(key);
+      else if (typeof value === "number") numberFields.add(key);
+    }
+  }
+  return { booleanFields, numberFields };
+}
+
+const { booleanFields: BOOLEAN_FIELDS, numberFields: NUMBER_FIELDS } =
+  buildFieldTypeSets();
+
+/**
+ * Non-stub config keys that setConfig accepts in addition to the resolved
+ * adapter stub's own keys. Kept identical to the list the card historically
+ * inlined so the allowed-field filter is unchanged.
+ */
+export const CARD_EXTRA_FIELDS: readonly string[] = [
+  "type",
+  "card_mod",
+  "allergens",
+  "icon_size",
+  "icon_color_mode",
+  "icon_color",
+  "city",
+  "location",
+  "region_id",
+  "tap_action",
+  "debug",
+  "show_version",
+  "title",
+  "days_to_show",
+  "date_locale",
+];
+
+/** The field set setConfig keeps: the stub's own keys plus the card extras. */
+export function cardAllowedFields(stub: AdapterStubConfig): string[] {
+  return Object.keys(stub).concat(CARD_EXTRA_FIELDS as string[]);
+}
+
+/**
+ * Merge a raw user config onto the adapter stub.
+ *
+ * `filter: true` (setConfig) keeps only allowed fields; `filter: false`
+ * (set hass) spreads the full raw config, preserving the card's long-standing
+ * asymmetry where set hass does not strip unknown keys. In both cases the
+ * resolved `integration` wins over any value carried in the stub or raw config.
+ * The raw object is never mutated (it may be HA's frozen config).
+ */
+export function mergeCardConfig(
+  raw: RawCardConfig,
+  stub: AdapterStubConfig,
+  { integration, filter }: { integration?: string; filter: boolean },
+): Record<string, unknown> {
+  let picked: Record<string, unknown>;
+  if (filter) {
+    picked = {};
+    for (const k of cardAllowedFields(stub)) {
+      if (k in raw) picked[k] = raw[k];
+    }
+  } else {
+    picked = { ...raw };
+  }
+  return { ...stub, ...picked, integration };
+}
+
+/**
+ * Coerce known-typed fields to their canonical runtime types, driven by the
+ * cross-stub field-type union ({@link BOOLEAN_FIELDS} / {@link NUMBER_FIELDS}).
+ * The stub is used only for the `allergens` array fallback. Returns a new
+ * object; the input is not mutated.
+ */
+export function coerceConfigTypes(
+  merged: Record<string, unknown>,
+  stub: AdapterStubConfig,
+): CardConfig {
+  const out: Record<string, unknown> = { ...merged };
+
+  for (const [key, value] of Object.entries(out)) {
+    if (BOOLEAN_FIELDS.has(key)) {
+      if (value === "true") out[key] = true;
+      else if (value === "false") out[key] = false;
+    } else if (NUMBER_FIELDS.has(key)) {
+      if (
+        typeof value === "string" &&
+        value.trim() !== "" &&
+        Number.isFinite(Number(value))
+      ) {
+        out[key] = Number(value);
+      }
+    }
+  }
+
+  // allergens must be an array for the adapters / render loops. A malformed
+  // non-array (e.g. a hand-written scalar) falls back to the stub default.
+  if ("allergens" in out && !Array.isArray(out.allergens)) {
+    const stubAllergens = (stub as Record<string, unknown>).allergens;
+    if (Array.isArray(stubAllergens)) out.allergens = stubAllergens;
+  }
+
+  return out as CardConfig;
+}
+
+/**
+ * Apply type coercion and freeze the result. The freeze enforces the
+ * card-wide invariant that config is immutable once built.
+ */
+export function finalizeCardConfig(
+  merged: Record<string, unknown>,
+  stub: AdapterStubConfig,
+): CardConfig {
+  return Object.freeze(coerceConfigTypes(merged, stub)) as CardConfig;
+}
+
+/**
+ * The full boundary: merge onto the stub, coerce known types, freeze. Used by
+ * setConfig; set hass composes mergeCardConfig + its hass-driven derivations +
+ * finalizeCardConfig so the coerce/freeze tail stays shared.
+ */
+export function normalizeCardConfig(
+  raw: RawCardConfig,
+  stub: AdapterStubConfig,
+  { integration, filter = true }: { integration?: string; filter?: boolean },
+): CardConfig {
+  return finalizeCardConfig(
+    mergeCardConfig(raw, stub, { integration, filter }),
+    stub,
+  );
+}

--- a/test/card/config-normalize.test.js
+++ b/test/card/config-normalize.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeCardConfig,
+  mergeCardConfig,
+  coerceConfigTypes,
+  finalizeCardConfig,
+  cardAllowedFields,
+  CARD_EXTRA_FIELDS,
+} from "../../src/utils/config-normalize.js";
+import { stubConfigPP } from "../../src/adapters/pp.js";
+import { stubConfigSILAM } from "../../src/adapters/silam.js";
+
+// The boundary is the single place YAML values are coerced. These tests pin the
+// legacy-YAML forms (string booleans, numeric strings, missing/malformed
+// allergens) and the structural guarantees (freeze, no input mutation, the
+// filter asymmetry between setConfig and set hass).
+
+describe("normalizeCardConfig: string boolean coercion", () => {
+  it('coerces "true"/"false" for stub-declared boolean fields', () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", minimal: "true", days_relative: "false" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.minimal).toBe(true);
+    expect(cfg.days_relative).toBe(false);
+  });
+
+  it("coerces the debug / show_version extras (boolean in the stub)", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", debug: "true", show_version: "false" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.debug).toBe(true);
+    expect(cfg.show_version).toBe(false);
+  });
+
+  it("leaves real booleans untouched", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", minimal: true, days_relative: false },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.minimal).toBe(true);
+    expect(cfg.days_relative).toBe(false);
+  });
+
+  it("does not coerce non-boolean-typed fields (title stays the string)", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", title: "false" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.title).toBe("false");
+  });
+});
+
+describe("normalizeCardConfig: numeric string coercion", () => {
+  it("coerces numeric strings for stub-declared number fields", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", days_to_show: "4", pollen_threshold: "3" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.days_to_show).toBe(4);
+    expect(cfg.pollen_threshold).toBe(3);
+  });
+
+  it("leaves a non-numeric string for a numeric field untouched", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", days_to_show: "abc" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.days_to_show).toBe("abc");
+  });
+
+  it("does not coerce icon_size (a string in the stub) to a number", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: "64" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.icon_size).toBe("64");
+  });
+});
+
+describe("normalizeCardConfig: allergens guard", () => {
+  it("falls back to the stub allergens when allergens is missing", () => {
+    const cfg = normalizeCardConfig({ integration: "pp" }, stubConfigPP, {
+      integration: "pp",
+      filter: true,
+    });
+    expect(cfg.allergens).toEqual(stubConfigPP.allergens);
+  });
+
+  it("replaces a malformed non-array allergens with the stub default", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", allergens: "birch" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.allergens).toEqual(stubConfigPP.allergens);
+  });
+
+  it("keeps a user-provided allergens array", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", allergens: ["Björk"] },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.allergens).toEqual(["Björk"]);
+  });
+});
+
+describe("normalizeCardConfig: passthrough + location keys", () => {
+  it("preserves the city key and tap_action (both action and type forms)", () => {
+    const withAction = normalizeCardConfig(
+      { integration: "pp", city: "Stockholm", tap_action: { action: "more-info" } },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(withAction.city).toBe("Stockholm");
+    expect(withAction.tap_action).toEqual({ action: "more-info" });
+
+    const withType = normalizeCardConfig(
+      { integration: "pp", tap_action: { type: "navigate" } },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(withType.tap_action).toEqual({ type: "navigate" });
+  });
+
+  it("forces the resolved integration over any stub/raw value", () => {
+    const cfg = normalizeCardConfig({ integration: "PP" }, stubConfigPP, {
+      integration: "pp",
+      filter: true,
+    });
+    expect(cfg.integration).toBe("pp");
+  });
+});
+
+describe("mergeCardConfig: filter asymmetry", () => {
+  it("filter:true drops unknown fields", () => {
+    const merged = mergeCardConfig(
+      { integration: "pp", unknown_field: "x" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(merged).not.toHaveProperty("unknown_field");
+  });
+
+  it("filter:false keeps unknown fields (the set hass path)", () => {
+    const merged = mergeCardConfig(
+      { integration: "pp", unknown_field: "x" },
+      stubConfigPP,
+      { integration: "pp", filter: false },
+    );
+    expect(merged.unknown_field).toBe("x");
+  });
+
+  it("allowed fields = stub keys + card extras", () => {
+    const allowed = cardAllowedFields(stubConfigPP);
+    for (const k of CARD_EXTRA_FIELDS) expect(allowed).toContain(k);
+    expect(allowed).toContain("pollen_threshold"); // a stub key
+  });
+});
+
+describe("cross-stub coercion union", () => {
+  it("coerces a field the active stub omits but another stub declares boolean", () => {
+    // show_summary_top_types is defined only in the GPL stub, not SILAM's, yet
+    // set hass spreads it (filter:false). The union coercion must still fire.
+    expect(stubConfigSILAM).not.toHaveProperty("show_summary_top_types");
+    const cfg = coerceConfigTypes(
+      { integration: "silam", show_summary_top_types: "false" },
+      stubConfigSILAM,
+    );
+    expect(cfg.show_summary_top_types).toBe(false);
+  });
+});
+
+describe("structural guarantees", () => {
+  it("finalizeCardConfig freezes the result", () => {
+    const cfg = finalizeCardConfig({ integration: "pp", minimal: true }, stubConfigPP);
+    expect(Object.isFrozen(cfg)).toBe(true);
+    expect(() => {
+      cfg.minimal = false;
+    }).toThrow();
+  });
+
+  it("coerceConfigTypes does not mutate its input", () => {
+    const input = { integration: "pp", minimal: "true" };
+    coerceConfigTypes(input, stubConfigPP);
+    expect(input.minimal).toBe("true");
+  });
+
+  it("does not mutate the raw config object (may be HA-frozen)", () => {
+    const raw = Object.freeze({ integration: "pp", minimal: "true" });
+    expect(() =>
+      normalizeCardConfig(raw, stubConfigPP, {
+        integration: "pp",
+        filter: true,
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fifteenth PR of the v4.0.0 migration (#259), the last debt PR: configuration is validated and coerced once at the setConfig boundary, and the card stops mutating config objects in `set hass`.

## What

- **`src/utils/config-normalize.ts`**: merge (stub under user config, preserving the existing filtered/unfiltered asymmetry between setConfig and set hass), one-pass YAML type coercion (string booleans, numeric strings, allergens array guard) driven by the union of field types across all adapter stubs (summary fields cross integration boundaries via set hass, so per-stub typing would miss them), and `Object.freeze` on the result — a repo-wide audit found no remaining config writes after assignment.
- **`set hass` builds new objects instead of mutating**: `delete cfg.city`/`region_id`, the allergens fallback and date-locale fill are replaced by spread-derived construction through the same boundary; the `deepEqual` guard and the cosmetic-only update path (the iOS scroll fix) are preserved exactly.
- **`CardConfig` enumerates ~65 known keys** with normalized types; a batch of access-site casts and three dead string-comparison guards drop out of the card.
- 19 new boundary tests (string booleans, numeric strings, coercion exemptions like a literal `title: "false"`, filter asymmetry, cross-stub union, freeze/no-input-mutation guarantees). Existing tests untouched and green; golden snapshots byte-identical.

## Deliberate user-visible correction (string-typed YAML only)

Hand-written string booleans now mean what they say. A/B-verified on the HA test instance: with the old bundle, `minimal: "false"` rendered the card in minimal mode (the string was truthy) and `days_to_show: "2"` was ignored; with this PR the same YAML renders a normal card with two day columns, and `show_text_allergen: "false"` actually disables the label. Canonical and editor-written configs are unaffected. The badge already coerces its fields and is deliberately left on its existing path.

## Verification

1342/1342 tests green; goldens zero diff; `tsc --noEmit` clean; eslint 0 errors; build within budget; legacy-YAML A/B screenshots per above, zero console/page errors.
