### PR TITLE
(editor) Fix SILAM auto-select reading a never-assigned property

### DIFF
--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -83,12 +83,6 @@ class PollenPrognosCardEditor extends PollenEditorBase {
   // subclass's own members are.
   declare installedCities: string[];
   declare installedRegionIds: string[];
-  // NOTE: `installedLocations` is read once in setConfig's SILAM auto-select
-  // branch but is never assigned anywhere (a latent bug preserved verbatim in
-  // this conversion). Declared optional so the read type-checks; the access
-  // site keeps the original throw-on-undefined behaviour via a non-null
-  // assertion.
-  declare installedLocations?: InstalledLocation[];
   declare _integrationExplicit: boolean;
   declare _thresholdExplicit: boolean;
   declare _prevIntegration?: string;
@@ -502,6 +496,15 @@ class PollenPrognosCardEditor extends PollenEditorBase {
             (id) => [id, `${id} — ${DWD_REGIONS[id] || id}`] as InstalledLocation,
           );
         }
+
+        // SILAM: device-based discovery so the auto-select below (and the
+        // dropdown) has data within this same setConfig call, mirroring PP/DWD.
+        if (integration === "silam") {
+          const silamDiscovery = discoverSilamSensors(this._hass, false);
+          if (silamDiscovery.locations.size > 0) {
+            this.installedSilamLocations = discoveryToLocations(silamDiscovery);
+          }
+        }
       }
       // 17. Auto-välj city/region om inte explicit
       if (!this._integrationExplicit) {
@@ -522,11 +525,9 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         if (
           integration === "silam" &&
           !this._userConfig.location &&
-          this.installedLocations!.length
+          this.installedSilamLocations.length
         ) {
-          // installedLocations is declared [string, string][] but the SILAM
-          // branch stores the location value; preserve the runtime assignment.
-          this._config.location = this.installedLocations![0] as unknown as string;
+          this._config.location = this.installedSilamLocations[0][0];
         }
       }
 
@@ -592,13 +593,6 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         this.installedIrmkmiLocations = discoveryToLocations(id);
       }
 
-      // SILAM discovery: run here too for same reason as GPL above
-      if (this._config.integration === "silam" && this._hass) {
-        const sd = discoverSilamSensors(this._hass, false);
-        if (sd.locations.size > 0) {
-          this.installedSilamLocations = discoveryToLocations(sd);
-        }
-      }
     } catch (e) {
       console.error("pollenprognos-card-editor: Fel i setConfig:", e, config);
       throw e;

--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -499,6 +499,11 @@ class PollenPrognosCardEditor extends PollenEditorBase {
 
         // SILAM: device-based discovery so the auto-select below (and the
         // dropdown) has data within this same setConfig call, mirroring PP/DWD.
+        // Deliberately NO else-clear on empty discovery: `set hass` owns the
+        // regex fallback for SILAM installs whose devices lack registry
+        // metadata, and clearing here would clobber that list. `set hass`
+        // always reassigns (fallback or empty) on the next hass tick, so a
+        // stale list cannot outlive one update cycle.
         if (integration === "silam") {
           const silamDiscovery = discoverSilamSensors(this._hass, false);
           if (silamDiscovery.locations.size > 0) {

--- a/test/card/editor-silam-autoselect.test.ts
+++ b/test/card/editor-silam-autoselect.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createHass } from "../helpers.js";
+
+// The editor is a LitElement and cannot be imported in the bare node test
+// environment (see test/card/autodetect.test.ts). Install a minimal DOM shim
+// so lit-html/reactive-element load and the element can be constructed. We
+// never render the element here; we only exercise setConfig's data logic.
+class FakeNode {
+  childNodes: unknown[] = [];
+  appendChild() {}
+}
+class FakeElement extends FakeNode {
+  content: unknown = { firstChild: null, cloneNode: () => new FakeElement() };
+  attachShadow() {
+    return new FakeElement();
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {
+    return true;
+  }
+  setAttribute() {}
+  getAttribute() {
+    return null;
+  }
+  remove() {}
+}
+
+function installDomShim() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.Document = class {};
+  g.HTMLElement = FakeElement;
+  g.ShadowRoot = class {};
+  g.CSSStyleSheet = class {
+    replaceSync() {}
+    replace() {}
+  };
+  const registry = new Map<string, unknown>();
+  g.customElements = {
+    define(name: string, ctor: unknown) {
+      registry.set(name, ctor);
+    },
+    get(name: string) {
+      return registry.get(name);
+    },
+  };
+  g.window = globalThis;
+  g.document = {
+    createElement: (t: string) =>
+      t === "template" ? new FakeElement() : new FakeElement(),
+    createElementNS: () => new FakeElement(),
+    createComment: () => new FakeNode(),
+    createTextNode: () => new FakeNode(),
+    createTreeWalker: () => ({ nextNode: () => null, currentNode: null }),
+    head: new FakeElement(),
+    adoptedStyleSheets: [],
+  };
+}
+
+// Build a hass fixture exposing one discoverable SILAM location (Stockholm),
+// mirroring the device-registry shape used in test/adapters/silam.test.ts.
+function createSilamHass() {
+  const weatherEntityId = "weather.silam_pollen_stockholm_forecast";
+  const sensorId = "sensor.silam_pollen_stockholm_birch";
+  const deviceId = "dev_sthlm";
+  const states = {
+    [weatherEntityId]: { state: "sunny", attributes: {} },
+    [sensorId]: { state: "30", attributes: {} },
+  };
+  const entities = {
+    [weatherEntityId]: {
+      entity_id: weatherEntityId,
+      platform: "silam_pollen",
+      device_id: deviceId,
+      entity_category: null,
+      translation_key: "forecast",
+    },
+    [sensorId]: {
+      entity_id: sensorId,
+      platform: "silam_pollen",
+      device_id: deviceId,
+      entity_category: null,
+      translation_key: "birch",
+    },
+  };
+  const devices = {
+    [deviceId]: { name: "Stockholm", config_entries: ["entry_sthlm"] },
+  };
+  return createHass(states, { entities, devices, language: "en" });
+}
+
+let EditorCtor: new () => {
+  _hass: unknown;
+  setConfig: (config: Record<string, unknown>) => void;
+  _config: Record<string, unknown>;
+};
+
+beforeAll(async () => {
+  installDomShim();
+  await import("../../src/pollenprognos-editor.js");
+  EditorCtor = (
+    globalThis as unknown as {
+      customElements: { get: (n: string) => new () => never };
+    }
+  ).customElements.get("pollenprognos-card-editor");
+});
+
+describe("editor SILAM auto-select (issue #302)", () => {
+  // The buggy branch only runs when the integration is auto-detected (not set
+  // explicitly by the user), so these configs omit `integration` and let the
+  // SILAM sensors in hass drive the detection.
+
+  // Regression: setConfig's SILAM branch previously read `installedLocations`,
+  // a property that is never assigned, throwing a TypeError at runtime whenever
+  // SILAM was auto-detected without an explicit location.
+  it("auto-selects the first discovered SILAM location when none is set", () => {
+    const editor = new EditorCtor();
+    editor._hass = createSilamHass();
+
+    expect(() =>
+      editor.setConfig({
+        type: "custom:pollenprognos-card",
+      }),
+    ).not.toThrow();
+
+    expect(editor._config.integration).toBe("silam");
+    // Discovery keys the location by config_entry_id ("entry_sthlm").
+    expect(editor._config.location).toBe("entry_sthlm");
+  });
+
+  it("keeps an explicitly configured SILAM location instead of auto-selecting", () => {
+    const editor = new EditorCtor();
+    editor._hass = createSilamHass();
+
+    editor.setConfig({
+      type: "custom:pollenprognos-card",
+      location: "entry_sthlm",
+    });
+
+    expect(editor._config.integration).toBe("silam");
+    expect(editor._config.location).toBe("entry_sthlm");
+  });
+});

--- a/test/card/editor-silam-autoselect.test.ts
+++ b/test/card/editor-silam-autoselect.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { createHass } from "../helpers.js";
 
 // The editor is a LitElement and cannot be imported in the bare node test
-// environment (see test/card/autodetect.test.ts). Install a minimal DOM shim
-// so lit-html/reactive-element load and the element can be constructed. We
+// environment, so this file installs a minimal DOM shim (a new pattern; the
+// other card tests import pure modules and need no DOM) so that
+// lit-html/reactive-element load and the element can be constructed. Vitest's
+// default per-file isolation keeps the shimmed globals out of other files. We
 // never render the element here; we only exercise setConfig's data logic.
 class FakeNode {
   childNodes: unknown[] = [];


### PR DESCRIPTION
Fixes #302 (milestone v4.0.1): the card editor's SILAM auto-select read `installedLocations`, a property never assigned anywhere, throwing `TypeError: Cannot read properties of undefined (reading 'length')`.

## Root cause

The setConfig auto-select branch was a broken duplicate of the working logic in `set hass` (which correctly reads `installedSilamLocations[0][0]`): wrong property name AND wrong indexing (`[0]` instead of `[0][0]` in the JS ancestor). The branch only runs when the integration was auto-detected rather than set explicitly, which is why it stayed dormant: an explicit `integration: silam` never enters it. Present since at least v3.4.0.

## Fix

The branch now reads the same `installedSilamLocations` list as `set hass`, and SILAM device discovery is added to the setConfig discovery block (mirroring how PP and DWD are discovered-then-selected within the same call), so the list is fresh before the selection. The now-redundant late SILAM discovery block and the dead `installedLocations` declaration are removed.

## Verification

- New `test/card/editor-silam-autoselect.test.ts` instantiates the real editor element (minimal DOM shim, no new dependency): auto-detected SILAM with no location now selects the first discovered location; an explicit location is preserved. Verified in both directions — with the pre-fix editor the test throws the exact reported TypeError; with the fix, 2/2 pass.
- Live check on the HA test instance with the fixed bundle: the real editor element, fed the instance's actual SILAM registry data, discovers all three configured locations (Trier, Karis, Stockholm) with no exception; full editor walkthrough (both editors, every section expanded) clean with zero console/page errors. The setConfig branch itself is lifecycle-order dependent (it requires the auto-detect path), so the deterministic branch coverage lives in the unit test; the live pass covers discovery and editor regression.
- 1376/1376 tests green; typecheck/lint clean; goldens zero diff; bundle within budget.
