### PR TITLE
(capture_editors) Use locale-independent editor entry

### DIFF
--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -60,6 +60,12 @@ editor element (the `ha-dialog` wrapper is portaled and has zero box):
 python capture_editors.py            # editor-card.png + editor-badge.png
 ```
 
+It drives the UI without matching any translated label (edit mode via `?edit=1`,
+edit controls via their structure inside `hui-card-options` /
+`hui-badge-edit-mode`), so it runs against an HA instance in any language. The
+resulting screenshots still show the instance's UI language, so shoot the
+committed docs images against an English-language HA.
+
 `shoot.py` is a thin helper for ad-hoc shots (a badge row or a card by index in
 a given view).
 

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -74,6 +74,8 @@ The README badge block (`hero-badges.png`) is shot manually: apply
 (~210 px) so the badges wrap into a compact block, and screenshot
 `hui-view-badges`.
 
-Images render in the HA UI language (English via the browser locale by default);
-avoid fixture cards that pin a `date_locale`. Keep PNGs lean (element crops, not
-full-page dumps).
+Images render in the HA UI language, which is set by the HA user profile and not
+by the browser locale (a browser running en-US against an instance whose profile
+language is Swedish still shoots Swedish images). Check the profile before
+regenerating committed images, and avoid fixture cards that pin a `date_locale`.
+Keep PNGs lean (element crops, not full-page dumps).

--- a/scripts/screenshots/capture_editors.py
+++ b/scripts/screenshots/capture_editors.py
@@ -11,6 +11,12 @@ Flow: write a throwaway single-card + single-badge "docedit" view live via the
 HA WebSocket API, enter dashboard edit mode, click the element's edit control,
 then shoot the editor element. The view is removed afterwards.
 
+Locale independence: nothing here matches on translated UI text, so the script
+works against a Home Assistant in any language. Edit mode is entered through
+HA's own `?edit=1` URL parameter instead of clicking a translated "Edit
+dashboard" control, and the per-element edit controls are found by their
+structural position inside `hui-card-options` / `hui-badge-edit-mode`.
+
 Auth: hass-test long-lived token in HASS_TOKEN (never committed).
 
 Usage:
@@ -62,23 +68,41 @@ def poll(pg, sel, t=15000):
     return False
 
 
+# Structural (untranslated) handles on the per-element edit controls in edit
+# mode. The card's edit button is the only ha-button that is a direct child of
+# the .card-actions row in hui-card-options (the reorder/overflow buttons sit in
+# a nested .right div). The badge's edit control is the .edit hit area that
+# hui-badge-edit-mode overlays on the badge.
+CARD_EDIT = "hui-card-options .card-actions > ha-button"
+BADGE_EDIT = "hui-badge-edit-mode .badge-overlay .edit"
+
+
+def click_center(pg, sel):
+    """Click the middle of a located element by coordinates. Both edit controls
+    live inside a shadow root whose host swallows Playwright's actionability
+    hit-test ("<hui-badge-edit-mode> intercepts pointer events"), so a plain
+    locator click is not reliable here."""
+    bb = pg.locator(sel).first.bounding_box()
+    if not bb:
+        return False
+    pg.mouse.click(bb["x"] + bb["width"] / 2, bb["y"] + bb["height"] / 2)
+    return True
+
+
 def open_editor(pg, kind):
-    pg.goto(f"{URL}/{DASH}/docedit", wait_until="networkidle"); pg.wait_for_timeout(3000)
-    pg.get_by_label("Edit dashboard").first.click(); pg.wait_for_timeout(2800)
-    if kind == "card":
-        # The card's "Edit" text button is in hui-card-options. A toolbar pencil
-        # is also labelled "Edit" but sits at the top; pick the lower, wider one.
-        btns = pg.get_by_role("button", name="Edit")
-        for i in range(btns.count()):
-            bb = btns.nth(i).bounding_box()
-            if bb and bb["y"] > 120 and bb["width"] > 45:
-                pg.mouse.click(bb["x"] + bb["width"] / 2, bb["y"] + bb["height"] / 2)
-                break
-        return poll(pg, "pollenprognos-card-editor")
-    else:
-        bb = pg.locator("pollenprognos-badge").first.bounding_box()
-        pg.mouse.click(bb["x"] + bb["width"] / 2, bb["y"] + bb["height"] / 2)
-        return poll(pg, "pollenprognos-badge-editor")
+    # ?edit=1 is HA's own URL entry into dashboard edit mode, so we never need to
+    # click a control whose label is translated.
+    pg.goto(f"{URL}/{DASH}/docedit?edit=1", wait_until="networkidle")
+    pg.wait_for_timeout(3000)
+    sel = CARD_EDIT if kind == "card" else BADGE_EDIT
+    if not poll(pg, sel):
+        print(f"ERROR: {kind} edit control ({sel}) never appeared; "
+              "is the dashboard in edit mode?", file=sys.stderr)
+        return False
+    if not click_center(pg, sel):
+        print(f"ERROR: {kind} edit control has no layout box", file=sys.stderr)
+        return False
+    return poll(pg, f"pollenprognos-{kind}-editor")
 
 
 def main():

--- a/scripts/screenshots/capture_editors.py
+++ b/scripts/screenshots/capture_editors.py
@@ -75,6 +75,11 @@ def poll(pg, sel, t=15000):
 # hui-badge-edit-mode overlays on the badge.
 CARD_EDIT = "hui-card-options .card-actions > ha-button"
 BADGE_EDIT = "hui-badge-edit-mode .badge-overlay .edit"
+KINDS = ("card", "badge")
+
+
+def editor_tag(kind):
+    return f"pollenprognos-{kind}-editor"
 
 
 def click_center(pg, sel):
@@ -102,13 +107,16 @@ def open_editor(pg, kind):
     if not click_center(pg, sel):
         print(f"ERROR: {kind} edit control has no layout box", file=sys.stderr)
         return False
-    return poll(pg, f"pollenprognos-{kind}-editor")
+    return poll(pg, editor_tag(kind))
 
 
 def main():
     if not TOKEN:
         print("ERROR: set HASS_TOKEN", file=sys.stderr); sys.exit(2)
-    kinds = [sys.argv[1]] if len(sys.argv) > 1 else ["card", "badge"]
+    kinds = [sys.argv[1]] if len(sys.argv) > 1 else list(KINDS)
+    if any(k not in KINDS for k in kinds):
+        print("ERROR: usage: capture_editors.py [card|badge]", file=sys.stderr)
+        sys.exit(2)
     with sync_playwright() as p:
         b = p.chromium.launch(headless=True)
         ctx = b.new_context(viewport={"width": 1000, "height": 1700}, device_scale_factor=2)
@@ -126,8 +134,8 @@ def main():
             print(f"{kind} editor present:", ok)
             if ok:
                 pg.wait_for_timeout(1500)
-                el = "pollenprognos-card-editor" if kind == "card" else "pollenprognos-badge-editor"
-                pg.locator(el).first.screenshot(path=os.path.join(OUT, f"editor-{kind}.png"))
+                pg.locator(editor_tag(kind)).first.screenshot(
+                    path=os.path.join(OUT, f"editor-{kind}.png"))
                 print(f"saved editor-{kind}.png")
         full["views"] = base
         hass_save(pg, full)


### PR DESCRIPTION
Closes #307 (manual close needed after merge; PR targets dev).

The editor-screenshot generator located its entry points via hardcoded English UI labels ("Edit dashboard", button name "Edit"), so it failed against a non-English test instance. Both label lookups are replaced with locale-independent mechanisms: the dashboard edit mode is entered through HA's own `?edit=1` URL parameter, and the card's edit control is found through the structural selector `hui-card-options .card-actions > ha-button` (the move/overflow buttons live in a nested `.right` div, so the child combinator disambiguates without coordinate heuristics). The badge path's implicit overlay click is made explicit via `hui-badge-edit-mode .badge-overlay .edit`.

Clicks go through a shared `click_center()` helper (Playwright's actionability check refuses direct `.click()` on these shadow-DOM overlays), and a missing edit control now produces a clear stderr message instead of a `None` bounding-box crash.

Verified empirically against a Swedish-language HA 2026.6.4 instance: both `editor-card.png` and `editor-badge.png` render fully (all sections present, Swedish labels). The tracked `docs/screenshots/` images are deliberately untouched — the script now runs against any UI language, but docs imagery should still be captured against an English instance (README updated with that note).

Internal tooling only; the shipped card bundle is unaffected.