### PR TITLE
(tap-action) Configured tap_action takes precedence and navigate actually navigates

### DIFF
--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -110,7 +110,6 @@ export const stubConfigATMO: AdapterStubConfig = {
   pollution_block_position: "bottom",
   show_block_separator: false,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: {

--- a/src/adapters/dwd.ts
+++ b/src/adapters/dwd.ts
@@ -68,7 +68,6 @@ export const stubConfigDWD: AdapterStubConfig = {
   sort: "value_descending",
   allergy_risk_top: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: {

--- a/src/adapters/gp/constants.ts
+++ b/src/adapters/gp/constants.ts
@@ -549,7 +549,6 @@ export const stubConfigGP: AdapterStubConfig = {
   sort: "value_descending",
   sort_category_allergens_first: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/gpl/constants.ts
+++ b/src/adapters/gpl/constants.ts
@@ -52,7 +52,6 @@ export const stubConfigGPL: AdapterStubConfig = {
   show_summary_top_types: true,
   show_summary_plants_in_season: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -144,7 +144,6 @@ export const stubConfigIRMKMI: AdapterStubConfig = {
   pollen_threshold: 1,
   sort: "value_descending",
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   debug: false,

--- a/src/adapters/kleenex/constants.ts
+++ b/src/adapters/kleenex/constants.ts
@@ -131,7 +131,6 @@ export const stubConfigKleenex: AdapterStubConfig = {
   sort_category_allergens_first: true,
   allergy_risk_top: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -119,7 +119,6 @@ export const stubConfigMSW: AdapterStubConfig = {
   pollen_threshold: 1,
   sort: "value_descending",
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   debug: false,

--- a/src/adapters/peu.ts
+++ b/src/adapters/peu.ts
@@ -76,7 +76,6 @@ export const stubConfigPEU: AdapterStubConfig = {
   sort: "value_descending",
   allergy_risk_top: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -180,7 +180,6 @@ export const stubConfigPLU: AdapterStubConfig = {
   sort: "value_descending",
   allergy_risk_top: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/pp.ts
+++ b/src/adapters/pp.ts
@@ -66,7 +66,6 @@ export const stubConfigPP: AdapterStubConfig = {
   sort: "value_descending",
   allergy_risk_top: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/adapters/silam.ts
+++ b/src/adapters/silam.ts
@@ -99,7 +99,6 @@ export const stubConfigSILAM: AdapterStubConfig = {
   show_summary_row: false,
   show_summary_separator: true,
   allergens_abbreviated: false,
-  link_to_sensors: true,
   date_locale: undefined,
   title: undefined,
   phrases: { full: {}, short: {}, levels: [], days: {}, no_information: "" },

--- a/src/pollenprognos-badge.ts
+++ b/src/pollenprognos-badge.ts
@@ -264,14 +264,25 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       config.badge_label_position === "below" ? "below" : "right";
     // tap_action: optional element-level action (more-info | navigate |
     // call-service), shared with the card. Keep only a plain object so a
-    // mis-typed YAML scalar can't reach the runtime handler. link_to_sensors
-    // passes through ...config unchanged (boolean, read default-on at runtime).
+    // mis-typed YAML scalar can't reach the runtime handler.
     const tapAction =
       config.tap_action &&
       typeof config.tap_action === "object" &&
       !Array.isArray(config.tap_action)
         ? config.tap_action
         : undefined;
+    // link_to_sensors has no stub default: absent means "default on", explicit
+    // true is a distinct opt-in that keeps per-icon more-info alongside a
+    // tap_action (see iconMoreInfoEnabled / #279). Coerce only the "true"/"false"
+    // YAML strings (mirroring the card's config boundary) so a hand-written
+    // link_to_sensors: "false" is honoured; an absent key stays undefined and
+    // reads default-on at runtime.
+    const linkToSensors =
+      config.link_to_sensors === "true"
+        ? true
+        : config.link_to_sensors === "false"
+          ? false
+          : config.link_to_sensors;
 
     // badge_visual drives two engine flags so the shared LevelCircleMixin
     // renders the right centre content: icon_in_ring shows the allergen icon;
@@ -326,6 +337,9 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
       // Type-guarded above; override the raw spread so a bad scalar becomes
       // undefined and the runtime click guard simply skips it.
       tap_action: tapAction,
+      // Coerced above; overrides the raw spread so a "false" string is a real
+      // boolean at the iconMoreInfoEnabled call site.
+      link_to_sensors: linkToSensors,
       ...(badgeSingleAllergen !== undefined
         ? { badge_single_allergen: badgeSingleAllergen }
         : {}),

--- a/src/pollenprognos-badge.ts
+++ b/src/pollenprognos-badge.ts
@@ -37,6 +37,7 @@ import {
 import {
   LevelCircleMixin,
   resolveTapActionType,
+  iconMoreInfoEnabled,
 } from "./rendering/level-circle-mixin.js";
 import { ringIconStyles } from "./rendering/ring-icon-styles.js";
 import { deepEqual } from "./utils/confcompare.js";
@@ -583,9 +584,11 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
 
     // Badge-level tap_action (shared with the card). Bind only when the action
     // resolves to a supported type (so an inert/unknown action doesn't make the
-    // badge clickable-but-dead); per-icon link_to_sensors clicks stopPropagation,
-    // so the two coexist without double-firing, exactly like the card. Handler
-    // and predicate live in LevelCircleMixin.
+    // badge clickable-but-dead). A configured tap_action takes precedence over
+    // per-icon more-info: iconMoreInfoEnabled suppresses the ring/icon click
+    // (which would otherwise stopPropagation and shadow the tap_action) unless
+    // link_to_sensors is explicitly true (#279). Handler and predicate live in
+    // LevelCircleMixin.
     const hasTap = resolveTapActionType(this.config?.tap_action) !== null;
 
     return html`
@@ -614,7 +617,8 @@ class PollenPrognosBadge extends LevelCircleMixin(LitElement) {
           const displayLevel =
             rawNum != null && (rawNum as number) >= 0 ? rawNum : ringLevel;
           const clickable =
-            this.config.link_to_sensors !== false && !!sensor.entity_id;
+            iconMoreInfoEnabled(this.config.link_to_sensors, hasTap) &&
+            !!sensor.entity_id;
 
           const visual = this._renderBadgeVisual(visualMode, sensor, {
             ringConfig,

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -52,6 +52,7 @@ import silamAllergenMap from "./adapters/silam_allergen_map.json";
 import {
   LevelCircleMixin,
   resolveTapActionType,
+  iconMoreInfoEnabled,
 } from "./rendering/level-circle-mixin.js";
 import { ringIconStyles } from "./rendering/ring-icon-styles.js";
 import type { HomeAssistant, UnsubscribeFunc } from "./types/home-assistant.js";
@@ -1451,6 +1452,9 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
       Number(this.config?.icon_in_ring_size_ratio) ||
       LEVELS_DEFAULTS.icon_in_ring_size_ratio;
     const iconSize = Number(this.config?.icon_size) || 48;
+    // A configured element-level tap_action takes precedence over per-icon
+    // more-info unless link_to_sensors is explicitly true (#279).
+    const hasTap = resolveTapActionType(this.tapAction) !== null;
 
     return html`
       ${this.header ? html`<div class="card-header">${this.header}</div>` : ""}
@@ -1525,9 +1529,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
               normalizedLevel,
             );
             const clickable =
-              this.config.link_to_sensors !== false && !!sensor.entity_id;
+              iconMoreInfoEnabled(this.config.link_to_sensors, hasTap) &&
+              !!sensor.entity_id;
             const onClickEntity = (e: Event) => {
-              if (this.config.link_to_sensors !== false && sensor.entity_id) {
+              if (clickable) {
                 e.stopPropagation();
                 this._openEntity(sensor.entity_id);
               }
@@ -1661,6 +1666,13 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     const ringIconRatio =
       Number(this.config?.icon_in_ring_size_ratio) ||
       LEVELS_DEFAULTS.icon_in_ring_size_ratio;
+    // A configured element-level tap_action takes precedence over per-icon
+    // more-info unless link_to_sensors is explicitly true (#279).
+    const hasTap = resolveTapActionType(this.tapAction) !== null;
+    const iconMoreInfo = iconMoreInfoEnabled(
+      this.config?.link_to_sensors,
+      hasTap,
+    );
 
     // Degenerate config: no day columns at all (e.g. every sensor
     // stale plus show_empty_days=false). The forecast table can't
@@ -1818,14 +1830,9 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                       this._getSvgKey(sensor.allergenReplaced),
                       normalLevel,
                       {
-                        clickable:
-                          this.config.link_to_sensors !== false &&
-                          !!sensor.entity_id,
+                        clickable: iconMoreInfo && !!sensor.entity_id,
                         onClick: (e: Event) => {
-                          if (
-                            this.config.link_to_sensors !== false &&
-                            sensor.entity_id
-                          ) {
+                          if (iconMoreInfo && sensor.entity_id) {
                             e.stopPropagation();
                             this._openEntity(sensor.entity_id);
                           }
@@ -1881,7 +1888,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                   i,
                   displayVal,
                   sensor.entity_id,
-                  this.config.link_to_sensors !== false,
+                  iconMoreInfo,
                 );
                 return html`<td>${circle}</td>`;
               });

--- a/src/rendering/level-circle-mixin.ts
+++ b/src/rendering/level-circle-mixin.ts
@@ -653,8 +653,21 @@ export const LevelCircleMixin = <T extends Constructor<LitElement>>(Base: T) =>
             ta.navigation_path &&
             typeof window !== "undefined" &&
             window.history?.pushState
-          )
+          ) {
             window.history.pushState(null, "", ta.navigation_path);
+            // HA's router listens on window for "location-changed"; a bare
+            // pushState updates the URL but never re-resolves the panel. Mirror
+            // the frontend navigate() helper's fireEvent form: a plain Event
+            // (bubbles+composed) with a { replace } detail bag attached.
+            const ev = new Event("location-changed", {
+              bubbles: true,
+              composed: true,
+            });
+            (ev as unknown as { detail: { replace: boolean } }).detail = {
+              replace: false,
+            };
+            window.dispatchEvent(ev);
+          }
           break;
         case "call-service": {
           // Accept the card's service/service_data and HA's modern

--- a/src/rendering/level-circle-mixin.ts
+++ b/src/rendering/level-circle-mixin.ts
@@ -117,6 +117,27 @@ export function resolveTapActionType(tapAction: unknown): TapActionType | null {
 }
 
 /**
+ * Decide whether a per-icon click should open more-info, given the badge/card
+ * `link_to_sensors` setting and whether the element has an active tap_action.
+ *
+ * Without a tap_action, per-icon more-info is the default (on unless the user
+ * set `link_to_sensors: false`). With a tap_action configured, the whole
+ * element runs that action and per-icon more-info is suppressed UNLESS the user
+ * explicitly opted in with `link_to_sensors: true` -- otherwise the ring/icon
+ * click handler (stopPropagation + more-info) would shadow the configured
+ * tap_action, since the ring covers almost the whole element (#279).
+ *
+ * `linkToSensors` is boolean|undefined after the config boundary coerces string
+ * scalars, but typed `unknown` here to stay tolerant of a raw call.
+ */
+export function iconMoreInfoEnabled(
+  linkToSensors: unknown,
+  hasTapAction: boolean,
+): boolean {
+  return hasTapAction ? linkToSensors === true : linkToSensors !== false;
+}
+
+/**
  * LevelCircleMixin — adds the level-circle / icon-in-ring rendering engine
  * to any LitElement subclass.
  *

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -62,6 +62,14 @@ function buildFieldTypeSets(): {
 const { booleanFields: BOOLEAN_FIELDS, numberFields: NUMBER_FIELDS } =
   buildFieldTypeSets();
 
+// link_to_sensors is a boolean flag that deliberately has NO stub default: its
+// absence means "default on" and an explicit `true` is a distinct, meaningful
+// opt-in (it lets a configured tap_action be shadowed by per-icon more-info,
+// see iconMoreInfoEnabled / #279). Because no stub declares it, the cross-stub
+// union above can't discover its type, so register it here so a hand-written
+// `link_to_sensors: "false"` YAML string still coerces to a boolean.
+BOOLEAN_FIELDS.add("link_to_sensors");
+
 /**
  * Non-stub config keys that setConfig accepts in addition to the resolved
  * adapter stub's own keys. Kept identical to the list the card historically
@@ -78,6 +86,11 @@ export const CARD_EXTRA_FIELDS: readonly string[] = [
   "location",
   "region_id",
   "tap_action",
+  // No stub declares link_to_sensors any more (absence = default on, explicit
+  // true = opt in to per-icon more-info alongside a tap_action; see #279), so
+  // it must be listed here or setConfig's allowed-field filter would strip a
+  // user-set value.
+  "link_to_sensors",
   "debug",
   "show_version",
   "title",

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -167,6 +167,40 @@ describe("mergeCardConfig: filter asymmetry", () => {
   });
 });
 
+describe("link_to_sensors: no stub default, explicit opt-in (#279)", () => {
+  it("stays absent when the user does not set it (default-on state)", () => {
+    // No stub declares link_to_sensors, so a config that omits it must not gain
+    // it from the merge -- an absent key is the "default on" signal that lets a
+    // configured tap_action take precedence over per-icon more-info.
+    const cfg = normalizeCardConfig({ integration: "pp" }, stubConfigPP, {
+      integration: "pp",
+      filter: true,
+    });
+    expect(cfg).not.toHaveProperty("link_to_sensors");
+  });
+
+  it("keeps an explicit boolean and coerces the YAML string form", () => {
+    const asTrue = normalizeCardConfig(
+      { integration: "pp", link_to_sensors: true },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(asTrue.link_to_sensors).toBe(true);
+
+    const asString = normalizeCardConfig(
+      { integration: "pp", link_to_sensors: "false" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(asString.link_to_sensors).toBe(false);
+  });
+
+  it("is an accepted extra field (survives the allowed-field filter)", () => {
+    expect(CARD_EXTRA_FIELDS).toContain("link_to_sensors");
+    expect(cardAllowedFields(stubConfigPP)).toContain("link_to_sensors");
+  });
+});
+
 describe("cross-stub coercion union", () => {
   it("coerces a field the active stub omits but another stub declares boolean", () => {
     // show_summary_top_types is defined only in the GPL stub, not SILAM's, yet

--- a/test/card/setConfig.test.ts
+++ b/test/card/setConfig.test.ts
@@ -22,6 +22,7 @@ const HARDCODED_EXTRAS = [
   "location",
   "region_id",
   "tap_action",
+  "link_to_sensors",
   "debug",
   "show_version",
   "title",
@@ -298,7 +299,7 @@ describe("setConfig: hardcoded extras pass through", () => {
     expect(result.date_locale).toBe("sv-SE");
   });
 
-  it("all 15 hardcoded extras survive when provided", () => {
+  it("all hardcoded extras survive when provided", () => {
     const config = {
       integration: "pp",
       type: "custom:pollenprognos-card",
@@ -311,6 +312,7 @@ describe("setConfig: hardcoded extras pass through", () => {
       location: "test_location",
       region_id: "42",
       tap_action: { action: "navigate" },
+      link_to_sensors: false,
       debug: true,
       show_version: false,
       title: "My Pollen Card",
@@ -445,8 +447,22 @@ describe("setConfig: unknown integration falls back to PP stub", () => {
 
     // Verify a sample of PP-unique stub defaults
     expect(result.allergy_risk_top).toBe(true);
-    expect(result.link_to_sensors).toBe(true);
     expect(result.sort).toBe("value_descending");
+  });
+
+  it("link_to_sensors has no stub default (absent means default-on, #279)", () => {
+    // No adapter stub declares link_to_sensors: an absent key is the "default
+    // on" state, so an explicit true is distinguishable as an opt-in that keeps
+    // per-icon more-info alongside a configured tap_action.
+    const result = simulateSetConfig({ integration: "pp" });
+    expect(result).not.toHaveProperty("link_to_sensors");
+  });
+
+  it("keeps a user-set link_to_sensors through the allowed-field filter", () => {
+    const off = simulateSetConfig({ integration: "pp", link_to_sensors: false });
+    expect(off.link_to_sensors).toBe(false);
+    const on = simulateSetConfig({ integration: "pp", link_to_sensors: true });
+    expect(on.link_to_sensors).toBe(true);
   });
 
   it("unknown fields still get dropped even with PP fallback", () => {

--- a/test/rendering/handle-tap-action.test.ts
+++ b/test/rendering/handle-tap-action.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   LevelCircleMixin,
   resolveTapActionType,
+  iconMoreInfoEnabled,
 } from "../../src/rendering/level-circle-mixin.js";
 
 // The shared element-level tap_action handler lives in LevelCircleMixin so the
@@ -230,6 +231,24 @@ describe("LevelCircleMixin._handleTapAction", () => {
         "/lovelace/1",
       );
     });
+  });
+});
+
+describe("iconMoreInfoEnabled", () => {
+  // Without a tap_action, per-icon more-info is the default (on unless
+  // link_to_sensors is explicitly false).
+  it("defaults on with no tap_action", () => {
+    expect(iconMoreInfoEnabled(undefined, false)).toBe(true);
+    expect(iconMoreInfoEnabled(true, false)).toBe(true);
+    expect(iconMoreInfoEnabled(false, false)).toBe(false);
+  });
+
+  // With a tap_action, the element runs it and per-icon more-info is suppressed
+  // unless the user explicitly opted in with link_to_sensors: true (#279).
+  it("yields to a configured tap_action unless explicitly opted in", () => {
+    expect(iconMoreInfoEnabled(undefined, true)).toBe(false);
+    expect(iconMoreInfoEnabled(false, true)).toBe(false);
+    expect(iconMoreInfoEnabled(true, true)).toBe(true);
   });
 });
 

--- a/test/rendering/handle-tap-action.test.ts
+++ b/test/rendering/handle-tap-action.test.ts
@@ -92,7 +92,10 @@ describe("LevelCircleMixin._handleTapAction", () => {
 
   it("honours the Lovelace-standard `action` key (navigate)", () => {
     const prev = globalThis.window;
-    globalThis.window = { history: { pushState: vi.fn() } } as any;
+    globalThis.window = {
+      history: { pushState: vi.fn() },
+      dispatchEvent: vi.fn(),
+    } as any;
     el.tapAction = { action: "navigate", navigation_path: "/lovelace/2" };
     el._handleTapAction(makeEvent());
     expect(window.history.pushState).toHaveBeenCalledWith(null, "", "/lovelace/2");
@@ -199,7 +202,10 @@ describe("LevelCircleMixin._handleTapAction", () => {
     let prevWindow: any;
     beforeEach(() => {
       prevWindow = globalThis.window;
-      globalThis.window = { history: { pushState: vi.fn() } } as any;
+      globalThis.window = {
+        history: { pushState: vi.fn() },
+        dispatchEvent: vi.fn(),
+      } as any;
     });
     afterEach(() => {
       globalThis.window = prevWindow;
@@ -215,10 +221,27 @@ describe("LevelCircleMixin._handleTapAction", () => {
       );
     });
 
+    it("dispatches location-changed so HA's router re-resolves the panel", () => {
+      // A bare pushState updates the URL but never re-renders the panel; HA's
+      // router listens on window for "location-changed". Mirror the frontend
+      // navigate() helper's fireEvent form (#279).
+      el.tapAction = { type: "navigate", navigation_path: "/lovelace/3" };
+      el._handleTapAction(makeEvent());
+      expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+      const ev = (window.dispatchEvent as any).mock.calls[0][0];
+      expect(ev.type).toBe("location-changed");
+      expect(ev.bubbles).toBe(true);
+      expect(ev.composed).toBe(true);
+      expect(ev.detail).toEqual({ replace: false });
+      // Fires after the URL is updated.
+      expect(window.history.pushState).toHaveBeenCalled();
+    });
+
     it("does nothing without a navigation path", () => {
       el.tapAction = { type: "navigate" };
       el._handleTapAction(makeEvent());
       expect(window.history.pushState).not.toHaveBeenCalled();
+      expect(window.dispatchEvent).not.toHaveBeenCalled();
     });
 
     it("navigates even without hass (navigate needs only the History API)", () => {
@@ -230,6 +253,7 @@ describe("LevelCircleMixin._handleTapAction", () => {
         "",
         "/lovelace/1",
       );
+      expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #279: a badge (or card) with a configured `tap_action` always opened the entity's more-info dialog instead of running the action.

## Root causes (two)

1. **Precedence.** The level ring / allergen icon covers almost the whole element, and its click handler stopped propagation and opened more-info (the default-on `link_to_sensors` behaviour) before the element-level `tap_action` handler could ever fire. On top of that, every adapter stub set `link_to_sensors: true` explicitly, so after the stub merge an explicitly-configured opt-in was indistinguishable from the default — which is why the fix also removes the key from the stubs (the on-by-default lives in code; the editor toggle and reset behave identically).
2. **Navigation.** The navigate branch only called `history.pushState`; Home Assistant's router needs the `location-changed` event (mirrored exactly from HA frontend's own `navigate()`/`fireEvent` implementation: bubbles+composed `Event` with `detail = { replace: false }` on `window`). The URL changed but the view never loaded.

## Semantics (documented in code and changelog)

- No `tap_action`: icon/ring opens more-info — unchanged default.
- `tap_action` configured: the whole element runs the action; per-icon more-info only with an explicit `link_to_sensors: true`.
- `link_to_sensors: false`: never per-icon more-info — unchanged.

Behaviour note for existing configs: a config that set a `tap_action` and relied on the implicit per-icon more-info now runs the `tap_action`; add `link_to_sensors: true` to keep more-info on the icons.

## Implementation

New pure `iconMoreInfoEnabled(linkToSensors, hasTapAction)` predicate co-located with `resolveTapActionType`, applied at every inner more-info site in badge and card; `link_to_sensors` removed from all 11 stubs, added to the setConfig allow-list and to the boolean coercion table (string-YAML `"false"` still coerces; the badge gains matching tri-state coercion in its own config builder).

## Verification

- 1371/1371 tests green (unit coverage for all six predicate combinations, the location-changed dispatch shape, and setConfig-level survival of absent/true/"false" values); typecheck/lint clean; goldens zero diff.
- Empirical pass on the HA test instance with the reporter's exact YAML (atmo, `badge_content: aggregate`, `badge_visual: ring_value`, `tap_action: {type: navigate, ...}`): clicking the ring navigates to the configured path with no more-info dialog. Control cases verified unchanged: no-tap_action badge still opens more-info; `link_to_sensors: true` alongside a tap_action still opens more-info on the ring; the card case navigates likewise. First iteration of the fix was caught as a runtime no-op by this same pass (the stub-default issue) and corrected.
