### PR TITLE
(config) Type icon_size as number in adapter stubs

### DIFF
--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -84,7 +84,7 @@ export const stubConfigATMO: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/dwd.ts
+++ b/src/adapters/dwd.ts
@@ -49,7 +49,7 @@ export const stubConfigDWD: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/gp/constants.ts
+++ b/src/adapters/gp/constants.ts
@@ -530,7 +530,7 @@ export const stubConfigGP: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/gpl/constants.ts
+++ b/src/adapters/gpl/constants.ts
@@ -24,7 +24,7 @@ export const stubConfigGPL: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -121,7 +121,7 @@ export const stubConfigIRMKMI: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/kleenex/constants.ts
+++ b/src/adapters/kleenex/constants.ts
@@ -111,7 +111,7 @@ export const stubConfigKleenex: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -95,7 +95,7 @@ export const stubConfigMSW: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/peu.ts
+++ b/src/adapters/peu.ts
@@ -56,7 +56,7 @@ export const stubConfigPEU: AdapterStubConfig = {
   minimal_gap: 35,
   mode: "daily",
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -161,7 +161,7 @@ export const stubConfigPLU: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/pp.ts
+++ b/src/adapters/pp.ts
@@ -47,7 +47,7 @@ export const stubConfigPP: AdapterStubConfig = {
   minimal: false,
   minimal_gap: 35,
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/adapters/silam.ts
+++ b/src/adapters/silam.ts
@@ -76,7 +76,7 @@ export const stubConfigSILAM: AdapterStubConfig = {
   minimal_gap: 35,
   mode: "daily",
   background_color: "",
-  icon_size: "48",
+  icon_size: 48,
   text_size_ratio: 1,
   ...LEVELS_DEFAULTS,
   show_text_allergen: true,

--- a/src/editor/sections/appearance.ts
+++ b/src/editor/sections/appearance.ts
@@ -5,6 +5,7 @@
 
 import { html, type TemplateResult } from "lit";
 import type { PollenEditorLike } from "../types.js";
+import { resolveIconSize } from "../../utils/config-normalize.js";
 
 export function renderAppearanceSection(
   editor: PollenEditorLike,
@@ -50,7 +51,7 @@ export function renderAppearanceSection(
                   min="16"
                   max="128"
                   step="1"
-                  .value=${c.icon_size ?? 48}
+                  .value=${resolveIconSize(c.icon_size)}
                   @input=${(e: Event) =>
                     editor._updateConfig(
                       "icon_size",
@@ -59,7 +60,7 @@ export function renderAppearanceSection(
                   style="width: 120px;"
                 ></ha-slider>
                 ${editor._renderNumberField({
-                  value: c.icon_size ?? 48,
+                  value: resolveIconSize(c.icon_size),
                   min: 16,
                   max: 128,
                   step: 1,

--- a/src/editor/sections/appearance.ts
+++ b/src/editor/sections/appearance.ts
@@ -59,7 +59,7 @@ export function renderAppearanceSection(
                   style="width: 120px;"
                 ></ha-slider>
                 ${editor._renderNumberField({
-                  value: (c.icon_size as unknown as number) ?? 48,
+                  value: c.icon_size ?? 48,
                   min: 16,
                   max: 128,
                   step: 1,

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -1451,7 +1451,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     const ringIconRatio =
       Number(this.config?.icon_in_ring_size_ratio) ||
       LEVELS_DEFAULTS.icon_in_ring_size_ratio;
-    const iconSize = Number(this.config?.icon_size) || 48;
+    const iconSize = this.config?.icon_size ?? 48;
     // A configured element-level tap_action takes precedence over per-icon
     // more-info unless link_to_sensors is explicitly true (#279).
     const hasTap = resolveTapActionType(this.tapAction) !== null;
@@ -1656,7 +1656,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     // thickness and gap. Same derivation minimal mode and the badge use.
     const { colors, emptyColor, gapColor, thickness, gap } =
       this._buildLevelRingConfig();
-    const iconSize = Number(this.config.icon_size) || 48;
+    const iconSize = this.config.icon_size ?? 48;
     const iconRatio = Number(this.config.levels_icon_ratio) || 1;
     const size = Math.min(100, Math.max(1, iconSize * iconRatio));
 
@@ -2141,8 +2141,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     const bg = (this.config.background_color as string | undefined)?.trim?.();
     const bgStyle = bg ? `background-color: ${bg};` : "";
     const cursorStyle = hasTap ? "pointer" : "auto";
-    const imgSize =
-      Number(this.config.icon_size) > 0 ? Number(this.config.icon_size) : 48;
+    const configuredIconSize = this.config.icon_size ?? 0;
+    const imgSize = configuredIconSize > 0 ? configuredIconSize : 48;
     const cardStyle = `
     ${bgStyle}
     cursor: ${cursorStyle};

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -40,6 +40,7 @@ import {
   mergeCardConfig,
   finalizeCardConfig,
   cardAllowedFields,
+  resolveIconSize,
 } from "./utils/config-normalize.js";
 import { computeGridOptions } from "./utils/grid-options.js";
 import {
@@ -1451,7 +1452,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     const ringIconRatio =
       Number(this.config?.icon_in_ring_size_ratio) ||
       LEVELS_DEFAULTS.icon_in_ring_size_ratio;
-    const iconSize = this.config?.icon_size ?? 48;
+    const iconSize = resolveIconSize(this.config?.icon_size);
     // A configured element-level tap_action takes precedence over per-icon
     // more-info unless link_to_sensors is explicitly true (#279).
     const hasTap = resolveTapActionType(this.tapAction) !== null;
@@ -1656,7 +1657,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     // thickness and gap. Same derivation minimal mode and the badge use.
     const { colors, emptyColor, gapColor, thickness, gap } =
       this._buildLevelRingConfig();
-    const iconSize = this.config.icon_size ?? 48;
+    const iconSize = resolveIconSize(this.config.icon_size);
     const iconRatio = Number(this.config.levels_icon_ratio) || 1;
     const size = Math.min(100, Math.max(1, iconSize * iconRatio));
 
@@ -2141,8 +2142,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     const bg = (this.config.background_color as string | undefined)?.trim?.();
     const bgStyle = bg ? `background-color: ${bg};` : "";
     const cursorStyle = hasTap ? "pointer" : "auto";
-    const configuredIconSize = this.config.icon_size ?? 0;
-    const imgSize = configuredIconSize > 0 ? configuredIconSize : 48;
+    const imgSize = resolveIconSize(this.config.icon_size);
     const cardStyle = `
     ${bgStyle}
     cursor: ${cursorStyle};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -76,7 +76,7 @@ export interface CardConfig extends LovelaceCardConfig {
   show_summary_plants_in_season?: boolean;
 
   // --- Icons ---
-  icon_size?: string;
+  icon_size?: number;
   icon_color_mode?: string;
   icon_color?: string;
   icon_in_ring?: boolean;

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -19,7 +19,7 @@
 //   - `allergens` is guaranteed to be an array (falls back to the stub default
 //     when a malformed non-array slips through).
 // Fields no stub types as boolean/number (title, city/location/region_id,
-// icon_size, date_locale, tap_action, ...) are never coerced, so title="false"
+// date_locale, tap_action, ...) are never coerced, so title="false"
 // stays the string the header logic expects and entity-id slugs stay strings.
 //
 // The result is frozen: nothing downstream mutates the card's config in place

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -142,16 +142,23 @@ export const DEFAULT_ICON_SIZE = 48;
  * The second half of a two-layer defence: {@link coerceConfigTypes} repairs
  * hand-written YAML (`icon_size: 48px`, plausible since the editor label reads
  * "Icon size (px)") at the config boundary, but not every config reaches the
- * card through it — the editor spreads its config without coercing. And the
- * boundary deliberately keeps 0 and negative numbers, which are legitimate for
- * other number fields but yield invalid CSS or a clamped ring as an edge
+ * card through it — the editor spreads its config without coercing. The guard
+ * therefore does its own numeric-string conversion instead of assuming the
+ * boundary ran: the legacy `icon_size: "64"` must show 64 on the editor's
+ * slider, not the default, or the controls start from a different value than
+ * the card renders.
+ *
+ * The boundary deliberately keeps 0 and negative numbers, which are legitimate
+ * for other number fields but yield invalid CSS or a clamped ring as an edge
  * length. Anything that isn't a positive finite number renders at the default
  * rather than flowing into the geometry, where the daily path would produce a
  * NaN donut width and minimal mode a literal `width: ${value}px`.
  */
 export function resolveIconSize(raw: unknown): number {
-  return typeof raw === "number" && Number.isFinite(raw) && raw > 0
-    ? raw
+  const value =
+    typeof raw === "string" ? (raw.trim() === "" ? NaN : Number(raw)) : raw;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
     : DEFAULT_ICON_SIZE;
 }
 

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -135,6 +135,21 @@ export function mergeCardConfig(
 export const DEFAULT_ICON_SIZE = 48;
 
 /**
+ * Numeric value of a config scalar, or NaN when it can never be one. The single
+ * definition of that rule: both layers below call this, and the whole point of
+ * having two layers is that they agree on what a usable number is.
+ *
+ * The rule is subtle in the way that invites drift, hence one copy: a blank
+ * string must not become 0, and a non-string must never reach Number(), which
+ * would turn `true` into 1, `[]` into 0 and `[64]` into 64.
+ */
+function toFiniteNumber(raw: unknown): number {
+  if (typeof raw === "number") return raw;
+  if (typeof raw !== "string" || raw.trim() === "") return NaN;
+  return Number(raw);
+}
+
+/**
  * The read-side guard for `icon_size`, shared by the card's three read-sites
  * (minimal rows, daily rows, the `--pollen-icon-size` custom property) and the
  * editor's slider/number field, so they can never disagree about a size.
@@ -155,11 +170,8 @@ export const DEFAULT_ICON_SIZE = 48;
  * NaN donut width and minimal mode a literal `width: ${value}px`.
  */
 export function resolveIconSize(raw: unknown): number {
-  const value =
-    typeof raw === "string" ? (raw.trim() === "" ? NaN : Number(raw)) : raw;
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? value
-    : DEFAULT_ICON_SIZE;
+  const value = toFiniteNumber(raw);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_ICON_SIZE;
 }
 
 /**
@@ -198,17 +210,13 @@ export function coerceConfigTypes(
       if (value === "true") out[key] = true;
       else if (value === "false") out[key] = false;
     } else if (NUMBER_FIELDS.has(key)) {
-      if (typeof value === "string") {
-        const n = value.trim() === "" ? NaN : Number(value);
-        if (Number.isFinite(n)) out[key] = n;
-        else dropUnusableNumber(out, key, stubFields);
-      } else if (typeof value !== "number" || !Number.isFinite(value)) {
-        // Everything that is neither a usable string nor a finite number:
-        // `icon_size: true` (Number(true) === 1, so the old read-sites drew a
-        // 1px icon), an object/array from a malformed nesting, null from an
-        // empty YAML scalar, .nan, Infinity.
-        dropUnusableNumber(out, key, stubFields);
-      }
+      // Unusable covers the numeric strings that don't parse ("48px") as well
+      // as `icon_size: true` (Number(true) === 1, so the old read-sites drew a
+      // 1px icon), an object/array from a malformed nesting, null from an empty
+      // YAML scalar, .nan and .inf.
+      const n = toFiniteNumber(value);
+      if (Number.isFinite(n)) out[key] = n;
+      else dropUnusableNumber(out, key, stubFields);
     }
   }
 

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -15,7 +15,9 @@
 //   - a field that is boolean in any stub coerces the exact strings
 //     "true"/"false" to booleans (everything else is left untouched);
 //   - a field that is a number in any stub coerces a finite numeric string to
-//     a number;
+//     a number, and falls back to the stub default when the value can never be
+//     one (icon_size: abc, an empty scalar, .nan) so read-sites doing
+//     arithmetic never see a string;
 //   - `allergens` is guaranteed to be an array (falls back to the stub default
 //     when a malformed non-array slips through).
 // Fields no stub types as boolean/number (title, city/location/region_id,
@@ -130,6 +132,23 @@ export function mergeCardConfig(
 }
 
 /**
+ * Replace a number-typed field whose value can never become a finite number
+ * (hand-written `icon_size: abc`, an explicit `.nan`, an empty scalar) with the
+ * stub default, dropping the key when the resolved stub does not declare the
+ * field. Without this a string survives to read-sites that now expect a number
+ * and reaches arithmetic — donut geometry calls toFixed on it and aborts the
+ * render, and the normal-mode paths emit NaN geometry.
+ */
+function dropUnusableNumber(
+  out: Record<string, unknown>,
+  key: string,
+  stubFields: Record<string, unknown>,
+): void {
+  if (typeof stubFields[key] === "number") out[key] = stubFields[key];
+  else delete out[key];
+}
+
+/**
  * Coerce known-typed fields to their canonical runtime types, driven by the
  * cross-stub field-type union ({@link BOOLEAN_FIELDS} / {@link NUMBER_FIELDS}).
  * The stub is used only for the `allergens` array fallback. Returns a new
@@ -140,18 +159,19 @@ export function coerceConfigTypes(
   stub: AdapterStubConfig,
 ): CardConfig {
   const out: Record<string, unknown> = { ...merged };
+  const stubFields = stub as Record<string, unknown>;
 
   for (const [key, value] of Object.entries(out)) {
     if (BOOLEAN_FIELDS.has(key)) {
       if (value === "true") out[key] = true;
       else if (value === "false") out[key] = false;
     } else if (NUMBER_FIELDS.has(key)) {
-      if (
-        typeof value === "string" &&
-        value.trim() !== "" &&
-        Number.isFinite(Number(value))
-      ) {
-        out[key] = Number(value);
+      if (typeof value === "string") {
+        const n = value.trim() === "" ? NaN : Number(value);
+        if (Number.isFinite(n)) out[key] = n;
+        else dropUnusableNumber(out, key, stubFields);
+      } else if (typeof value === "number" && !Number.isFinite(value)) {
+        dropUnusableNumber(out, key, stubFields);
       }
     }
   }

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -131,6 +131,30 @@ export function mergeCardConfig(
   return { ...stub, ...picked, integration };
 }
 
+/** Icon edge length in px when `icon_size` is absent or unusable. */
+export const DEFAULT_ICON_SIZE = 48;
+
+/**
+ * The read-side guard for `icon_size`, shared by the card's three read-sites
+ * (minimal rows, daily rows, the `--pollen-icon-size` custom property) and the
+ * editor's slider/number field, so they can never disagree about a size.
+ *
+ * The second half of a two-layer defence: {@link coerceConfigTypes} repairs
+ * hand-written YAML (`icon_size: 48px`, plausible since the editor label reads
+ * "Icon size (px)") at the config boundary, but not every config reaches the
+ * card through it — the editor spreads its config without coercing. And the
+ * boundary deliberately keeps 0 and negative numbers, which are legitimate for
+ * other number fields but yield invalid CSS or a clamped ring as an edge
+ * length. Anything that isn't a positive finite number renders at the default
+ * rather than flowing into the geometry, where the daily path would produce a
+ * NaN donut width and minimal mode a literal `width: ${value}px`.
+ */
+export function resolveIconSize(raw: unknown): number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_ICON_SIZE;
+}
+
 /**
  * Replace a number-typed field whose value can never become a finite number
  * (hand-written `icon_size: abc` or `icon_size: true`, an explicit `.nan`, an

--- a/src/utils/config-normalize.ts
+++ b/src/utils/config-normalize.ts
@@ -16,8 +16,8 @@
 //     "true"/"false" to booleans (everything else is left untouched);
 //   - a field that is a number in any stub coerces a finite numeric string to
 //     a number, and falls back to the stub default when the value can never be
-//     one (icon_size: abc, an empty scalar, .nan) so read-sites doing
-//     arithmetic never see a string;
+//     one (icon_size: abc, an empty scalar, .nan, a boolean or a nested
+//     structure) so read-sites doing arithmetic only ever see a number;
 //   - `allergens` is guaranteed to be an array (falls back to the stub default
 //     when a malformed non-array slips through).
 // Fields no stub types as boolean/number (title, city/location/region_id,
@@ -133,11 +133,12 @@ export function mergeCardConfig(
 
 /**
  * Replace a number-typed field whose value can never become a finite number
- * (hand-written `icon_size: abc`, an explicit `.nan`, an empty scalar) with the
- * stub default, dropping the key when the resolved stub does not declare the
- * field. Without this a string survives to read-sites that now expect a number
- * and reaches arithmetic — donut geometry calls toFixed on it and aborts the
- * render, and the normal-mode paths emit NaN geometry.
+ * (hand-written `icon_size: abc` or `icon_size: true`, an explicit `.nan`, an
+ * empty scalar) with the stub default, dropping the key when the resolved stub
+ * does not declare the field. Without this the value survives to read-sites
+ * that now expect a number and reaches arithmetic — donut geometry calls
+ * toFixed on it and aborts the render, the normal-mode paths emit NaN geometry,
+ * and minimal mode interpolates it straight into `width: ${value}px`.
  */
 function dropUnusableNumber(
   out: Record<string, unknown>,
@@ -170,7 +171,11 @@ export function coerceConfigTypes(
         const n = value.trim() === "" ? NaN : Number(value);
         if (Number.isFinite(n)) out[key] = n;
         else dropUnusableNumber(out, key, stubFields);
-      } else if (typeof value === "number" && !Number.isFinite(value)) {
+      } else if (typeof value !== "number" || !Number.isFinite(value)) {
+        // Everything that is neither a usable string nor a finite number:
+        // `icon_size: true` (Number(true) === 1, so the old read-sites drew a
+        // 1px icon), an object/array from a malformed nesting, null from an
+        // empty YAML scalar, .nan, Infinity.
         dropUnusableNumber(out, key, stubFields);
       }
     }

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -227,6 +227,44 @@ describe("resolveIconSize", () => {
     expect(rendered(-10)).toBe(48);
   });
 
+  it("renders the same size whether or not the boundary ran", () => {
+    // Both layers parse numeric scalars through one shared rule, so passing a
+    // value through the boundary must never change what the guard renders.
+    // Drift between the two is what produced the round 1 and round 3 findings:
+    // a boundary that accepted [64] as 64 while the guard said 48 would fail
+    // here, as would a guard that started accepting "48px".
+    for (const raw of [
+      64,
+      "64",
+      " 64 ",
+      "48px",
+      "abc",
+      "",
+      "  ",
+      "0x10",
+      0,
+      "0",
+      -10,
+      "-10",
+      true,
+      false,
+      {},
+      [],
+      [64],
+      null,
+      undefined,
+      NaN,
+      Infinity,
+    ]) {
+      const throughBoundary = normalizeCardConfig(
+        { integration: "pp", icon_size: raw } as Record<string, unknown>,
+        stubConfigPP,
+        { integration: "pp", filter: true },
+      ).icon_size;
+      expect(resolveIconSize(throughBoundary)).toBe(resolveIconSize(raw));
+    }
+  });
+
   it("uses the stub default when icon_size is absent", () => {
     const cfg = normalizeCardConfig({ integration: "pp" }, stubConfigPP, {
       integration: "pp",

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -162,24 +162,29 @@ describe("normalizeCardConfig: numeric string coercion", () => {
 //      icon_size sites (minimal rows, daily rows, --pollen-icon-size) and the
 //      editor's slider/number field. It covers what the boundary deliberately
 //      leaves alone — 0 and negative numbers are legitimate values there — and
-//      keeps the number type backed by a runtime check for configs that never
-//      passed the boundary (the editor spreads config without coercing it).
+//      stands on its own for configs that never passed the boundary (the editor
+//      spreads config without coercing it).
 describe("resolveIconSize", () => {
   it("passes a usable size through", () => {
     expect(resolveIconSize(64)).toBe(64);
     expect(resolveIconSize(16)).toBe(16);
   });
 
+  it("converts a numeric string, for configs that skipped the boundary", () => {
+    // The editor spreads config uncoerced, so legacy icon_size: "64" arrives
+    // here as a string; returning the default would make the slider and number
+    // field start from a different value than the card renders.
+    expect(resolveIconSize("64")).toBe(64);
+    expect(resolveIconSize(" 64 ")).toBe(64);
+  });
+
   it("falls back to 48 for every unusable value", () => {
     // "48px" is plausible by hand: the editor label reads "Icon size (px)".
-    // "64" is here on purpose too — converting numeric strings is the
-    // boundary's job, so a string reaching the guard means it bypassed it.
     for (const raw of [
       "abc",
       "48px",
       "",
       "  ",
-      "64",
       true,
       {},
       [],
@@ -197,6 +202,8 @@ describe("resolveIconSize", () => {
     // through (Number(-10) || 48 === -10), which is invalid CSS anyway.
     expect(resolveIconSize(0)).toBe(48);
     expect(resolveIconSize(-10)).toBe(48);
+    expect(resolveIconSize("0")).toBe(48);
+    expect(resolveIconSize("-10")).toBe(48);
   });
 
   it("layers with the boundary for real YAML values", () => {

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -6,6 +6,7 @@ import {
   finalizeCardConfig,
   cardAllowedFields,
   CARD_EXTRA_FIELDS,
+  resolveIconSize,
 } from "../../src/utils/config-normalize.js";
 import { stubConfigPP } from "../../src/adapters/pp.js";
 import { stubConfigSILAM } from "../../src/adapters/silam.js";
@@ -145,6 +146,81 @@ describe("normalizeCardConfig: numeric string coercion", () => {
       { ...stubConfigPP, pollen_threshold: undefined } as never,
     );
     expect(cfg).not.toHaveProperty("pollen_threshold");
+  });
+});
+
+// Two layers keep the icon geometry safe, and both are exercised here.
+//   1. The boundary (the block above) repairs hand-written YAML for every
+//      number field: a non-coercible string, NaN, a boolean or a nested
+//      structure becomes the stub default before the card sees it.
+//   2. resolveIconSize is the read-side guard shared by the card's three
+//      icon_size sites (minimal rows, daily rows, --pollen-icon-size) and the
+//      editor's slider/number field. It covers what the boundary deliberately
+//      leaves alone — 0 and negative numbers are legitimate values there — and
+//      keeps the number type backed by a runtime check for configs that never
+//      passed the boundary (the editor spreads config without coercing it).
+describe("resolveIconSize", () => {
+  it("passes a usable size through", () => {
+    expect(resolveIconSize(64)).toBe(64);
+    expect(resolveIconSize(16)).toBe(16);
+  });
+
+  it("falls back to 48 for every unusable value", () => {
+    // "48px" is plausible by hand: the editor label reads "Icon size (px)".
+    // "64" is here on purpose too — converting numeric strings is the
+    // boundary's job, so a string reaching the guard means it bypassed it.
+    for (const raw of [
+      "abc",
+      "48px",
+      "",
+      "  ",
+      "64",
+      true,
+      {},
+      [],
+      null,
+      undefined,
+      NaN,
+      Infinity,
+    ]) {
+      expect(resolveIconSize(raw)).toBe(48);
+    }
+  });
+
+  it("falls back to 48 for non-positive sizes the boundary keeps", () => {
+    // Behaviour change: the minimal/daily sites previously let a negative
+    // through (Number(-10) || 48 === -10), which is invalid CSS anyway.
+    expect(resolveIconSize(0)).toBe(48);
+    expect(resolveIconSize(-10)).toBe(48);
+  });
+
+  it("layers with the boundary for real YAML values", () => {
+    const rendered = (raw: unknown) =>
+      resolveIconSize(
+        normalizeCardConfig(
+          { integration: "pp", icon_size: raw } as Record<string, unknown>,
+          stubConfigPP,
+          { integration: "pp", filter: true },
+        ).icon_size,
+      );
+    // Repaired by the boundary, passed through by the guard.
+    expect(rendered("64")).toBe(64);
+    expect(rendered(64)).toBe(64);
+    // Repaired by the boundary before the guard is reached.
+    for (const raw of ["abc", "48px", "", true, {}, null]) {
+      expect(rendered(raw)).toBe(48);
+    }
+    // Survives the boundary as a valid number; only the guard rejects it.
+    expect(rendered("0")).toBe(48);
+    expect(rendered(-10)).toBe(48);
+  });
+
+  it("uses the stub default when icon_size is absent", () => {
+    const cfg = normalizeCardConfig({ integration: "pp" }, stubConfigPP, {
+      integration: "pp",
+      filter: true,
+    });
+    expect(resolveIconSize(cfg.icon_size)).toBe(stubConfigPP.icon_size);
   });
 });
 

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -67,15 +67,6 @@ describe("normalizeCardConfig: numeric string coercion", () => {
     expect(cfg.pollen_threshold).toBe(3);
   });
 
-  it("leaves a non-numeric string for a numeric field untouched", () => {
-    const cfg = normalizeCardConfig(
-      { integration: "pp", days_to_show: "abc" },
-      stubConfigPP,
-      { integration: "pp", filter: true },
-    );
-    expect(cfg.days_to_show).toBe("abc");
-  });
-
   it("coerces a legacy string icon_size to a number", () => {
     const cfg = normalizeCardConfig(
       { integration: "pp", icon_size: "64" },
@@ -83,6 +74,49 @@ describe("normalizeCardConfig: numeric string coercion", () => {
       { integration: "pp", filter: true },
     );
     expect(cfg.icon_size).toBe(64);
+  });
+
+  it("keeps zero and negative numeric strings as-is", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: "0", days_to_show: "-1" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.icon_size).toBe(0);
+    expect(cfg.days_to_show).toBe(-1);
+  });
+
+  it("falls back to the stub default for an unusable numeric value", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: "abc", days_to_show: "abc" },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    // A string reaching the donut geometry would abort the render (toFixed).
+    expect(cfg.icon_size).toBe(stubConfigPP.icon_size);
+    expect(cfg.icon_size).toBe(48);
+    expect(cfg.days_to_show).toBe(stubConfigPP.days_to_show);
+  });
+
+  it("falls back for an empty scalar and for NaN", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: "  ", days_to_show: NaN },
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.icon_size).toBe(48);
+    expect(cfg.days_to_show).toBe(4);
+  });
+
+  it("drops an unusable number field the resolved stub does not declare", () => {
+    // set hass spreads the full config, so a field only another stub declares
+    // can arrive; with no stub default to restore, the key is removed and the
+    // read-site default applies.
+    const cfg = coerceConfigTypes(
+      { integration: "pp", pollen_threshold: "abc" },
+      { ...stubConfigPP, pollen_threshold: undefined } as never,
+    );
+    expect(cfg).not.toHaveProperty("pollen_threshold");
   });
 });
 

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -108,6 +108,34 @@ describe("normalizeCardConfig: numeric string coercion", () => {
     expect(cfg.days_to_show).toBe(4);
   });
 
+  it("falls back for values that are neither string nor number", () => {
+    // icon_size: true used to render as a 1px icon (Number(true)); an object
+    // slips in through a malformed nesting. Both must not reach the geometry.
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: true, days_to_show: {} } as Record<
+        string,
+        unknown
+      >,
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.icon_size).toBe(48);
+    expect(cfg.days_to_show).toBe(4);
+  });
+
+  it("falls back for null and undefined", () => {
+    const cfg = normalizeCardConfig(
+      { integration: "pp", icon_size: null, days_to_show: undefined } as Record<
+        string,
+        unknown
+      >,
+      stubConfigPP,
+      { integration: "pp", filter: true },
+    );
+    expect(cfg.icon_size).toBe(48);
+    expect(cfg.days_to_show).toBe(4);
+  });
+
   it("drops an unusable number field the resolved stub does not declare", () => {
     // set hass spreads the full config, so a field only another stub declares
     // can arrive; with no stub default to restore, the key is removed and the

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -83,8 +83,13 @@ describe("normalizeCardConfig: numeric string coercion", () => {
       stubConfigPP,
       { integration: "pp", filter: true },
     );
+    // The boundary coerces the type and stops there: 0 and -1 are legitimate
+    // values for some number fields, so range-checking is not its job. For
+    // icon_size the read-side guard rejects them, so both layers have to be
+    // read together — hence the guard assertion alongside the config one.
     expect(cfg.icon_size).toBe(0);
     expect(cfg.days_to_show).toBe(-1);
+    expect(resolveIconSize(cfg.icon_size)).toBe(48);
   });
 
   it("falls back to the stub default for an unusable numeric value", () => {

--- a/test/card/config-normalize.test.ts
+++ b/test/card/config-normalize.test.ts
@@ -76,13 +76,13 @@ describe("normalizeCardConfig: numeric string coercion", () => {
     expect(cfg.days_to_show).toBe("abc");
   });
 
-  it("does not coerce icon_size (a string in the stub) to a number", () => {
+  it("coerces a legacy string icon_size to a number", () => {
     const cfg = normalizeCardConfig(
       { integration: "pp", icon_size: "64" },
       stubConfigPP,
       { integration: "pp", filter: true },
     );
-    expect(cfg.icon_size).toBe("64");
+    expect(cfg.icon_size).toBe(64);
   });
 });
 


### PR DESCRIPTION
Closes #305 (manual close needed after merge; PR targets dev).

All eleven adapter stubs typed `icon_size` as the string `"48"` while every read site converted with `Number(...)`. This retypes the stubs to `48` (number), updates `CardConfig.icon_size` to `number`, and drops the now-redundant conversions at the three card read sites plus the editor double-cast. Legacy YAML strings (`icon_size: "64"`) keep working with no new code: `buildFieldTypeSets` derives `NUMBER_FIELDS` from stub value types, so the config boundary coerces them automatically.

Review rounds hardened the change in two complementary layers:

- **Boundary layer** (`coerceConfigTypes`): a number-typed field whose value can never become a finite number — non-numeric strings (`"abc"`, `"48px"`), empty scalars, `.nan`, booleans, nested structures, null/undefined — now falls back to the stub default (or the key is dropped when the resolved stub does not declare the field). This applies to every NUMBER_FIELD, not just `icon_size`; previously such values leaked to read sites as-is.
- **Read-site guard** (`resolveIconSize`): the three card read sites and the editor controls share one rule — finite number > 0, else 48. This protects paths that bypass the boundary (the editor spreads config without coercion) and enforces the positive-size rule: 0 and negative sizes now fall back to 48 in minimal/daily views too, where the old `Number(...) || 48` let negatives through. Only hand-written YAML can produce those values (the editor slider is 16-128).

Verification: typecheck 0 errors, lint 0/0, 1386 tests passed (10 new), goldens unchanged, gzip 208502 bytes within budget.