### PR TITLE
(ci) Move nightly HACS validation off the midnight rate-limit rush

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,11 @@ on:
     branches: [master, dev]
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    # Run at an off-peak, odd-minute time (03:43 UTC) rather than midnight.
+    # Top-of-the-hour crons like "0 0 * * *" hit GitHub's scheduled-workflow
+    # rush, which rate-limited hacs/action's raw-content fetches and caused
+    # flaky "no images in Readme" validation failures.
+    - cron: "43 3 * * *"
 
 jobs:
   validate-hacs:
@@ -18,7 +22,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Validate HACS manifest & structure
         uses: hacs/action@main


### PR DESCRIPTION
## Why

The scheduled Validate HACS run on 2026-07-09 failed with `<Validation images> failed: The repository does not have images in the Readme file`, even though the README has plenty of images. The run before and after passed. Root cause: the cron fires at 00:00 UTC, GitHub's busiest scheduled-workflow slot, and hacs/action's raw-content fetches get rate-limited (the sibling repo's log from the same night shows the rate-limit warning explicitly).

## What

- Move the nightly cron from `0 0 * * *` to `43 3 * * *` (off-peak, odd minute, per GitHub's own guidance to avoid top-of-the-hour crons).
- Bump `actions/checkout@v3` to `@v4` (Node 20 deprecation warnings in the run logs).

No change to the push/pull_request triggers or the fork guard.