### PR TITLE
(autodetect) Move detection onto per-adapter descriptors via the registry

### DIFF
--- a/src/adapter-registry.ts
+++ b/src/adapter-registry.ts
@@ -2,7 +2,7 @@
 // Thin alias layer: maps integration ID → { module, stub }.
 // Replaces scattered if/else chains in card and editor.
 
-import type { AdapterModule } from "./types/adapter.js";
+import type { AdapterModule, AdapterAutodetect } from "./types/adapter.js";
 import type { AdapterStubConfig } from "./types/config.js";
 import * as PP from "./adapters/pp.js";
 import * as DWD from "./adapters/dwd.js";
@@ -47,4 +47,29 @@ export function getStubConfig(
 
 export function getAllAdapterIds(): string[] {
   return Object.keys(registry);
+}
+
+/**
+ * Return an integration's autodetect descriptor, or undefined if the id is
+ * unknown or the adapter exposes none. The shared autodetect module
+ * (`src/utils/autodetect.ts`) uses this instead of importing adapter internals.
+ */
+export function getAutodetect(
+  id: string | undefined,
+): AdapterAutodetect | undefined {
+  return id ? registry[id]?.module.autodetect : undefined;
+}
+
+/**
+ * Return every `[id, descriptor]` pair sorted by the descriptor's `priority`
+ * (lowest first). This is the single source of truth for the autodetect
+ * precedence order that INTEGRATION_PRIORITY used to hardcode.
+ */
+export function getAllAutodetect(): Array<[string, AdapterAutodetect]> {
+  const out: Array<[string, AdapterAutodetect]> = [];
+  for (const [id, entry] of Object.entries(registry)) {
+    if (entry.module.autodetect) out.push([id, entry.module.autodetect]);
+  }
+  out.sort((a, b) => a[1].priority - b[1].priority);
+  return out;
 }

--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -5,6 +5,12 @@ import type {
 } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../types/adapter.js";
 import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
@@ -793,3 +799,50 @@ export async function fetchForecast(
   if (debug) console.debug("ATMO adapter complete sensors:", sensors);
   return sensors;
 }
+
+/**
+ * Autodetect descriptor. Detection is discovery-primary (device/registry via
+ * discoverAtmoSensors) with a legacy regex fallback for older HA registries.
+ * The fallback matches current `niveau_<allergen>` and legacy
+ * `niveau_alerte_<allergen>` pollen sensors plus the pollution/summary sensors,
+ * excluding forecast-day entities (`_j_<n>` suffix). The eagerly-computed
+ * discovery is returned so autoSelectLocation reuses it. Location extraction
+ * from the entity id stays in the shared autodetect module (the auto-select and
+ * per-entity paths use subtly different niveau regexes).
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 6,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+    debug = false,
+  ): AutodetectDetectResult {
+    const discovery = discoverAtmoSensors(hass, debug) as AutodetectDiscovery;
+    const ids: string[] = [];
+    if (discovery.locations.size > 0) {
+      for (const [, loc] of discovery.locations) {
+        if (loc.entities) {
+          for (const eid of loc.entities.values()) ids.push(eid);
+        }
+      }
+    }
+    if (!ids.length) {
+      // Legacy fallback. Matches current niveau_{slug} and legacy
+      // niveau_alerte_{slug}.
+      for (const id of ctx.stateIds) {
+        if (
+          typeof id === "string" &&
+          /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(
+            id,
+          ) &&
+          !/_j_\d+$/.test(id)
+        ) {
+          ids.push(id);
+        }
+      }
+    }
+    return { ids, discovery };
+  },
+  discover: (hass, debug) =>
+    discoverAtmoSensors(hass, debug) as AutodetectDiscovery,
+};

--- a/src/adapters/dwd.ts
+++ b/src/adapters/dwd.ts
@@ -1,6 +1,11 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+} from "../types/adapter.js";
 import { normalizeDWD } from "../utils/normalize.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import {
@@ -422,3 +427,25 @@ export async function fetchForecast(
     },
   });
 }
+
+/**
+ * Autodetect descriptor. Detection matches the `pollenflug_<allergen>_<region>`
+ * segment whether or not HA has prepended a device-name slug (#217).
+ * `extractLocationSlug` returns the numeric region id, used by
+ * deriveLocationForEntity for the card-picker suggestion.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 3,
+  detectStates(
+    _hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const ids = ctx.stateIds.filter(
+      (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
+    );
+    return { ids };
+  },
+  discover: discoverDwdSensors,
+  extractLocationSlug: (entityId: string) =>
+    entityId.match(DWD_ENTITY_ID_RE)?.[2] || null,
+};

--- a/src/adapters/gp/index.ts
+++ b/src/adapters/gp/index.ts
@@ -4,3 +4,63 @@
 export { fetchForecast } from "./forecast.js";
 export { resolveEntityIds, discoverGpSensors, discoverGpAllergens } from "./discovery.js";
 export { stubConfigGP, capitalize, GP_DOMAIN, GP_BASE_ALLERGENS, GP_DISPLAY_NAME_MAP, GP_COLLISION_PLANTS } from "./constants.js";
+
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../../types/adapter.js";
+import { discoverGpSensors as _discoverGpSensors } from "./discovery.js";
+
+/** Exclude date/timestamp helper entities so they are never treated as pollen data. */
+function isNonDataDeviceClass(hass: HomeAssistant, eid: string): boolean {
+  const dc = hass?.states?.[eid]?.attributes?.device_class;
+  return dc === "date" || dc === "timestamp";
+}
+
+/**
+ * Autodetect descriptor. Detection is discovery-primary (device/registry via
+ * discoverGpSensors), falling back to the `google_pollen` platform in
+ * hass.entities and finally to the `sensor.google_pollen_` prefix. The
+ * eagerly-computed discovery is returned so autoSelectLocation reuses it.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 7,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+    debug = false,
+  ): AutodetectDetectResult {
+    const discovery = _discoverGpSensors(hass, debug) as AutodetectDiscovery;
+    let ids: string[] = [];
+    if (discovery.locations.size > 0) {
+      for (const [, loc] of discovery.locations) {
+        if (loc.entities) {
+          for (const eid of loc.entities.values()) ids.push(eid);
+        }
+      }
+    }
+    if (!ids.length) {
+      if (hass && hass.entities) {
+        ids = Object.entries(hass.entities)
+          .filter(
+            ([eid, entry]) =>
+              (entry as { platform?: string }).platform === "google_pollen" &&
+              !(entry as { entity_category?: string }).entity_category &&
+              !isNonDataDeviceClass(hass, eid),
+          )
+          .map(([eid]) => eid);
+      }
+      if (!ids.length) {
+        ids = ctx.stateIds.filter(
+          (id) => typeof id === "string" && id.startsWith("sensor.google_pollen_"),
+        );
+      }
+    }
+    return { ids, discovery };
+  },
+  discover: (hass, debug) =>
+    _discoverGpSensors(hass, debug) as AutodetectDiscovery,
+};

--- a/src/adapters/gpl/index.ts
+++ b/src/adapters/gpl/index.ts
@@ -3,3 +3,56 @@
 export { GPL_ATTRIBUTION, GPL_TYPE_ICON_MAP, GPL_BASE_ALLERGENS, stubConfigGPL, capitalize } from "./constants.js";
 export { classifySensor, isGplDataSensor, discoverGplSensors, discoverGplAllergens, resolveEntityIds } from "./discovery.js";
 export { fetchForecast } from "./forecast.js";
+
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../../types/adapter.js";
+import { GPL_ATTRIBUTION as _GPL_ATTRIBUTION } from "./constants.js";
+import { discoverGplSensors as _discoverGplSensors } from "./discovery.js";
+
+/**
+ * Autodetect descriptor. Detection uses the `pollenlevels` platform in
+ * hass.entities (primary) or the attribution string (fallback), excluding
+ * date/timestamp helper entities in both paths (issue #258). Discovery is lazy
+ * (used only by autoSelectLocation), so detectStates returns no discovery.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 8,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const isNonDataDeviceClass = (eid: string): boolean => {
+      const dc = hass?.states?.[eid]?.attributes?.device_class;
+      return dc === "date" || dc === "timestamp";
+    };
+    let ids: string[] = [];
+    if (hass && hass.entities) {
+      ids = Object.entries(hass.entities)
+        .filter(
+          ([eid, entry]) =>
+            (entry as { platform?: string }).platform === "pollenlevels" &&
+            !(entry as { entity_category?: string }).entity_category &&
+            !isNonDataDeviceClass(eid),
+        )
+        .map(([eid]) => eid);
+    }
+    if (!ids.length) {
+      ids = ctx.stateIds.filter((id) => {
+        const s = hass.states[id];
+        return (
+          s?.attributes?.attribution === _GPL_ATTRIBUTION &&
+          s.attributes.device_class !== "date" &&
+          s.attributes.device_class !== "timestamp"
+        );
+      });
+    }
+    return { ids };
+  },
+  discover: (hass, debug) =>
+    _discoverGplSensors(hass, debug) as AutodetectDiscovery,
+};

--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -29,6 +29,12 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../types/adapter.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import {
@@ -364,3 +370,42 @@ export async function fetchForecast(
   if (debug) console.debug("IRMKMI adapter complete sensors:", sensors);
   return sensors;
 }
+
+/**
+ * Autodetect descriptor. IRM KMI entity ids follow
+ * sensor.<location-slug>_<allergen>_level. Detection uses the `irm_kmi`
+ * platform in hass.entities (primary) with a regex fallback for older
+ * registries. Discovery is lazy (used only by autoSelectLocation).
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 10,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const irmkmiLevelRe = /_(?:alder|ash|birch|grasses|hazel|mugwort|oak)_level$/;
+    let ids: string[] = [];
+    if (hass && hass.entities) {
+      ids = Object.entries(hass.entities)
+        .filter(
+          ([eid, entry]) =>
+            (entry as { platform?: string }).platform === "irm_kmi" &&
+            !(entry as { entity_category?: string }).entity_category &&
+            irmkmiLevelRe.test(eid),
+        )
+        .map(([eid]) => eid);
+    }
+    if (!ids.length) {
+      ids = ctx.stateIds.filter(
+        (id) =>
+          typeof id === "string" &&
+          /^sensor\.\w+_(?:alder|ash|birch|grasses|hazel|mugwort|oak)_level$/.test(
+            id,
+          ),
+      );
+    }
+    return { ids };
+  },
+  discover: (hass, debug) =>
+    discoverIrmkmiSensors(hass, debug) as AutodetectDiscovery,
+};

--- a/src/adapters/kleenex/index.ts
+++ b/src/adapters/kleenex/index.ts
@@ -11,3 +11,31 @@ export {
 export { ppmToLevel } from "./levels.js";
 export { resolveEntityIds } from "./discovery.js";
 export { fetchForecast } from "./forecast.js";
+
+import type { HomeAssistant } from "../../types/home-assistant.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+} from "../../types/adapter.js";
+
+/**
+ * Autodetect descriptor. Detection matches the `sensor.kleenex_pollen_radar_`
+ * prefix. Kleenex has no discovery dimension (location resolution scans the
+ * sibling `_date` sensors, handled by the shared autodetect module), so neither
+ * `discover` nor `extractLocationSlug` is provided.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 5,
+  detectStates(
+    _hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const ids = ctx.stateIds.filter(
+      (id) =>
+        typeof id === "string" &&
+        id.startsWith("sensor.kleenex_pollen_radar_"),
+    );
+    return { ids };
+  },
+};

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -24,6 +24,12 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../types/adapter.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import {
@@ -332,3 +338,44 @@ export async function fetchForecast(
   if (debug) console.debug("MSW adapter complete sensors:", sensors);
   return sensors;
 }
+
+/**
+ * Autodetect descriptor. MSW entity ids follow
+ * sensor.<device-slug>_pollen_<allergen>_level_at_<station>; the device-slug
+ * prefix is added by HA and varies per install. Detection uses the
+ * `swissweather` platform in hass.entities (primary) with a regex fallback for
+ * older registries. Discovery is lazy (used only by autoSelectLocation).
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 9,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const mswLevelRe =
+      /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
+    let ids: string[] = [];
+    if (hass && hass.entities) {
+      ids = Object.entries(hass.entities)
+        .filter(
+          ([eid, entry]) =>
+            (entry as { platform?: string }).platform === "swissweather" &&
+            !(entry as { entity_category?: string }).entity_category &&
+            mswLevelRe.test(eid),
+        )
+        .map(([eid]) => eid);
+    }
+    if (!ids.length) {
+      ids = ctx.stateIds.filter(
+        (id) =>
+          typeof id === "string" &&
+          /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(
+            id,
+          ),
+      );
+    }
+    return { ids };
+  },
+  discover: (hass, debug) =>
+    discoverMswSensors(hass, debug) as AutodetectDiscovery,
+};

--- a/src/adapters/peu.ts
+++ b/src/adapters/peu.ts
@@ -1,6 +1,11 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+} from "../types/adapter.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNamesForScale } from "../utils/level-names.js";
 import { slugify } from "../utils/slugify.js";
@@ -627,3 +632,24 @@ export async function fetchForecast(
     },
   });
 }
+
+/**
+ * Autodetect descriptor. Detection matches the `sensor.polleninformation_`
+ * prefix. `extractLocationSlug` derives the location from the entity id, used
+ * as the fallback when the integration's `location_slug` attribute is absent.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 2,
+  detectStates(
+    _hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const ids = ctx.stateIds.filter(
+      (id) =>
+        typeof id === "string" && id.startsWith("sensor.polleninformation_"),
+    );
+    return { ids };
+  },
+  discover: discoverPeuSensors,
+  extractLocationSlug: extractPeuLocationSlugFromEntityId,
+};

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -2,6 +2,11 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+} from "../types/adapter.js";
 import { t } from "../i18n.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
 import { buildLevelNames } from "../utils/level-names.js";
@@ -509,3 +514,36 @@ export async function fetchForecast(
 
   return sensors;
 }
+
+/**
+ * PLU allergen slugs, exported so the PP autodetect descriptor can disambiguate
+ * `sensor.pollen_<allergen>` (single underscore) between PP and PLU without PP
+ * importing PLU internals. The detection driver reads this to build the shared
+ * autodetect context.
+ */
+export const PLU_ALLERGEN_SLUGS = new Set<string>(
+  Object.values(PLU_ALIAS_MAP).flat(),
+);
+
+/**
+ * Autodetect descriptor. Detection matches `sensor.pollen_<allergen>` with a
+ * single underscore whose allergen slug is a known PLU allergen. PLU has no
+ * location dimension in the card, so no `extractLocationSlug` is provided.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 1,
+  detectStates(
+    _hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const ids = ctx.stateIds.filter((id) => {
+      if (typeof id !== "string") return false;
+      const match = /^sensor\.pollen_([^_]+)$/.exec(id);
+      if (!match) return false;
+      return ctx.pluAllergenSlugs.has(match[1]);
+    });
+    return { ids };
+  },
+  discover: discoverPluSensors,
+  allergenSlugs: PLU_ALLERGEN_SLUGS,
+};

--- a/src/adapters/pp.ts
+++ b/src/adapters/pp.ts
@@ -1,6 +1,11 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+} from "../types/adapter.js";
 import { normalize } from "../utils/normalize.js";
 import { slugify } from "../utils/slugify.js";
 import { LEVELS_DEFAULTS } from "../utils/levels-defaults.js";
@@ -415,3 +420,39 @@ export async function fetchForecast(
     },
   });
 }
+
+/**
+ * Autodetect descriptor. Detection matches `sensor.pollen_<allergen>[_<city>]`
+ * while excluding DWD (`sensor.pollenflug_`) and MSW (`_level_at_`) shapes, and
+ * disambiguating against PLU: a single-underscore id whose allergen slug is a
+ * known PLU allergen is treated as PLU, not PP.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 0,
+  detectStates(
+    _hass: HomeAssistant,
+    ctx: AutodetectContext,
+  ): AutodetectDetectResult {
+    const ids = ctx.stateIds.filter((id) => {
+      if (typeof id !== "string") return false;
+      if (!id.startsWith("sensor.pollen_")) return false;
+      if (id.startsWith("sensor.pollenflug_")) return false;
+      // Exclude MSW (hass-swissweather): sensor.pollen_<allergen>_level_at_<station>
+      if (id.includes("_level_at_")) return false;
+
+      // Match manual mode (sensor.pollen_<allergen>) and city mode
+      // (sensor.pollen_<allergen>_<city>).
+      const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
+      if (!match) return false;
+
+      const allergenSlug = match[1];
+      // Single underscore AND a known PLU allergen -> likely PLU, not PP.
+      if (!match[2] && ctx.pluAllergenSlugs.has(allergenSlug)) return false;
+
+      return true;
+    });
+    return { ids };
+  },
+  discover: discoverPpSensors,
+  extractLocationSlug: extractCitySlugFromEntityId,
+};

--- a/src/adapters/silam.ts
+++ b/src/adapters/silam.ts
@@ -1,6 +1,12 @@
 import type { HomeAssistant } from "../types/home-assistant.js";
 import type { CardConfig, AdapterStubConfig } from "../types/config.js";
 import type { PollenSensor, ForecastDay } from "../types/sensor.js";
+import type {
+  AdapterAutodetect,
+  AutodetectContext,
+  AutodetectDetectResult,
+  AutodetectDiscovery,
+} from "../types/adapter.js";
 import { normalize } from "../utils/normalize.js";
 import {
   findSilamWeatherEntity,
@@ -688,3 +694,46 @@ export async function fetchForecast(
     );
   return sensors;
 }
+
+/**
+ * Autodetect descriptor. Detection is discovery-primary (device/registry via
+ * discoverSilamSensors) with a `sensor.silam_pollen_` prefix fallback. A
+ * weather-only install (no allergen sensors) still counts as evidence via the
+ * location's weatherEntity. The eagerly-computed discovery is returned so
+ * autoSelectLocation reuses it. `extractLocationSlug` is the regex fallback used
+ * when discovery yields no location.
+ */
+export const autodetect: AdapterAutodetect = {
+  priority: 4,
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+    debug = false,
+  ): AutodetectDetectResult {
+    const discovery = discoverSilamSensors(hass, debug) as AutodetectDiscovery;
+    const ids: string[] = [];
+    if (discovery.locations.size > 0) {
+      for (const [, loc] of discovery.locations) {
+        if (loc.sensors) {
+          for (const eid of loc.sensors.values()) ids.push(eid);
+        }
+        // A SILAM install can enable only the weather entity (no allergen
+        // sensors) and still expose the allergy_risk index; count the weather
+        // entity as evidence so weather-only installs are detected too.
+        if (loc.weatherEntity) ids.push(loc.weatherEntity);
+      }
+    }
+    if (!ids.length) {
+      for (const id of ctx.stateIds) {
+        if (typeof id === "string" && id.startsWith("sensor.silam_pollen_")) {
+          ids.push(id);
+        }
+      }
+    }
+    return { ids, discovery };
+  },
+  discover: (hass, debug) =>
+    discoverSilamSensors(hass, debug) as AutodetectDiscovery,
+  extractLocationSlug: (entityId: string) =>
+    entityId.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/)?.[1] || null,
+};

--- a/src/pollenprognos-badge-editor.ts
+++ b/src/pollenprognos-badge-editor.ts
@@ -23,11 +23,7 @@ import { extractCitySlugFromEntityId as extractPpCitySlugFromEntityId } from "./
 import type { HomeAssistant } from "./types/home-assistant.js";
 import type { CardConfig, RawCardConfig } from "./types/config.js";
 import type { InstalledLocation } from "./editor/types.js";
-
-// The autodetect module (src/utils/autodetect.js) is still untyped JS; its
-// return shape (memoized discovery getters, state buckets) is typed properly in
-// a later PR. Until then the detection object crosses this boundary as `any`.
-type DetectionResult = any;
+import type { DetectionResult } from "./utils/autodetect.js";
 
 class PollenPrognosBadgeEditor extends PollenEditorBase {
   // ------------------------------------------------------------------ //

--- a/src/pollenprognos-badge.ts
+++ b/src/pollenprognos-badge.ts
@@ -211,7 +211,9 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       config,
       "integration",
     );
-    let integration = normalizeIntegration(config.integration);
+    let integration = normalizeIntegration(config.integration) as
+      | string
+      | undefined;
 
     // Autodetect integration when the user didn't pin one.
     let detection = null;
@@ -222,7 +224,7 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     }
 
     const stub = (getStubConfig(integration) || getStubConfig("pp"))!;
-    if (!integration) integration = stub.integration;
+    if (!integration) integration = stub.integration as string;
 
     // Defensive typeguards (repo policy): coerce YAML-sourced fields that the
     // badge adds so mis-typed values can't cause silent misbehaviour.
@@ -337,7 +339,12 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
     // user didn't set one (and isn't in manual mode). Reuses the detection
     // computed above; the guard keeps an explicit "manual" / user value.
     if (!explicit && hass && detection) {
-      const sel = autoSelectLocation(integration, built, hass, detection);
+      const sel = autoSelectLocation(
+        integration as string,
+        built,
+        hass,
+        detection,
+      );
       if (sel && built[sel.key] !== "manual" && !built[sel.key]) {
         built[sel.key] = sel.value;
       }

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -18,6 +18,8 @@ import {
   scaleRingLevel,
   resolveNumericValue,
   hasValidPollenData,
+  type DeviceDiscovery,
+  type DiscoveredLocation,
 } from "./utils/adapter-helpers.js";
 import { COSMETIC_FIELDS } from "./constants.js";
 // Sensor detection / integration pick / location auto-select are shared with
@@ -697,20 +699,14 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     if (this.debug)
       console.debug("[Card] set hass called; explicit:", explicit);
 
-    // Sensordetektion — shared autodetect (see src/utils/autodetect.js).
+    // Sensordetektion — shared autodetect (see src/utils/autodetect.ts).
     // Destructure local aliases with the same names the header block below
     // already uses, so only the scan/pick/location logic moves to the shared
     // module while the rest of set hass() is untouched. The lazy discovery
     // getters preserve the per-tick discovery call count on large installs.
-    // detectIntegrationStates lives in the still-JS autodetect module; its
-    // JSDoc @returns typedef is incomplete (e.g. omits getIrmkmiDiscovery) and
-    // types every discovery object as the opaque `object`, so the destructured
-    // getters/discoveries would not typecheck against the helpers that consume
-    // them. Cast at this JS boundary; the shapes are exercised by the adapter
-    // contract tests. (Latent: the autodetect JSDoc should be completed.)
     const detection = detectIntegrationStates(hass, {
       debug: this.debug,
-    }) as any;
+    });
     // peuStates + the discovery objects/getters below are consumed by the
     // header label-resolution block further down; the per-integration state
     // lists used only for the pick/location are handled inside the shared
@@ -884,7 +880,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // numeric region_id slugs and user-customized device names all render
         // the friendly location name instead of the raw config value. Reuses
         // the cached discovery from set hass() to avoid a second registry scan.
-        const dwdDiscovery = getDwdDiscovery();
+        const dwdDiscovery = getDwdDiscovery() as DeviceDiscovery;
         const wantedLocation =
           cfg.region_id && cfg.region_id !== "manual" ? cfg.region_id : "";
         const match = resolveLocationByKey(dwdDiscovery, wantedLocation, {
@@ -902,7 +898,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // Primary: resolve via shared discovery so config_entry_id keys and
         // legacy lowercase slugs both produce the friendly location name.
         // Reuses cached discovery from set hass() to avoid a second scan.
-        const peuDiscovery = getPeuDiscovery();
+        const peuDiscovery = getPeuDiscovery() as DeviceDiscovery;
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const peuMatch = resolveLocationByKey(peuDiscovery, wantedLocation, {
@@ -978,7 +974,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
           cfg.location === "manual" ? "" : cfg.location || "";
         if (cfg.location !== "manual") {
           const discoveredLoc = resolveDiscoveredLocation(
-            silamDiscovery,
+            silamDiscovery as Parameters<typeof resolveDiscoveredLocation>[0],
             configLocation,
             this.debug,
           );
@@ -1129,18 +1125,18 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         let title = "";
         if (wantedLocation) {
           if (atmoDiscovery.locations.has(wantedLocation)) {
-            title = atmoDiscovery.locations.get(wantedLocation).label;
+            title = atmoDiscovery.locations.get(wantedLocation)!.label;
           } else {
             // Legacy slug configs ("nice"): map slug -> config_entry_id via discovery
             const entryId = findAtmoLocationBySlug(
-              atmoDiscovery,
+              atmoDiscovery as Parameters<typeof findAtmoLocationBySlug>[0],
               wantedLocation,
             );
-            if (entryId) title = atmoDiscovery.locations.get(entryId).label;
+            if (entryId) title = atmoDiscovery.locations.get(entryId)!.label;
           }
         } else if (atmoDiscovery.locations.size) {
           // No explicit location: pick first discovered
-          title = atmoDiscovery.locations.values().next().value.label;
+          title = atmoDiscovery.locations.values().next().value!.label;
         }
 
         if (title) {
@@ -1152,8 +1148,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // Google Pollen Levels: resolve via shared discovery so config_entry_id
         // keys and legacy label slugs both produce the friendly location name.
         // Reuses cached discovery from set hass() to avoid a second scan.
-        const gplDiscovery = getGplDiscovery();
-        let gplMatch = null;
+        const gplDiscovery = getGplDiscovery() as DeviceDiscovery;
+        let gplMatch: [string, DiscoveredLocation] | null = null;
         if (cfg.location === "manual" && cfg.entity_prefix) {
           // Manual mode: entity resolution filters by prefix AND suffix
           // (gpl/discovery.js:resolveEntityId). Title resolution has to
@@ -1199,7 +1195,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // friendly location name. Reuses gpDiscovery computed in set hass().
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
-        const gpMatch = resolveLocationByKey(gpDiscovery, wantedLocation);
+        const gpMatch = resolveLocationByKey(gpDiscovery as DeviceDiscovery, wantedLocation);
         // Defensive: same rationale as the GPL branch above.
         const title = gpMatch ? cleanDeviceLabel(gpMatch[1].label) : "";
 
@@ -1208,7 +1204,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // MeteoSwiss / hass-swissweather: resolve via shared device discovery
         // so config_entry_id keys, friendly device names, and renamed devices
         // (name_by_user) all surface the right station label in the header.
-        const mswDiscovery = getMswDiscovery();
+        const mswDiscovery = getMswDiscovery() as DeviceDiscovery;
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const mswMatch = resolveLocationByKey(mswDiscovery, wantedLocation);
@@ -1218,7 +1214,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // IRM KMI / meteo.be: resolve via shared device discovery so
         // config_entry_id keys, device names (the location), and renamed
         // devices (name_by_user) all surface the right location label.
-        const irmkmiDiscovery = getIrmkmiDiscovery();
+        const irmkmiDiscovery = getIrmkmiDiscovery() as DeviceDiscovery;
         const wantedLocation =
           cfg.location && cfg.location !== "manual" ? cfg.location : "";
         const irmkmiMatch = resolveLocationByKey(
@@ -1239,7 +1235,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
         // config_entry_id keys, legacy city slugs and user-customized device
         // names all render the friendly location name. Reuses cached discovery
         // from set hass() to avoid a second scan.
-        const ppDiscovery = getPpDiscovery();
+        const ppDiscovery = getPpDiscovery() as DeviceDiscovery;
         const wantedLocation =
           cfg.city && cfg.city !== "manual" ? cfg.city : "";
         const ppMatch = resolveLocationByKey(ppDiscovery, wantedLocation, {

--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -35,7 +35,10 @@ import {
   discoverSilamSensors,
   resolveDiscoveredLocation,
 } from "./utils/silam.js";
-import { findLocationBySlug } from "./utils/adapter-helpers.js";
+import {
+  findLocationBySlug,
+  type DeviceDiscovery,
+} from "./utils/adapter-helpers.js";
 import { slugify } from "./utils/slugify.js";
 import { formatNumberForInput } from "./utils/number-format.js";
 import {
@@ -53,11 +56,7 @@ import silamAllergenMap from "./adapters/silam_allergen_map.json";
 import type { HomeAssistant } from "./types/home-assistant.js";
 import type { CardConfig, RawCardConfig } from "./types/config.js";
 import type { InstalledLocation } from "./editor/types.js";
-
-// The autodetect module (src/utils/autodetect.js) is still untyped JS; its
-// memoized-discovery return shape is typed in a later PR. Until then the
-// detection object crosses this boundary as `any`.
-type DetectionResult = any;
+import type { DetectionResult } from "./utils/autodetect.js";
 
 /**
  * Map a discovery result's `locations` Map into the editor's `[key, label]`
@@ -743,7 +742,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       // 3) Fyll installerade regioner/städer via discovery helpers
 
       // PP: device-based discovery with legacy slug fallback (memoized).
-      const ppDiscovery = getPpDiscovery();
+      const ppDiscovery = getPpDiscovery() as DeviceDiscovery;
       if (ppDiscovery.locations.size > 0) {
         this.installedPpLocations = discoveryToLocations(ppDiscovery);
         // Legacy compatibility: if config.city is a slug not present as a key,
@@ -789,7 +788,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
 
       // DWD: device-based discovery with legacy region_id fallback (memoized).
-      const dwdDiscovery = getDwdDiscovery();
+      const dwdDiscovery = getDwdDiscovery() as DeviceDiscovery;
       if (dwdDiscovery.locations.size > 0) {
         this.installedDwdLocations = discoveryToLocations(dwdDiscovery);
         // Legacy compatibility: if config.region_id is a numeric ID not present as a key,
@@ -829,7 +828,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
       // PEU: device-based discovery with legacy location slug fallback.
       // Sort by label so the dropdown stays stable across HA restarts (memoized).
-      const peuDiscovery = getPeuDiscovery();
+      const peuDiscovery = getPeuDiscovery() as DeviceDiscovery;
       if (peuDiscovery.locations.size > 0) {
         this.installedPeuLocations = discoveryToLocations(peuDiscovery).sort(
           ([, a], [, b]) =>
@@ -1015,9 +1014,12 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         cfgLoc !== "manual" &&
         !atmoDiscovery.locations.has(cfgLoc)
       ) {
-        const matchEntryId = findAtmoLocationBySlug(atmoDiscovery, cfgLoc);
+        const matchEntryId = findAtmoLocationBySlug(
+          atmoDiscovery as Parameters<typeof findAtmoLocationBySlug>[0],
+          cfgLoc,
+        );
         if (matchEntryId) {
-          const label = atmoDiscovery.locations.get(matchEntryId).label;
+          const label = atmoDiscovery.locations.get(matchEntryId)!.label;
           this.installedAtmoLocations.push([cfgLoc, label] as InstalledLocation);
         }
       }

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -60,7 +60,7 @@ export interface AutodetectDiscovery {
   locations: Map<
     string,
     {
-      label?: string;
+      label: string;
       entities?: Map<string, string>;
       sensors?: Map<string, string>;
       weatherEntity?: string;

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -38,4 +38,99 @@ export interface AdapterModule {
 
   /** Default configuration template consumed by the editor (`stubConfig*`). */
   stubConfig?: CardConfig;
+
+  /**
+   * Autodetection descriptor. Every adapter exports one so the shared
+   * autodetect module (`src/utils/autodetect.ts`) can detect the integration,
+   * run its discovery, and resolve legacy-config location slugs without
+   * importing adapter internals. See {@link AdapterAutodetect}.
+   */
+  autodetect?: AdapterAutodetect;
+}
+
+/**
+ * The discovery shape the autodetect module reads structurally. It is the
+ * common denominator of the two concrete discovery return types:
+ * `DeviceDiscovery` (device-based adapters expose `entities`) and
+ * `SilamDiscovery` (exposes `sensors` plus an optional `weatherEntity`).
+ * Autodetect only reads `locations` and, for reverse-mapping, each location's
+ * `entities`/`sensors`/`weatherEntity`.
+ */
+export interface AutodetectDiscovery {
+  locations: Map<
+    string,
+    {
+      label?: string;
+      entities?: Map<string, string>;
+      sensors?: Map<string, string>;
+      weatherEntity?: string;
+      deviceId?: string;
+    }
+  >;
+  tierUsed?: 0 | 1 | 2 | 3;
+}
+
+/**
+ * Cross-adapter context the detection driver passes to every `detectStates`.
+ * Computed once per detection pass so individual adapters don't re-scan
+ * `hass.states` or rebuild the PLU alias set.
+ */
+export interface AutodetectContext {
+  /** All entity ids in `hass.states`, computed once by the driver. */
+  stateIds: string[];
+  /**
+   * PLU allergen slugs, for the PP-vs-PLU disambiguation (both integrations can
+   * expose `sensor.pollen_<allergen>`). Sourced from the PLU descriptor's
+   * `allergenSlugs` so PP never imports PLU internals.
+   */
+  pluAllergenSlugs: Set<string>;
+}
+
+/**
+ * Result of an adapter's `detectStates`: the entity ids it owns, plus — for
+ * discovery-primary adapters (silam/atmo/gp) — the discovery object it computed
+ * eagerly, so `autoSelectLocation` can reuse it instead of recomputing.
+ */
+export interface AutodetectDetectResult {
+  ids: string[];
+  discovery?: AutodetectDiscovery;
+}
+
+/**
+ * Per-adapter autodetection descriptor. Keeps every integration's detection
+ * knowledge (entity-id regexes, platform checks, attribution strings, alias
+ * disambiguation, discovery wrappers, legacy slug extraction) in the adapter
+ * itself; the shared autodetect module orchestrates them uniformly via the
+ * registry (`getAutodetect`/`getAllAutodetect`).
+ */
+export interface AdapterAutodetect {
+  /** Position in the canonical autodetect precedence order (lower wins). */
+  priority: number;
+  /**
+   * Return the entity ids this integration owns in `hass`. Encapsulates the
+   * integration's full detection strategy: regex match, `hass.entities`
+   * platform check, discovery-primary + regex fallback, attribution fallback,
+   * and PP-vs-PLU disambiguation.
+   */
+  detectStates(
+    hass: HomeAssistant,
+    ctx: AutodetectContext,
+    debug?: boolean,
+  ): AutodetectDetectResult;
+  /**
+   * Run the integration's device/registry discovery. Absent for adapters with
+   * no location dimension resolved via discovery (kleenex, plu).
+   */
+  discover?(hass: HomeAssistant, debug?: boolean): AutodetectDiscovery;
+  /**
+   * Derive the location/city/region slug from a single entity id (pp → city,
+   * dwd → region_id, peu → location). Used by `autoSelectLocation` and
+   * `deriveLocationForEntity`.
+   */
+  extractLocationSlug?(entityId: string): string | null;
+  /**
+   * PLU exposes its allergen slug set so the driver can build the PP-vs-PLU
+   * disambiguation context without PP importing PLU.
+   */
+  allergenSlugs?: Set<string>;
 }

--- a/src/utils/autodetect.ts
+++ b/src/utils/autodetect.ts
@@ -41,10 +41,12 @@ export type LocationResult = { key: string; value: unknown } | null;
 export interface DetectionResult {
   stateIds: string[];
   states: Record<string, string[]>;
+  // silam/atmo/gp run their discovery eagerly during detection (their
+  // descriptors always return it), so these are always present.
   discovery: {
-    silam?: AutodetectDiscovery;
-    atmo?: AutodetectDiscovery;
-    gp?: AutodetectDiscovery;
+    silam: AutodetectDiscovery;
+    atmo: AutodetectDiscovery;
+    gp: AutodetectDiscovery;
   };
   getPpDiscovery: () => AutodetectDiscovery;
   getDwdDiscovery: () => AutodetectDiscovery;
@@ -128,10 +130,12 @@ export function detectIntegrationStates(
   }
 
   // Preserve the { silam, atmo, gp } discovery shape consumers read directly.
+  // These descriptors always run discovery eagerly, so the entries are present.
+  const emptyDiscovery: AutodetectDiscovery = { locations: new Map() };
   const discovery: DetectionResult["discovery"] = {
-    silam: eagerDiscovery.silam,
-    atmo: eagerDiscovery.atmo,
-    gp: eagerDiscovery.gp,
+    silam: eagerDiscovery.silam ?? emptyDiscovery,
+    atmo: eagerDiscovery.atmo ?? emptyDiscovery,
+    gp: eagerDiscovery.gp ?? emptyDiscovery,
   };
 
   // Lazy/memoized discoveries for adapters whose header label / location

--- a/src/utils/autodetect.ts
+++ b/src/utils/autodetect.ts
@@ -1,4 +1,4 @@
-// src/utils/autodetect.js
+// src/utils/autodetect.ts
 //
 // Shared Home Assistant integration autodetection. Extracted from the card
 // element and card editor (which previously each carried their own inline copy
@@ -6,6 +6,12 @@
 // element, and badge editor all detect integrations and auto-select a location
 // the same way. One source of truth; the divergences (editor setConfig missing
 // PLU, editor set hass missing Kleenex) are gone.
+//
+// This module is a pure orchestrator: every integration's detection knowledge
+// (entity-id regexes, platform checks, attribution strings, alias
+// disambiguation, discovery wrappers, legacy slug extraction) lives in the
+// adapter's autodetect descriptor and is consumed uniformly via the registry
+// (`getAutodetect`/`getAllAutodetect`). No adapter internals are imported here.
 //
 // Three layers, each pure and side-effect free:
 //   detectIntegrationStates(hass)  -> per-integration entity-id lists + cached
@@ -15,50 +21,77 @@
 //
 // Plus normalizeIntegration() and detectedIntegrationIds() helpers.
 
-import { PLU_ALIAS_MAP } from "../adapters/plu.js";
-import { discoverAtmoSensors } from "../adapters/atmo.js";
-import { GPL_ATTRIBUTION, discoverGplSensors } from "../adapters/gpl/index.js";
-import { discoverGpSensors } from "../adapters/gp/index.js";
-import { discoverMswSensors } from "../adapters/msw.js";
-import { discoverIrmkmiSensors } from "../adapters/irmkmi.js";
-import {
-  discoverPpSensors,
-  extractCitySlugFromEntityId as extractPpCitySlugFromEntityId,
-} from "../adapters/pp.js";
-import { discoverDwdSensors, DWD_ENTITY_ID_RE } from "../adapters/dwd.js";
-import {
-  discoverPeuSensors,
-  extractPeuLocationSlugFromEntityId,
-} from "../adapters/peu.js";
-import { discoverSilamSensors } from "./silam.js";
+import type { HomeAssistant } from "../types/home-assistant.js";
+import type { CardConfig } from "../types/config.js";
+import type {
+  AutodetectContext,
+  AutodetectDiscovery,
+} from "../types/adapter.js";
+import { getAutodetect, getAllAutodetect } from "../adapter-registry.js";
 
-// Canonical autodetect priority order. The first integration with detected
-// sensors (and not in `skip`) wins. Single source of truth for every consumer.
-export const INTEGRATION_PRIORITY = [
-  "pp",
-  "plu",
-  "peu",
-  "dwd",
-  "silam",
-  "kleenex",
-  "atmo",
-  "gp",
-  "gpl",
-  "msw",
-  "irmkmi",
-];
+/** A location auto-selection: which config key to set and to what value. */
+export type LocationResult = { key: string; value: unknown } | null;
+
+/**
+ * The cached result of a detection pass. Preserves the exact shape the card,
+ * editors and badge consume: per-integration entity-id lists, the eagerly
+ * computed silam/atmo/gp discovery, and lazily memoized discovery getters for
+ * the remaining integrations.
+ */
+export interface DetectionResult {
+  stateIds: string[];
+  states: Record<string, string[]>;
+  discovery: {
+    silam?: AutodetectDiscovery;
+    atmo?: AutodetectDiscovery;
+    gp?: AutodetectDiscovery;
+  };
+  getPpDiscovery: () => AutodetectDiscovery;
+  getDwdDiscovery: () => AutodetectDiscovery;
+  getPeuDiscovery: () => AutodetectDiscovery;
+  getGplDiscovery: () => AutodetectDiscovery;
+  getMswDiscovery: () => AutodetectDiscovery;
+  getIrmkmiDiscovery: () => AutodetectDiscovery;
+}
+
+// Canonical autodetect priority order, derived from the descriptor registry so
+// there is a single source of truth. The first integration with detected
+// sensors (and not in `skip`) wins. Order:
+//   PP > PLU > PEU > DWD > SILAM > Kleenex > ATMO > GP > GPL > MSW > IRMKMI
+export const INTEGRATION_PRIORITY: string[] = getAllAutodetect().map(
+  ([id]) => id,
+);
 
 /**
  * Normalize an integration id from config: trim + lowercase when it's a string,
  * pass through otherwise. Previously duplicated in the card, badge, and both
  * editors.
- *
- * @param {*} value
- * @returns {*}
  */
-export function normalizeIntegration(value) {
+export function normalizeIntegration(value: unknown): unknown {
   if (value && typeof value === "string") return value.trim().toLowerCase();
   return value;
+}
+
+/**
+ * Build a memoized discovery getter for an integration: runs the adapter's
+ * `discover` at most once, caching the result. Integrations without a
+ * `discover` yield an empty discovery.
+ */
+function makeLazyDiscovery(
+  id: string,
+  hass: HomeAssistant,
+  debug: boolean,
+): () => AutodetectDiscovery {
+  let cached: AutodetectDiscovery | null = null;
+  return () => {
+    if (cached === null) {
+      const desc = getAutodetect(id);
+      cached = desc?.discover
+        ? desc.discover(hass, debug)
+        : { locations: new Map() };
+    }
+    return cached;
+  };
 }
 
 /**
@@ -66,285 +99,61 @@ export function normalizeIntegration(value) {
  * helpers. Returns per-integration entity-id arrays plus discovery results so
  * callers never re-scan hass.states or re-run discovery within a single update.
  *
- * Discovery cost is preserved from the card: silam/atmo/gp run eagerly (the card
- * always did); pp/dwd/peu/gpl/msw stay behind memoized getters so large installs
- * don't gain extra registry scans per HA tick.
- *
- * @param {object} hass
- * @param {{debug?: boolean}} [opts]
- * @returns {{
- *   stateIds: string[],
- *   states: Record<string, string[]>,
- *   discovery: { silam: object, atmo: object, gp: object },
- *   getPpDiscovery: () => object,
- *   getDwdDiscovery: () => object,
- *   getPeuDiscovery: () => object,
- *   getGplDiscovery: () => object,
- *   getMswDiscovery: () => object,
- * }}
+ * Discovery cost is preserved from the card: silam/atmo/gp run eagerly (their
+ * descriptors return the discovery they computed during detection); the
+ * remaining integrations stay behind memoized getters so large installs don't
+ * gain extra registry scans per HA tick.
  */
-export function detectIntegrationStates(hass, { debug = false } = {}) {
-  const stateIds = hass && hass.states ? Object.keys(hass.states) : [];
+export function detectIntegrationStates(
+  hass: HomeAssistant,
+  { debug = false }: { debug?: boolean } = {},
+): DetectionResult {
+  const stateIds =
+    hass && hass.states ? Object.keys(hass.states as object) : [];
 
   // PP allergen disambiguation against PLU (both can use sensor.pollen_<x>).
-  const pluAllergenSlugs = new Set(Object.values(PLU_ALIAS_MAP).flat());
+  const pluAllergenSlugs =
+    getAutodetect("plu")?.allergenSlugs ?? new Set<string>();
+  const ctx: AutodetectContext = { stateIds, pluAllergenSlugs };
 
-  const ppStates = stateIds.filter((id) => {
-    if (typeof id !== "string") return false;
-    if (!id.startsWith("sensor.pollen_")) return false;
-    if (id.startsWith("sensor.pollenflug_")) return false;
-    // Exclude MSW (hass-swissweather): sensor.pollen_<allergen>_level_at_<station>
-    if (id.includes("_level_at_")) return false;
+  const states: Record<string, string[]> = {};
+  const eagerDiscovery: Record<string, AutodetectDiscovery> = {};
 
-    // Match manual mode (sensor.pollen_<allergen>) and city mode
-    // (sensor.pollen_<allergen>_<city>).
-    const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
-    if (!match) return false;
-
-    const allergenSlug = match[1];
-    // Single underscore AND a known PLU allergen -> likely PLU, not PP.
-    if (!match[2] && pluAllergenSlugs.has(allergenSlug)) return false;
-
-    return true;
-  });
-
-  // DWD: match the pollenflug_<allergen>_<region> segment whether or not HA has
-  // prepended a device-name slug (#217).
-  const dwdStates = stateIds.filter(
-    (id) => typeof id === "string" && DWD_ENTITY_ID_RE.test(id),
-  );
-
-  const peuStates = stateIds.filter(
-    (id) => typeof id === "string" && id.startsWith("sensor.polleninformation_"),
-  );
-
-  // SILAM: primary via discovery, fallback via regex.
-  const silamDiscovery = discoverSilamSensors(hass, debug);
-  let silamStates = [];
-  if (silamDiscovery.locations.size > 0) {
-    for (const [, loc] of silamDiscovery.locations) {
-      for (const eid of loc.sensors.values()) silamStates.push(eid);
-      // A SILAM install can enable only the weather entity (no allergen
-      // sensors) and still expose the allergy_risk index; count the weather
-      // entity as evidence so weather-only installs are detected too.
-      if (loc.weatherEntity) silamStates.push(loc.weatherEntity);
-    }
-  }
-  if (!silamStates.length) {
-    silamStates = stateIds.filter(
-      (id) => typeof id === "string" && id.startsWith("sensor.silam_pollen_"),
-    );
+  // Detect every integration uniformly, in priority order. Descriptors that run
+  // discovery eagerly (silam/atmo/gp) return it so it isn't recomputed below.
+  for (const [id, desc] of getAllAutodetect()) {
+    const result = desc.detectStates(hass, ctx, debug);
+    states[id] = result.ids;
+    if (result.discovery) eagerDiscovery[id] = result.discovery;
   }
 
-  const kleenexStates = stateIds.filter(
-    (id) =>
-      typeof id === "string" && id.startsWith("sensor.kleenex_pollen_radar_"),
-  );
-
-  const pluStates = stateIds.filter((id) => {
-    if (typeof id !== "string") return false;
-    const match = /^sensor\.pollen_([^_]+)$/.exec(id);
-    if (!match) return false;
-    return pluAllergenSlugs.has(match[1]);
-  });
-
-  // ATMO: primary via discovery (prefixed entity IDs + device-based), fallback
-  // to regex for older HA registries.
-  const atmoDiscovery = discoverAtmoSensors(hass, debug);
-  let atmoStates = [];
-  if (atmoDiscovery.locations.size > 0) {
-    for (const [, loc] of atmoDiscovery.locations) {
-      for (const eid of loc.entities.values()) atmoStates.push(eid);
-    }
-  }
-  if (!atmoStates.length) {
-    // Legacy fallback. Matches current niveau_{slug} and legacy
-    // niveau_alerte_{slug}.
-    atmoStates = stateIds.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:niveau_(?:alerte_)?(?:ambroisie|armoise|aulne|bouleau|gramine|olivier)|(?:pm25|pm10|ozone|dioxyde_d_azote|dioxyde_de_soufre)|qualite_globale(?:_pollen)?)_/.test(
-          id,
-        ) &&
-        !/_j_\d+$/.test(id),
-    );
-  }
-
-  // GPL: hass.entities platform (primary) or attribution (fallback). Exclude
-  // date/timestamp helper entities (e.g. an "update time" sensor) so they are
-  // never treated as pollen sensors -- matching the attribution fallback below.
-  const isNonDataDeviceClass = (eid) => {
-    const dc = hass?.states?.[eid]?.attributes?.device_class;
-    return dc === "date" || dc === "timestamp";
+  // Preserve the { silam, atmo, gp } discovery shape consumers read directly.
+  const discovery: DetectionResult["discovery"] = {
+    silam: eagerDiscovery.silam,
+    atmo: eagerDiscovery.atmo,
+    gp: eagerDiscovery.gp,
   };
-  let gplStates = [];
-  if (hass && hass.entities) {
-    gplStates = Object.entries(hass.entities)
-      .filter(
-        ([eid, entry]) =>
-          entry.platform === "pollenlevels" &&
-          !entry.entity_category &&
-          !isNonDataDeviceClass(eid),
-      )
-      .map(([eid]) => eid);
-  }
-  if (!gplStates.length) {
-    gplStates = stateIds.filter((id) => {
-      const s = hass.states[id];
-      return (
-        s?.attributes?.attribution === GPL_ATTRIBUTION &&
-        s.attributes.device_class !== "date" &&
-        s.attributes.device_class !== "timestamp"
-      );
-    });
-  }
-
-  // GP (svenove/google_pollen): full discovery; state list derived from it.
-  const gpDiscovery = discoverGpSensors(hass, debug);
-  let gpStates = [];
-  if (gpDiscovery.locations.size > 0) {
-    for (const [, loc] of gpDiscovery.locations) {
-      for (const eid of loc.entities.values()) gpStates.push(eid);
-    }
-  }
-  if (!gpStates.length) {
-    if (hass && hass.entities) {
-      gpStates = Object.entries(hass.entities)
-        .filter(
-          ([eid, entry]) =>
-            entry.platform === "google_pollen" &&
-            !entry.entity_category &&
-            !isNonDataDeviceClass(eid),
-        )
-        .map(([eid]) => eid);
-    }
-    if (!gpStates.length) {
-      gpStates = stateIds.filter(
-        (id) => typeof id === "string" && id.startsWith("sensor.google_pollen_"),
-      );
-    }
-  }
-
-  // MSW (MeteoSwiss / hass-swissweather). Entity IDs follow
-  // sensor.<device-slug>_pollen_<allergen>_level_at_<station>; the device-slug
-  // prefix is added by HA and varies per install. Primary via hass.entities
-  // platform check; fallback regex for older registries.
-  const mswLevelRe =
-    /(?:^|_)pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/;
-  let mswStates = [];
-  if (hass && hass.entities) {
-    mswStates = Object.entries(hass.entities)
-      .filter(
-        ([eid, entry]) =>
-          entry.platform === "swissweather" &&
-          !entry.entity_category &&
-          mswLevelRe.test(eid),
-      )
-      .map(([eid]) => eid);
-  }
-  if (!mswStates.length) {
-    mswStates = stateIds.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.(?:\w+_)*pollen_(?:birch|grasses|alder|hazel|beech|ash|oak)_level_at_/.test(
-          id,
-        ),
-    );
-  }
-
-  // IRM KMI (meteo.be / irm-kmi-ha). Entity IDs follow
-  // sensor.<location-slug>_<allergen>_level. Primary via hass.entities platform
-  // check; fallback regex for older registries.
-  const irmkmiLevelRe =
-    /_(?:alder|ash|birch|grasses|hazel|mugwort|oak)_level$/;
-  let irmkmiStates = [];
-  if (hass && hass.entities) {
-    irmkmiStates = Object.entries(hass.entities)
-      .filter(
-        ([eid, entry]) =>
-          entry.platform === "irm_kmi" &&
-          !entry.entity_category &&
-          irmkmiLevelRe.test(eid),
-      )
-      .map(([eid]) => eid);
-  }
-  if (!irmkmiStates.length) {
-    irmkmiStates = stateIds.filter(
-      (id) =>
-        typeof id === "string" &&
-        /^sensor\.\w+_(?:alder|ash|birch|grasses|hazel|mugwort|oak)_level$/.test(
-          id,
-        ),
-    );
-  }
 
   // Lazy/memoized discoveries for adapters whose header label / location
-  // resolution would otherwise re-scan the registry. SILAM/Atmo/GP are already
-  // computed above; PP/DWD/PEU/GPL/MSW go behind getters so callers that only
-  // need the state lists don't pay for the scan.
-  let _ppDiscovery = null;
-  let _dwdDiscovery = null;
-  let _peuDiscovery = null;
-  let _gplDiscovery = null;
-  let _mswDiscovery = null;
-  let _irmkmiDiscovery = null;
-  const getPpDiscovery = () => {
-    if (_ppDiscovery === null) _ppDiscovery = discoverPpSensors(hass, debug);
-    return _ppDiscovery;
-  };
-  const getDwdDiscovery = () => {
-    if (_dwdDiscovery === null) _dwdDiscovery = discoverDwdSensors(hass, debug);
-    return _dwdDiscovery;
-  };
-  const getPeuDiscovery = () => {
-    if (_peuDiscovery === null) _peuDiscovery = discoverPeuSensors(hass, debug);
-    return _peuDiscovery;
-  };
-  const getGplDiscovery = () => {
-    if (_gplDiscovery === null) _gplDiscovery = discoverGplSensors(hass, debug);
-    return _gplDiscovery;
-  };
-  const getMswDiscovery = () => {
-    if (_mswDiscovery === null) _mswDiscovery = discoverMswSensors(hass, debug);
-    return _mswDiscovery;
-  };
-  const getIrmkmiDiscovery = () => {
-    if (_irmkmiDiscovery === null)
-      _irmkmiDiscovery = discoverIrmkmiSensors(hass, debug);
-    return _irmkmiDiscovery;
-  };
+  // resolution would otherwise re-scan the registry.
+  const getPpDiscovery = makeLazyDiscovery("pp", hass, debug);
+  const getDwdDiscovery = makeLazyDiscovery("dwd", hass, debug);
+  const getPeuDiscovery = makeLazyDiscovery("peu", hass, debug);
+  const getGplDiscovery = makeLazyDiscovery("gpl", hass, debug);
+  const getMswDiscovery = makeLazyDiscovery("msw", hass, debug);
+  const getIrmkmiDiscovery = makeLazyDiscovery("irmkmi", hass, debug);
 
   if (debug) {
     console.debug("Sensor states detected:");
-    console.debug("PP:", ppStates);
-    console.debug("DWD:", dwdStates);
-    console.debug("PEU:", peuStates);
-    console.debug("SILAM:", silamStates);
-    console.debug("KLEENEX:", kleenexStates);
-    console.debug("PLU:", pluStates);
-    console.debug("ATMO:", atmoStates);
-    console.debug("GPL:", gplStates);
-    console.debug("GP:", gpStates);
-    console.debug("MSW:", mswStates);
-    console.debug("IRMKMI:", irmkmiStates);
+    for (const id of INTEGRATION_PRIORITY) {
+      console.debug(`${id.toUpperCase()}:`, states[id]);
+    }
   }
 
   return {
     stateIds,
-    states: {
-      pp: ppStates,
-      dwd: dwdStates,
-      peu: peuStates,
-      silam: silamStates,
-      kleenex: kleenexStates,
-      plu: pluStates,
-      atmo: atmoStates,
-      gpl: gplStates,
-      gp: gpStates,
-      msw: mswStates,
-      irmkmi: irmkmiStates,
-    },
-    discovery: { silam: silamDiscovery, atmo: atmoDiscovery, gp: gpDiscovery },
+    states,
+    discovery,
     getPpDiscovery,
     getDwdDiscovery,
     getPeuDiscovery,
@@ -358,12 +167,11 @@ export function detectIntegrationStates(hass, { debug = false } = {}) {
  * Ordered Set of integration ids that have detected sensors, in canonical
  * priority order. Powers the editor integration dropdown's "installed first"
  * sort.
- *
- * @param {ReturnType<typeof detectIntegrationStates>} detection
- * @returns {Set<string>}
  */
-export function detectedIntegrationIds(detection) {
-  const out = new Set();
+export function detectedIntegrationIds(
+  detection: DetectionResult | null | undefined,
+): Set<string> {
+  const out = new Set<string>();
   if (!detection || !detection.states) return out;
   for (const id of INTEGRATION_PRIORITY) {
     if (detection.states[id] && detection.states[id].length) out.add(id);
@@ -376,20 +184,22 @@ export function detectedIntegrationIds(detection) {
  * wins unchanged (autodetect never overrides an explicit choice). Otherwise the
  * first integration in INTEGRATION_PRIORITY with detected sensors and not in
  * `skip` is chosen.
- *
- * @param {ReturnType<typeof detectIntegrationStates>} detection
- * @param {{explicit?: boolean, userIntegration?: *, skip?: Set<string>}} [opts]
- * @returns {string|undefined}
  */
 export function pickIntegration(
-  detection,
-  { explicit = false, userIntegration, skip } = {},
-) {
-  const normalized = normalizeIntegration(userIntegration);
+  detection: DetectionResult | null | undefined,
+  {
+    explicit = false,
+    userIntegration,
+    skip,
+  }: { explicit?: boolean; userIntegration?: unknown; skip?: Set<string> } = {},
+): string | undefined {
+  const normalized = normalizeIntegration(userIntegration) as
+    | string
+    | undefined;
   if (explicit) return normalized;
 
   const states = detection?.states || {};
-  const skipSet = skip || new Set();
+  const skipSet = skip || new Set<string>();
   for (const id of INTEGRATION_PRIORITY) {
     if (states[id] && states[id].length && !skipSet.has(id)) return id;
   }
@@ -403,14 +213,13 @@ export function pickIntegration(
  * Callers apply the value under their own guards (typically
  * cfg[key] !== "manual" && !cfg[key] && states.length) so "manual" mode and
  * already-set values are honoured at the call site.
- *
- * @param {string} integration
- * @param {object} cfg              current config (read-only here)
- * @param {object} hass
- * @param {ReturnType<typeof detectIntegrationStates>} detection
- * @returns {{key: string, value: *}|null}
  */
-export function autoSelectLocation(integration, cfg, hass, detection) {
+export function autoSelectLocation(
+  integration: string,
+  _cfg: CardConfig | Record<string, unknown>,
+  hass: HomeAssistant,
+  detection: DetectionResult,
+): LocationResult {
   const states = detection?.states || {};
 
   if (integration === "dwd" && states.dwd?.length) {
@@ -425,8 +234,9 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
     // allergens whose slug contains underscores (e.g. "salg_och_viden") and
     // manual-mode sensors are handled correctly; a naive `_[^_]+$` split would
     // mis-derive the city. Pick the first sensor that yields a real city slug.
+    const extract = getAutodetect("pp")?.extractLocationSlug;
     for (const id of states.pp) {
-      const value = extractPpCitySlugFromEntityId(id);
+      const value = extract?.(id);
       if (value) return { key: "city", value };
     }
     return null;
@@ -436,7 +246,9 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
     const peuLocations = Array.from(
       new Set(
         states.peu
-          .map((eid) => hass.states[eid]?.attributes?.location_slug || null)
+          .map(
+            (eid) => hass.states[eid]?.attributes?.location_slug || null,
+          )
           .filter(Boolean),
       ),
     );
@@ -446,18 +258,14 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
 
   if (integration === "silam" && states.silam?.length) {
     const silamDiscovery = detection.discovery.silam;
-    if (silamDiscovery.locations.size > 0) {
+    if (silamDiscovery && silamDiscovery.locations.size > 0) {
       const firstLocId = silamDiscovery.locations.keys().next().value;
       return firstLocId ? { key: "location", value: firstLocId } : null;
     }
+    const extract = getAutodetect("silam")?.extractLocationSlug;
     const silamLocations = Array.from(
       new Set(
-        states.silam
-          .map((eid) => {
-            const m = eid.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
-            return m ? m[1] : null;
-          })
-          .filter(Boolean),
+        states.silam.map((eid) => extract?.(eid) || null).filter(Boolean),
       ),
     );
     const value = silamLocations[0];
@@ -509,7 +317,7 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
 
   if (integration === "gp" && states.gp?.length) {
     const gpDiscovery = detection.discovery.gp;
-    const firstLocId = gpDiscovery.locations.keys().next().value;
+    const firstLocId = gpDiscovery?.locations.keys().next().value;
     return firstLocId ? { key: "location", value: firstLocId } : null;
   }
 
@@ -534,12 +342,11 @@ export function autoSelectLocation(integration, cfg, hass, detection) {
  * `entities` (Map<key, entityId>), SILAM exposes `sensors` (Map) plus an
  * optional `weatherEntity`. Returns the location map key (the same value
  * autoSelectLocation returns as `value`) or null.
- *
- * @param {{locations?: Map<string, {entities?: Map, sensors?: Map, weatherEntity?: string}>}} discovery
- * @param {string} entityId
- * @returns {string|null}
  */
-function findLocationKeyInDiscovery(discovery, entityId) {
+function findLocationKeyInDiscovery(
+  discovery: AutodetectDiscovery | null | undefined,
+  entityId: string,
+): string | null {
   if (!discovery || !discovery.locations) return null;
   for (const [key, loc] of discovery.locations) {
     if (!loc) continue;
@@ -564,26 +371,26 @@ function findLocationKeyInDiscovery(discovery, entityId) {
  *
  * Mirrors the per-integration logic in autoSelectLocation; discovery-based
  * integrations (gp/gpl/msw/silam-discovery/atmo) resolve via
- * findLocationKeyInDiscovery, id-pattern integrations via their adapter regexes.
- *
- * @param {string} integration
- * @param {string} entityId
- * @param {object} hass
- * @param {ReturnType<typeof detectIntegrationStates>} detection
- * @returns {{key: string, value: *}|null}
+ * findLocationKeyInDiscovery, id-pattern integrations via their adapter
+ * descriptors' extractLocationSlug or inline regexes.
  */
-export function deriveLocationForEntity(integration, entityId, hass, detection) {
+export function deriveLocationForEntity(
+  integration: string,
+  entityId: string,
+  hass: HomeAssistant,
+  detection: DetectionResult,
+): LocationResult {
   if (typeof integration !== "string" || typeof entityId !== "string")
     return null;
 
   switch (integration) {
     case "pp": {
-      const value = extractPpCitySlugFromEntityId(entityId);
+      const value = getAutodetect("pp")?.extractLocationSlug?.(entityId);
       return value ? { key: "city", value } : null;
     }
 
     case "dwd": {
-      const value = entityId.match(DWD_ENTITY_ID_RE)?.[2] || null;
+      const value = getAutodetect("dwd")?.extractLocationSlug?.(entityId);
       return value ? { key: "region_id", value } : null;
     }
 
@@ -593,7 +400,7 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
       // don't expose the (optional) attribute still pin the picked location.
       const value =
         hass?.states?.[entityId]?.attributes?.location_slug ||
-        extractPeuLocationSlugFromEntityId(entityId);
+        getAutodetect("peu")?.extractLocationSlug?.(entityId);
       return value ? { key: "location", value } : null;
     }
 
@@ -623,8 +430,8 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
         entityId,
       );
       if (fromDiscovery) return { key: "location", value: fromDiscovery };
-      const m = entityId.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
-      return m ? { key: "location", value: m[1] } : null;
+      const value = getAutodetect("silam")?.extractLocationSlug?.(entityId);
+      return value ? { key: "location", value } : null;
     }
 
     case "kleenex": {
@@ -645,8 +452,8 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
             })
             .filter(Boolean),
         ),
-      );
-      let best = null;
+      ) as string[];
+      let best: string | null = null;
       for (const loc of locations) {
         const prefix = `sensor.kleenex_pollen_radar_${loc}_`;
         if (
@@ -717,12 +524,11 @@ export function deriveLocationForEntity(integration, entityId, hass, detection) 
  * entities); any entity not owned by a known pollen integration -- including
  * weather.* entities that aren't SILAM's -- then returns null, so we never
  * clutter the picker.
- *
- * @param {object} hass
- * @param {string} entityId
- * @returns {{config: object}|null}
  */
-export function suggestEntityConfig(hass, entityId) {
+export function suggestEntityConfig(
+  hass: HomeAssistant,
+  entityId: string,
+): { config: Record<string, unknown> } | null {
   // Pollen sensors live on sensor.*; SILAM weather-only installs expose the
   // allergy_risk index via a weather.* entity that detection/discovery already
   // recognise, so let that domain through too.
@@ -735,7 +541,7 @@ export function suggestEntityConfig(hass, entityId) {
 
   const detection = detectIntegrationStates(hass);
 
-  let integration;
+  let integration: string | undefined;
   for (const id of INTEGRATION_PRIORITY) {
     if (detection.states[id]?.includes(entityId)) {
       integration = id;
@@ -744,7 +550,12 @@ export function suggestEntityConfig(hass, entityId) {
   }
   if (!integration) return null;
 
-  const derived = deriveLocationForEntity(integration, entityId, hass, detection);
+  const derived = deriveLocationForEntity(
+    integration,
+    entityId,
+    hass,
+    detection,
+  );
 
   // For gpl/gp/msw/irmkmi/kleenex a null derivation means the entity isn't a
   // render-usable pollen sensor at the resolved location: gpl/gp/msw include
@@ -758,10 +569,9 @@ export function suggestEntityConfig(hass, entityId) {
   const STRICT_DERIVATION = new Set(["gpl", "gp", "msw", "irmkmi", "kleenex"]);
   if (!derived && STRICT_DERIVATION.has(integration)) return null;
 
-  const loc =
-    derived || autoSelectLocation(integration, {}, hass, detection);
+  const loc = derived || autoSelectLocation(integration, {}, hass, detection);
 
-  const config = {
+  const config: Record<string, unknown> = {
     type: "custom:pollenprognos-card",
     integration,
     ...(loc ? { [loc.key]: loc.value } : {}),

--- a/test/card/autodetect.test.ts
+++ b/test/card/autodetect.test.ts
@@ -618,7 +618,7 @@ describe("badge picker integration choice (getStubConfig logic)", () => {
   });
 
   it("detectIntegrationStates tolerates an empty hass", () => {
-    const detection = detectIntegrationStates({ states: {}, entities: {} });
+    const detection = detectIntegrationStates({ states: {}, entities: {} } as any);
     expect(detectedIntegrationIds(detection).size).toBe(0);
   });
 });

--- a/test/utils/autodetect-characterization.test.ts
+++ b/test/utils/autodetect-characterization.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Characterization tests for src/utils/autodetect.js.
+ *
+ * These lock the OBSERVABLE behaviour of the shared autodetection module before
+ * the descriptor-registry refactor (PR 9b). They are the contract: the refactor
+ * must keep every value here byte-identical. Where existing suites already pin a
+ * behaviour (test/card/autodetect.test.ts covers detection precedence and the
+ * PP/PLU, DWD, MSW, ATMO, SILAM, GPL matchers; test/utils/suggest.test.ts covers
+ * suggestEntityConfig and every deriveLocationForEntity branch) this file does
+ * NOT duplicate it. It adds the three facits those suites leave thin:
+ *
+ *   1. detectIntegrationStates -> the FULL per-integration `states` partition
+ *      for one combined fixture (locks all 11 matchers simultaneously; this is
+ *      the single strongest guard for the "matchStateId moves home" step).
+ *   2. autoSelectLocation -> per-integration branch outcomes (only ever tested
+ *      indirectly through suggestEntityConfig before).
+ *   3. pickIntegration explicit/skip semantics, normalizeIntegration, and
+ *      detectedIntegrationIds ordering.
+ *
+ * The autoSelectLocation cases hand-build `detection` objects (mirroring
+ * suggest.test's deriveLocationForEntity style) so each branch is exercised
+ * deterministically without depending on any adapter's discovery internals.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectIntegrationStates,
+  pickIntegration,
+  autoSelectLocation,
+  normalizeIntegration,
+  detectedIntegrationIds,
+  INTEGRATION_PRIORITY,
+} from "../../src/utils/autodetect.js";
+import { createHassWithRegistry } from "../helpers.js";
+
+// ---------------------------------------------------------------------------
+// 1. detectIntegrationStates — full per-integration partition
+// ---------------------------------------------------------------------------
+
+/**
+ * One realistic entity per integration, wired through the entity/device
+ * registry so the platform-based matchers (silam/gpl/gp/msw/irmkmi) and the
+ * id-pattern matchers (pp/plu/peu/dwd/kleenex/atmo) all fire from the same hass.
+ */
+function combinedHass() {
+  return createHassWithRegistry([
+    { entityId: "sensor.pollen_stockholm_bjork" }, // pp (city suffix)
+    { entityId: "sensor.pollen_bouleau" }, // plu (known allergen, no suffix)
+    {
+      entityId: "sensor.polleninformation_wien_birch",
+      attributes: { location_slug: "wien" },
+    }, // peu
+    { entityId: "sensor.pollenflug_erle_11" }, // dwd
+    {
+      entityId: "sensor.silam_pollen_birch_home",
+      platform: "silam_pollen",
+      deviceId: "dev_s",
+      translationKey: "birch",
+      deviceMeta: { configEntries: ["entry_s"], name: "Home" },
+    }, // silam
+    { entityId: "sensor.kleenex_pollen_radar_amsterdam_trees" }, // kleenex
+    { entityId: "sensor.niveau_bouleau_montpellier" }, // atmo
+    {
+      entityId: "sensor.gpl_grass",
+      platform: "pollenlevels",
+      deviceId: "dev_g",
+      deviceMeta: { configEntries: ["entry_gpl"], name: "Home" },
+    }, // gpl
+    {
+      entityId: "sensor.google_pollen_grass",
+      platform: "google_pollen",
+      deviceId: "dev_gp",
+      deviceMeta: { configEntries: ["entry_gp"], name: "Home" },
+    }, // gp
+    {
+      entityId: "sensor.bern_pollen_birch_level_at_3000_pbe",
+      platform: "swissweather",
+      deviceId: "dev_m",
+      deviceMeta: { configEntries: ["entry_msw"], name: "Bern" },
+    }, // msw
+    {
+      entityId: "sensor.antwerp_birch_level",
+      platform: "irm_kmi",
+      deviceId: "dev_i",
+      deviceMeta: { configEntries: ["entry_irm"], name: "Antwerp" },
+    }, // irmkmi
+  ]);
+}
+
+describe("detectIntegrationStates: full partition (all matchers at once)", () => {
+  it("assigns each entity to exactly its owning integration", () => {
+    const detection = detectIntegrationStates(combinedHass());
+    expect(detection.states).toEqual({
+      pp: ["sensor.pollen_stockholm_bjork"],
+      dwd: ["sensor.pollenflug_erle_11"],
+      peu: ["sensor.polleninformation_wien_birch"],
+      silam: ["sensor.silam_pollen_birch_home"],
+      kleenex: ["sensor.kleenex_pollen_radar_amsterdam_trees"],
+      plu: ["sensor.pollen_bouleau"],
+      atmo: ["sensor.niveau_bouleau_montpellier"],
+      gpl: ["sensor.gpl_grass"],
+      gp: ["sensor.google_pollen_grass"],
+      msw: ["sensor.bern_pollen_birch_level_at_3000_pbe"],
+      irmkmi: ["sensor.antwerp_birch_level"],
+    });
+  });
+
+  it("exposes the canonical priority order (facit for descriptor priority)", () => {
+    expect(INTEGRATION_PRIORITY).toEqual([
+      "pp",
+      "plu",
+      "peu",
+      "dwd",
+      "silam",
+      "kleenex",
+      "atmo",
+      "gp",
+      "gpl",
+      "msw",
+      "irmkmi",
+    ]);
+  });
+
+  it("detectedIntegrationIds returns every installed id in priority order", () => {
+    const detection = detectIntegrationStates(combinedHass());
+    expect([...detectedIntegrationIds(detection)]).toEqual([
+      "pp",
+      "plu",
+      "peu",
+      "dwd",
+      "silam",
+      "kleenex",
+      "atmo",
+      "gp",
+      "gpl",
+      "msw",
+      "irmkmi",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. pickIntegration — explicit / skip semantics
+// ---------------------------------------------------------------------------
+
+describe("pickIntegration: explicit and skip", () => {
+  it("picks the highest-priority installed integration (pp over plu here)", () => {
+    expect(pickIntegration(detectIntegrationStates(combinedHass()))).toBe("pp");
+  });
+
+  it("explicit user choice wins unchanged, normalized", () => {
+    const detection = detectIntegrationStates(combinedHass());
+    expect(
+      pickIntegration(detection, { explicit: true, userIntegration: " DWD " }),
+    ).toBe("dwd");
+  });
+
+  it("skip set removes candidates in priority order", () => {
+    const detection = detectIntegrationStates(combinedHass());
+    expect(
+      pickIntegration(detection, { skip: new Set(["pp", "plu", "peu"]) }),
+    ).toBe("dwd");
+  });
+
+  it("falls back to the normalized user integration when nothing is detected", () => {
+    const detection = detectIntegrationStates(
+      createHassWithRegistry([]),
+    );
+    expect(pickIntegration(detection, { userIntegration: "PP" })).toBe("pp");
+    expect(pickIntegration(detection)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. autoSelectLocation — per-integration branch outcomes
+//
+// id-pattern integrations use a real hass; discovery-backed integrations use a
+// hand-built detection object (locations Map) so the "first discovery key" and
+// lazy-getter branches are pinned without discovery internals.
+// ---------------------------------------------------------------------------
+
+describe("autoSelectLocation: id-pattern integrations", () => {
+  it("dwd -> smallest region_id from the entity-id suffix", () => {
+    const hass = createHassWithRegistry([
+      { entityId: "sensor.pollenflug_erle_50" },
+      { entityId: "sensor.pollenflug_birke_11" },
+    ]);
+    const detection = detectIntegrationStates(hass);
+    expect(autoSelectLocation("dwd", {}, hass, detection)).toEqual({
+      key: "region_id",
+      value: "11",
+    });
+  });
+
+  it("pp -> city slug from the first sensor that yields one", () => {
+    const hass = createHassWithRegistry([
+      { entityId: "sensor.pollen_stockholm_bjork" },
+    ]);
+    const detection = detectIntegrationStates(hass);
+    expect(autoSelectLocation("pp", {}, hass, detection)).toEqual({
+      key: "city",
+      value: "stockholm",
+    });
+  });
+
+  it("peu -> location_slug attribute of the first sensor", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.polleninformation_wien_birch",
+        attributes: { location_slug: "wien" },
+      },
+    ]);
+    const detection = detectIntegrationStates(hass);
+    expect(autoSelectLocation("peu", {}, hass, detection)).toEqual({
+      key: "location",
+      value: "wien",
+    });
+  });
+
+  it("kleenex -> location parsed from the sibling _date sensor", () => {
+    const hass = createHassWithRegistry([
+      { entityId: "sensor.kleenex_pollen_radar_amsterdam_trees" },
+      { entityId: "sensor.kleenex_pollen_radar_amsterdam_date" },
+    ]);
+    const detection = detectIntegrationStates(hass);
+    expect(autoSelectLocation("kleenex", {}, hass, detection)).toEqual({
+      key: "location",
+      value: "amsterdam",
+    });
+  });
+
+  it("atmo -> slug from the niveau_<allergen>_<slug> pattern", () => {
+    const hass = createHassWithRegistry([
+      { entityId: "sensor.niveau_bouleau_montpellier" },
+    ]);
+    const detection = detectIntegrationStates(hass);
+    expect(autoSelectLocation("atmo", {}, hass, detection)).toEqual({
+      key: "location",
+      value: "montpellier",
+    });
+  });
+
+  it("returns null when the integration has no detected states", () => {
+    const hass = createHassWithRegistry([]);
+    const detection = detectIntegrationStates(hass);
+    for (const id of INTEGRATION_PRIORITY) {
+      expect(autoSelectLocation(id, {}, hass, detection)).toBeNull();
+    }
+  });
+});
+
+describe("autoSelectLocation: discovery-backed integrations", () => {
+  // Minimal detection stub: states present + a discovery locations Map whose
+  // first key is what the branch returns.
+  const withDiscovery = (integration: string, discovery: any, lazy = false) => {
+    const detection: any = {
+      states: { [integration]: ["sensor.x"] },
+      stateIds: ["sensor.x"],
+      discovery: {},
+    };
+    if (lazy) {
+      const getterName = {
+        gpl: "getGplDiscovery",
+        msw: "getMswDiscovery",
+        irmkmi: "getIrmkmiDiscovery",
+      }[integration]!;
+      detection[getterName] = () => discovery;
+    } else {
+      detection.discovery[integration] = discovery;
+    }
+    return detection;
+  };
+
+  const disc = (firstKey: string) => ({
+    locations: new Map([[firstKey, { entities: new Map() }]]),
+  });
+
+  it("silam -> first discovery location key (eager discovery)", () => {
+    const detection = withDiscovery("silam", disc("entry_s"));
+    expect(autoSelectLocation("silam", {}, {}, detection)).toEqual({
+      key: "location",
+      value: "entry_s",
+    });
+  });
+
+  it("gp -> first discovery location key (eager discovery)", () => {
+    const detection = withDiscovery("gp", disc("entry_gp"));
+    expect(autoSelectLocation("gp", {}, {}, detection)).toEqual({
+      key: "location",
+      value: "entry_gp",
+    });
+  });
+
+  it("gpl -> first discovery location key (lazy getter)", () => {
+    const detection = withDiscovery("gpl", disc("entry_gpl"), true);
+    expect(autoSelectLocation("gpl", {}, {}, detection)).toEqual({
+      key: "location",
+      value: "entry_gpl",
+    });
+  });
+
+  it("msw -> first discovery location key (lazy getter)", () => {
+    const detection = withDiscovery("msw", disc("entry_msw"), true);
+    expect(autoSelectLocation("msw", {}, {}, detection)).toEqual({
+      key: "location",
+      value: "entry_msw",
+    });
+  });
+
+  it("irmkmi -> first discovery location key (lazy getter)", () => {
+    const detection = withDiscovery("irmkmi", disc("entry_irm"), true);
+    expect(autoSelectLocation("irmkmi", {}, {}, detection)).toEqual({
+      key: "location",
+      value: "entry_irm",
+    });
+  });
+
+  it("silam -> regex fallback when discovery has no locations", () => {
+    const detection: any = {
+      states: { silam: ["sensor.silam_pollen_helsinki_birch"] },
+      discovery: { silam: { locations: new Map() } },
+    };
+    expect(
+      autoSelectLocation("silam", {}, {}, detection),
+    ).toEqual({ key: "location", value: "helsinki" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. normalizeIntegration
+// ---------------------------------------------------------------------------
+
+describe("normalizeIntegration", () => {
+  it("trims and lowercases strings", () => {
+    expect(normalizeIntegration("  PP  ")).toBe("pp");
+    expect(normalizeIntegration("Dwd")).toBe("dwd");
+  });
+
+  it("passes non-strings through unchanged", () => {
+    expect(normalizeIntegration(undefined)).toBeUndefined();
+    expect(normalizeIntegration(null)).toBeNull();
+    const obj = {};
+    expect(normalizeIntegration(obj)).toBe(obj);
+  });
+});

--- a/test/utils/autodetect-characterization.test.ts
+++ b/test/utils/autodetect-characterization.test.ts
@@ -277,7 +277,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
 
   it("silam -> first discovery location key (eager discovery)", () => {
     const detection = withDiscovery("silam", disc("entry_s"));
-    expect(autoSelectLocation("silam", {}, {}, detection)).toEqual({
+    expect(autoSelectLocation("silam", {}, {} as any, detection)).toEqual({
       key: "location",
       value: "entry_s",
     });
@@ -285,7 +285,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
 
   it("gp -> first discovery location key (eager discovery)", () => {
     const detection = withDiscovery("gp", disc("entry_gp"));
-    expect(autoSelectLocation("gp", {}, {}, detection)).toEqual({
+    expect(autoSelectLocation("gp", {}, {} as any, detection)).toEqual({
       key: "location",
       value: "entry_gp",
     });
@@ -293,7 +293,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
 
   it("gpl -> first discovery location key (lazy getter)", () => {
     const detection = withDiscovery("gpl", disc("entry_gpl"), true);
-    expect(autoSelectLocation("gpl", {}, {}, detection)).toEqual({
+    expect(autoSelectLocation("gpl", {}, {} as any, detection)).toEqual({
       key: "location",
       value: "entry_gpl",
     });
@@ -301,7 +301,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
 
   it("msw -> first discovery location key (lazy getter)", () => {
     const detection = withDiscovery("msw", disc("entry_msw"), true);
-    expect(autoSelectLocation("msw", {}, {}, detection)).toEqual({
+    expect(autoSelectLocation("msw", {}, {} as any, detection)).toEqual({
       key: "location",
       value: "entry_msw",
     });
@@ -309,7 +309,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
 
   it("irmkmi -> first discovery location key (lazy getter)", () => {
     const detection = withDiscovery("irmkmi", disc("entry_irm"), true);
-    expect(autoSelectLocation("irmkmi", {}, {}, detection)).toEqual({
+    expect(autoSelectLocation("irmkmi", {}, {} as any, detection)).toEqual({
       key: "location",
       value: "entry_irm",
     });
@@ -321,7 +321,7 @@ describe("autoSelectLocation: discovery-backed integrations", () => {
       discovery: { silam: { locations: new Map() } },
     };
     expect(
-      autoSelectLocation("silam", {}, {}, detection),
+      autoSelectLocation("silam", {}, {} as any, detection),
     ).toEqual({ key: "location", value: "helsinki" });
   });
 });

--- a/test/utils/suggest.test.ts
+++ b/test/utils/suggest.test.ts
@@ -362,13 +362,13 @@ describe("deriveLocationForEntity", () => {
 
   it("PP: city from the entity id", () => {
     expect(
-      deriveLocationForEntity("pp", "sensor.pollen_goteborg_bjork", {}, {} as any),
+      deriveLocationForEntity("pp", "sensor.pollen_goteborg_bjork", {} as any, {} as any),
     ).toEqual({ key: "city", value: "goteborg" });
   });
 
   it("DWD: region_id from the entity id", () => {
     expect(
-      deriveLocationForEntity("dwd", "sensor.pollenflug_erle_91", {}, {} as any),
+      deriveLocationForEntity("dwd", "sensor.pollenflug_erle_91", {} as any, {} as any),
     ).toEqual({ key: "region_id", value: "91" });
   });
 
@@ -379,7 +379,7 @@ describe("deriveLocationForEntity", () => {
       },
     };
     expect(
-      deriveLocationForEntity("peu", "sensor.polleninformation_x", hass, {} as any),
+      deriveLocationForEntity("peu", "sensor.polleninformation_x", hass as any, {} as any),
     ).toEqual({ key: "location", value: "wien" });
   });
 
@@ -389,7 +389,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "peu",
         "sensor.polleninformation_wien_birch",
-        hass,
+        hass as any,
         {} as any,
       ),
     ).toEqual({ key: "location", value: "wien" });
@@ -412,7 +412,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "atmo",
         "sensor.niveau_bouleau_paris",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "paris" });
@@ -424,7 +424,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "atmo",
         "sensor.niveau_bouleau_paris",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "paris" });
@@ -439,7 +439,7 @@ describe("deriveLocationForEntity", () => {
       },
     };
     expect(
-      deriveLocationForEntity("atmo", "sensor.pm25_paris", {}, detection),
+      deriveLocationForEntity("atmo", "sensor.pm25_paris", {} as any, detection),
     ).toEqual({ key: "location", value: "entry_atmo" });
   });
 
@@ -452,7 +452,7 @@ describe("deriveLocationForEntity", () => {
       },
     };
     expect(
-      deriveLocationForEntity("atmo", "sensor.pm25_paris", {}, detection),
+      deriveLocationForEntity("atmo", "sensor.pm25_paris", {} as any, detection),
     ).toBeNull();
   });
 
@@ -471,7 +471,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "silam",
         "weather.silam_pollen_oslo",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "entry_s" });
@@ -483,7 +483,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "silam",
         "sensor.silam_pollen_helsinki_birch",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "helsinki" });
@@ -500,7 +500,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "kleenex",
         "sensor.kleenex_pollen_radar_noord_holland_trees",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "noord_holland" });
@@ -515,7 +515,7 @@ describe("deriveLocationForEntity", () => {
         deriveLocationForEntity(
           "kleenex",
           `sensor.kleenex_pollen_radar_amsterdam_${suffix}`,
-          {},
+          {} as any,
           detection,
         ),
       ).toBeNull();
@@ -525,7 +525,7 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "kleenex",
         "sensor.kleenex_pollen_radar_amsterdam_trees",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "amsterdam" });
@@ -540,7 +540,7 @@ describe("deriveLocationForEntity", () => {
       },
     };
     expect(
-      deriveLocationForEntity("gp", "sensor.gp_grass", {}, detection),
+      deriveLocationForEntity("gp", "sensor.gp_grass", {} as any, detection),
     ).toEqual({ key: "location", value: "entry_gp" });
   });
 
@@ -552,7 +552,7 @@ describe("deriveLocationForEntity", () => {
         ]),
     };
     expect(
-      deriveLocationForEntity("gpl", "sensor.gpl_tree", {}, detection),
+      deriveLocationForEntity("gpl", "sensor.gpl_tree", {} as any, detection),
     ).toEqual({ key: "location", value: "entry_gpl" });
   });
 
@@ -574,13 +574,13 @@ describe("deriveLocationForEntity", () => {
       deriveLocationForEntity(
         "msw",
         "sensor.bern_pollen_birch_level_at_3000",
-        {},
+        {} as any,
         detection,
       ),
     ).toEqual({ key: "location", value: "entry_msw" });
   });
 
   it("returns null for an unknown integration", () => {
-    expect(deriveLocationForEntity("nope", "sensor.x", {}, {} as any)).toBeNull();
+    expect(deriveLocationForEntity("nope", "sensor.x", {} as any, {} as any)).toBeNull();
   });
 });


### PR DESCRIPTION
Companion PR to the v4.0.0 migration (#259), broken out of the sensor-contract PR: the autodetect layer moves onto a per-adapter descriptor surface, and the last JavaScript file leaves `src/`.

## What

- **`AdapterAutodetect` descriptor** exported by every adapter: `priority`, `detectStates` (owning the whole per-integration detection strategy — regex, platform scan, discovery, attribution, the PP-vs-PLU alias disambiguation), optional `discover`/`extractLocationSlug`, and PLU's allergen-slug set exposed so PP never imports from PLU. The design deviates from the original `matchStateId` sketch deliberately: detection is not a per-id predicate for discovery/platform-based integrations.
- **`autodetect.ts`** now imports only types and the registry — every adapter-internal import (alias maps, entity-id regexes, attribution strings, slug extractors) moved home to its adapter. The `INTEGRATION_PRIORITY` array is derived from descriptor priorities (order verified identical).
- **Characterization tests first** (21 new, committed before any refactor): a full states-partition fixture pinning all 11 matchers simultaneously, per-integration auto-select outcomes, and picker semantics — the refactor's contract.
- The `detection as any` casts in the card and both editors are replaced by a real `DetectionResult` type.
- **Considered decision, documented rather than deferred**: the editors' remaining direct adapter imports (allergen lists, stub configs, discover functions for integration-specific UI) stay — that is legitimate public adapter API with no descriptor home; the layering violation this PR exists to fix was autodetect's dependence on adapter internals, which is now fully resolved.

## Verification

- Characterization tests identical through every refactor step; golden snapshots zero diff; 1363/1363 tests green; `tsc --noEmit` clean; eslint 0 errors; build within budget.
- Live check on the HA test instance: the autodetect QA view (a card with no integration specified) detects and renders correctly on the descriptor-driven path; all 17 QA cards render, zero console/page errors.
