### PR TITLE
(typescript) Enable noUncheckedIndexedAccess

### DIFF
--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -149,6 +149,7 @@ function classifyAtmoEntity(entityId: string): string | null {
   // Pollution: {fr_slug} without niveau_ or concentration_ prefix
   for (const canonical of ATMO_POLLUTION_ALLERGENS) {
     const frSlug = ATMO_ALLERGEN_MAP[canonical];
+    if (!frSlug) continue;
     if (
       id.includes(frSlug) &&
       !id.includes(`niveau_${frSlug}`) &&
@@ -312,7 +313,7 @@ function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
     );
     if (m) {
       if (debug) console.debug("[ATMO] auto-detected location:", m[2]);
-      return m[2];
+      return m[2] ?? null;
     }
   }
   // Fallback: try pollution entities
@@ -326,7 +327,7 @@ function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
           "[ATMO] auto-detected location from pollution entity:",
           m[2],
         );
-      return m[2];
+      return m[2] ?? null;
     }
   }
   // Fallback: try summary entities (qualite_globale_pollen_* or qualite_globale_*)
@@ -339,7 +340,7 @@ function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
           "[ATMO] auto-detected location from pollen summary entity:",
           mp[1],
         );
-      return mp[1];
+      return mp[1] ?? null;
     }
     // Match qualite_globale_{location} but not qualite_globale_pollen_*
     const mg = id.match(/^sensor\.qualite_globale_(?!pollen)(.+?)(?:_j_\d+)?$/);
@@ -349,7 +350,7 @@ function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
           "[ATMO] auto-detected location from global summary entity:",
           mg[1],
         );
-      return mg[1];
+      return mg[1] ?? null;
     }
   }
   return null;
@@ -497,7 +498,7 @@ export function resolveEntityIds(
           return false;
         return true;
       });
-      if (candidates.length === 1) sensorId = candidates[0];
+      if (candidates.length === 1) sensorId = candidates[0]!;
       else continue;
     }
     if (debug)
@@ -651,7 +652,8 @@ export async function fetchForecast(
       const sensorId = entityMap.get(allergen);
       if (!sensorId) continue;
 
-      const sensor = hass.states[sensorId];
+      // resolveEntityIds only maps ids it found in hass.states.
+      const sensor = hass.states[sensorId]!;
       dict.entity_id = sensorId;
 
       // Today's value

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -400,7 +400,7 @@ export function padForecastDates(
   }
   const forecastDates = upcoming.slice();
   let lastDate =
-    upcoming.length > 0 ? parseDate(upcoming[upcoming.length - 1]) : today;
+    upcoming.length > 0 ? parseDate(upcoming[upcoming.length - 1]!) : today;
   while (forecastDates.length < daysToShow) {
     lastDate = new Date(lastDate.getTime() + 86400000);
     const yyyy = lastDate.getFullYear();

--- a/src/adapters/dwd.ts
+++ b/src/adapters/dwd.ts
@@ -277,7 +277,7 @@ function dwdTemplateFallback({
         if (m[1] !== rawKey) return false;
         return regionId ? m[2] === String(regionId) : true;
       });
-      if (candidates.length === 1) sensorId = candidates[0];
+      if (candidates.length === 1) sensorId = candidates[0]!;
       else if (candidates.length > 1 && debug) {
         console.debug(
           `[DWD:resolveEntityIds] template fallback ambiguous for '${allergen}' (${candidates.length} candidates); skipping`,

--- a/src/adapters/gp/discovery.ts
+++ b/src/adapters/gp/discovery.ts
@@ -35,7 +35,7 @@ const UNIQUE_ID_RE = /^google_pollen_(.+?)_-?\d/;
 function codeFromUniqueId(uniqueId: string | undefined): string | null {
   if (!uniqueId) return null;
   const m = UNIQUE_ID_RE.exec(uniqueId);
-  return m ? m[1].toLowerCase() : null;
+  return m?.[1]?.toLowerCase() ?? null;
 }
 
 // Category codes used in unique_id for the three base category sensors.

--- a/src/adapters/gp/forecast.ts
+++ b/src/adapters/gp/forecast.ts
@@ -83,7 +83,8 @@ export async function fetchForecast(
       const sensorId = entityMap.get(allergen);
       if (!sensorId) continue;
 
-      const sensor = hass.states[sensorId];
+      // resolveEntityIds only maps ids it found in hass.states.
+      const sensor = hass.states[sensorId]!;
       dict.entity_id = sensorId;
 
       if (debug) {
@@ -101,7 +102,7 @@ export async function fetchForecast(
 
       for (let i = 0; i < FORECAST_ATTRS.length; i++) {
         if (levels.length >= days_to_show) break;
-        const attrKey = FORECAST_ATTRS[i];
+        const attrKey = FORECAST_ATTRS[i]!;
         const val = sensor.attributes?.[attrKey];
         const offset =
           attrKey === "tomorrow"

--- a/src/adapters/gpl/forecast.ts
+++ b/src/adapters/gpl/forecast.ts
@@ -166,7 +166,8 @@ export async function fetchForecast(
       const sensorId = entityMap.get(allergen);
       if (!sensorId) continue;
 
-      const sensor = hass.states[sensorId];
+      // resolveEntityIds only maps ids it found in hass.states.
+      const sensor = hass.states[sensorId]!;
       dict.entity_id = sensorId;
 
       // Summary block (issue #222): tag the aggregate and enrich it with the
@@ -299,7 +300,7 @@ export async function fetchForecast(
       const levels = entries
         .filter((e) => e.date.getTime() - today.getTime() >= 0)
         .sort((a, b) => a.date.getTime() - b.date.getTime());
-      if (!levels.length || levels[0].date.getTime() - today.getTime() > 0) {
+      if (!levels.length || levels[0]!.date.getTime() - today.getTime() > 0) {
         levels.unshift({ date: today, level: -1 });
       }
       levels.splice(days_to_show);
@@ -308,7 +309,8 @@ export async function fetchForecast(
       // array index): forecast items are placed by their `date`, so an
       // index-based date could collide with a date already in the list.
       while (levels.length < days_to_show) {
-        const last = levels[levels.length - 1].date;
+        // The unshift above guarantees at least one entry.
+        const last = levels[levels.length - 1]!.date;
         const next = new Date(last.getTime() + 36 * 3600000);
         next.setHours(0, 0, 0, 0);
         levels.push({ date: next, level: -1 });

--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -93,7 +93,7 @@ function classifyIrmkmiEntity(eid: string): string | null {
   if (typeof eid !== "string") return null;
   const m = IRMKMI_LEVEL_RE.exec(eid);
   if (!m) return null;
-  return IRMKMI_POLLEN_TYPES[m[1]] || null;
+  return IRMKMI_POLLEN_TYPES[m[1] ?? ""] || null;
 }
 
 // Extract the location slug from an IRM KMI entity_id
@@ -111,7 +111,7 @@ export function extractIrmkmiLocationSlugFromEntityId(
 ): string | null {
   if (typeof eid !== "string") return null;
   const m = IRMKMI_LOCATION_SLUG_RE.exec(eid);
-  return m ? m[1] : null;
+  return m?.[1] ?? null;
 }
 
 export const stubConfigIRMKMI: AdapterStubConfig = {

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -231,7 +231,7 @@ function resolveKleenexLabel(ctx: DiscoveryContext): string {
     // Default device name is "Kleenex Pollen Radar (<instance>)"; the instance
     // is what the user configured as the location.
     const m = /^Kleenex Pollen Radar\s*\((.+)\)\s*$/.exec(device.name);
-    if (m) return m[1].trim();
+    if (m?.[1]) return m[1].trim();
     return device.name;
   }
 
@@ -491,7 +491,7 @@ export function resolveKleenexLocationEntry(
       if (step.length === 0) continue;
       // The first step with any match decides; more than one match there means
       // the config value cannot say which location it meant.
-      return step.length > 1 ? "ambiguous" : step[0];
+      return step.length > 1 ? "ambiguous" : step[0]!;
     }
     return null;
   }
@@ -691,10 +691,10 @@ export function resolveEntityIds(
             if (!afterPrefix.startsWith(locationSlug + "_")) return false;
           }
           const parts = id.split("_");
-          const suffix = parts[parts.length - 1];
+          const suffix = parts[parts.length - 1] ?? "";
           return possiblePrefixes.some((lp) => suffix.startsWith(lp));
         });
-        if (candidates.length >= 1) sensorId = candidates[0];
+        if (candidates.length >= 1) sensorId = candidates[0]!;
       }
     }
 

--- a/src/adapters/kleenex/forecast.ts
+++ b/src/adapters/kleenex/forecast.ts
@@ -837,7 +837,8 @@ export async function fetchForecast(
 
       // Build day objects for card display
       for (let i = 0; i < days_to_show; i++) {
-        const dayData = levels[i];
+        // levels was padded to days_to_show entries above.
+        const dayData = levels[i]!;
         const d = dayData.date;
         const diff = Math.round((d.getTime() - today.getTime()) / 86400000);
 

--- a/src/adapters/kleenex/levels.ts
+++ b/src/adapters/kleenex/levels.ts
@@ -12,7 +12,7 @@ export function ppmToLevel(value: unknown, allergenName: string): number {
   const category = KLEENEX_ALLERGEN_CATEGORIES[allergenName] || "trees"; // Default to trees
 
   // Category-specific thresholds: [low, moderate, high] -> levels 1, 2, 3, with 4 being very-high
-  let thresholds: number[];
+  let thresholds: [number, number, number];
   switch (category) {
     case "trees":
       thresholds = [95, 207, 703];

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -85,7 +85,7 @@ function classifyMswEntity(eid: string): string | null {
   if (typeof eid !== "string") return null;
   const m = MSW_LEVEL_RE.exec(eid);
   if (!m) return null;
-  return MSW_POLLEN_TYPES[m[1]] || null;
+  return MSW_POLLEN_TYPES[m[1] ?? ""] || null;
 }
 
 export const stubConfigMSW: AdapterStubConfig = {

--- a/src/adapters/peu.ts
+++ b/src/adapters/peu.ts
@@ -243,7 +243,7 @@ export function discoverPeuSensors(
           .replace(/^\s*polleninformation\b[\s:\-–—]*/i, "")
           .trim();
         const paren = stripped.match(/^\(([^)]+)\)$/);
-        if (paren) return paren[1].trim();
+        if (paren?.[1]) return paren[1].trim();
         if (stripped) return stripped;
         return rawName.trim();
       }
@@ -285,10 +285,10 @@ function detectLocation(cfg: CardConfig, hass: HomeAssistant): string {
       id.startsWith("sensor.polleninformation_"),
     );
     if (peuStates.length) {
-      const match = peuStates[0].match(
+      const match = peuStates[0]!.match(
         /^sensor\.polleninformation_(.+)_[^_]+$/,
       );
-      locationSlug = match ? match[1] : "";
+      locationSlug = match?.[1] ?? "";
     }
   }
   return locationSlug;
@@ -342,7 +342,7 @@ function peuTemplateFallback({
         }
         return (!locationSlug || loc === locationSlug) && allg === allergenSlug;
       });
-      if (cands.length === 1) sensorId = cands[0];
+      if (cands.length === 1) sensorId = cands[0]!;
       else continue;
     }
     if (debug) {
@@ -624,7 +624,7 @@ export async function fetchForecast(
         );
         if (idx > 0) {
           const [special] = sensors.splice(idx, 1);
-          sensors.unshift(special);
+          sensors.unshift(special!);
         }
       }
       if (ctx.debug) console.debug("PEU.fetchForecast — done", sensors);

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -539,7 +539,7 @@ export const autodetect: AdapterAutodetect = {
       if (typeof id !== "string") return false;
       const match = /^sensor\.pollen_([^_]+)$/.exec(id);
       if (!match) return false;
-      return ctx.pluAllergenSlugs.has(match[1]);
+      return ctx.pluAllergenSlugs.has(match[1] ?? "");
     });
     return { ids };
   },

--- a/src/adapters/pp.ts
+++ b/src/adapters/pp.ts
@@ -229,7 +229,7 @@ function detectCity(cfg: CardConfig, hass: HomeAssistant): string {
       (id) => extractCitySlugFromEntityId(id) !== null,
     );
     if (ppStates.length) {
-      cityKey = extractCitySlugFromEntityId(ppStates[0]) || "";
+      cityKey = extractCitySlugFromEntityId(ppStates[0]!) || "";
     }
   }
   return cityKey;
@@ -262,7 +262,7 @@ function ppTemplateFallback({
       const cands = Object.keys(hass.states).filter(
         (id) => id.startsWith(base) && id.endsWith(`_${rawKey}`),
       );
-      if (cands.length === 1) sensorId = cands[0];
+      if (cands.length === 1) sensorId = cands[0]!;
       else continue;
     }
     if (debug) {
@@ -373,7 +373,7 @@ function buildPpDict({
         // display_state mirrors state: PP has no separate display value, so the
         // contract's always-present display_state carries the same level.
         display_state: level,
-        state_text: ctx.levelNames[level],
+        state_text: ctx.levelNames[level]!,
       };
       dict.days.push(dayObj);
     } else if (ctx.pollen_threshold === 0) {
@@ -444,7 +444,7 @@ export const autodetect: AdapterAutodetect = {
       const match = /^sensor\.pollen_([^_]+)(_.*)?$/.exec(id);
       if (!match) return false;
 
-      const allergenSlug = match[1];
+      const allergenSlug = match[1] ?? "";
       // Single underscore AND a known PLU allergen -> likely PLU, not PP.
       if (!match[2] && ctx.pluAllergenSlugs.has(allergenSlug)) return false;
 

--- a/src/adapters/silam.ts
+++ b/src/adapters/silam.ts
@@ -131,12 +131,13 @@ export function grainsToLevel(allergen: string, grains: number): number {
   const arr = SILAM_THRESHOLDS[allergen];
   if (!arr) return -1;
   if (isNaN(grains)) return -1;
-  if (grains < arr[0]) return 0;
-  if (grains < arr[1]) return 1;
-  if (grains < arr[2]) return 2;
-  if (grains < arr[3]) return 3;
-  if (grains < arr[4]) return 4;
-  if (grains < arr[5]) return 5;
+  // Every threshold row is a fixed six-step ladder (see SILAM_THRESHOLDS).
+  if (grains < arr[0]!) return 0;
+  if (grains < arr[1]!) return 1;
+  if (grains < arr[2]!) return 2;
+  if (grains < arr[3]!) return 3;
+  if (grains < arr[4]!) return 4;
+  if (grains < arr[5]!) return 5;
   return 6;
 }
 
@@ -181,12 +182,13 @@ export function indexToLevel(val: unknown): number {
   };
   if (typeof val === "string") {
     const idx = map[val.toLowerCase()];
-    return idx == null ? -1 : scale[Math.max(0, Math.min(idx, 4))];
+    // The index is clamped to 0-4 and the spread has exactly five entries.
+    return idx == null ? -1 : scale[Math.max(0, Math.min(idx, 4))]!;
   }
   const num = Number(val);
   if (!isNaN(num)) {
     const idx = Math.max(0, Math.min(Math.round(num), 4));
-    return scale[idx];
+    return scale[idx]!;
   }
   return -1;
 }
@@ -432,7 +434,8 @@ export async function fetchForecast(
     }
   }
 
-  const entity = hass.states[weatherEntity];
+  // Both branches above returned early unless hass.states holds the entity.
+  const entity = hass.states[weatherEntity]!;
   const rawAllergens =
     (config.allergens as string[] | undefined) ||
     (stubConfigSILAM.allergens as string[]);
@@ -593,7 +596,8 @@ export async function fetchForecast(
 
       // Fyll dag-objekt för kortet
       for (let i = 0; i < maxItems; ++i) {
-        const scaled = stateList[i];
+        // Every branch above pushed exactly maxItems entries onto stateList.
+        const scaled = stateList[i]!;
         let label: string;
         let icon: string | null;
         let d: Date;
@@ -637,7 +641,7 @@ export async function fetchForecast(
         // than our level-0 label ("No pollen").
         const stateText =
           autoAddedAllergyRisk && allergen === "allergy_risk" && scaled === 0
-            ? t("card.index.very_low", lang) || levelNames[0]
+            ? t("card.index.very_low", lang) || levelNames[0]!
             : scaled < 0
               ? noInfoLabel
               : levelNames[lvlIndex] || String(scaled);
@@ -683,7 +687,7 @@ export async function fetchForecast(
     );
     if (idx > 0) {
       const [special] = sensors.splice(idx, 1);
-      sensors.unshift(special);
+      sensors.unshift(special!);
     }
   }
 

--- a/src/editor/sections/allergen-icons.ts
+++ b/src/editor/sections/allergen-icons.ts
@@ -131,7 +131,7 @@ export function renderAllergenIconsSection(
                               onClick: () => {
                                 const newColors = [...allergenColors];
                                 newColors[i] =
-                                  LEVELS_DEFAULTS.allergen_colors[i];
+                                  LEVELS_DEFAULTS.allergen_colors[i]!;
                                 editor._updateConfig(
                                   "allergen_colors",
                                   newColors,

--- a/src/editor/sections/level-circles.ts
+++ b/src/editor/sections/level-circles.ts
@@ -105,7 +105,7 @@ export function renderLevelCirclesSection(
                         style: "margin-left: 8px;",
                         onClick: () => {
                           const newColors = [...levelsColors];
-                          newColors[i] = LEVELS_DEFAULTS.levels_colors[i];
+                          newColors[i] = LEVELS_DEFAULTS.levels_colors[i]!;
                           editor._updateConfig("levels_colors", newColors);
                         },
                       })}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -15,8 +15,9 @@ const localeModules = import.meta.glob<{ default: LocaleData }>(
 const LOCALES: Record<string, LocaleData> = {};
 for (const filePath in localeModules) {
   const match = filePath.match(/\.\/locales\/([\w-]+)\.json$/);
-  if (match) {
-    LOCALES[match[1]] = localeModules[filePath].default;
+  const code = match?.[1];
+  if (code) {
+    LOCALES[code] = localeModules[filePath]!.default;
   }
 }
 

--- a/src/pollenprognos-badge-editor.ts
+++ b/src/pollenprognos-badge-editor.ts
@@ -208,7 +208,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       ? toList(ppDiscovery)
       : Array.from(
           new Set(
-            detection.states.pp
+            (detection.states.pp ?? [])
               .map((id: string) => extractPpCitySlugFromEntityId(id))
               .filter(Boolean),
           ),
@@ -218,7 +218,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
     this.installedDwdLocations = dwdDiscovery.locations.size
       ? toList(dwdDiscovery)
       : Array.from(
-          new Set(detection.states.dwd.map((id: string) => id.split("_").pop())),
+          new Set((detection.states.dwd ?? []).map((id: string) => id.split("_").pop())),
         )
           .sort((a, b) => Number(a) - Number(b))
           .map((id) => [id, id] as InstalledLocation);
@@ -228,7 +228,7 @@ class PollenPrognosBadgeEditor extends PollenEditorBase {
       ? toList(peuDiscovery)
       : Array.from(
           new Set(
-            detection.states.peu
+            (detection.states.peu ?? [])
               .map(
                 (eid: string) =>
                   hass.states[eid]?.attributes?.location_slug || null,

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -229,10 +229,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
     let targetLocation =
       this.config.location === "manual" ? "" : this.config.location;
     if (!targetLocation && this.config.location !== "manual") {
-      const match = peuStates[0].match(
+      const match = peuStates[0]!.match(
         /^sensor\.polleninformation_(.+)_[^_]+$/,
       );
-      targetLocation = match ? match[1] : "";
+      targetLocation = match?.[1] ?? "";
     }
 
     if (!targetLocation) {
@@ -1022,7 +1022,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
               /^sensor\.silam_pollen_(.*)_([^_]+)$/,
             );
             if (!match) return false;
-            return SilamValidAllergenSlugs.has(match[2]);
+            return SilamValidAllergenSlugs.has(match[2] ?? "");
           });
           const wantedSlug = slugify(cfg.location as string);
           const match = wantedSlug
@@ -1827,8 +1827,8 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
                 this.config.show_block_separator &&
                 sIdx > 0 &&
                 sensor.group &&
-                rowSensors[sIdx - 1].group &&
-                sensor.group !== rowSensors[sIdx - 1].group
+                rowSensors[sIdx - 1]?.group &&
+                sensor.group !== rowSensors[sIdx - 1]?.group
                   ? html`<tr class="block-separator-row">
                       <td colspan="${totalCols}">
                         <hr class="block-separator" />

--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -518,21 +518,21 @@ class PollenPrognosCardEditor extends PollenEditorBase {
           !this._userConfig.region_id &&
           this.installedDwdLocations.length
         ) {
-          this._config.region_id = this.installedDwdLocations[0][0];
+          this._config.region_id = this.installedDwdLocations[0]![0];
         }
         if (
           integration === "pp" &&
           !this._userConfig.city &&
           this.installedPpLocations.length
         ) {
-          this._config.city = this.installedPpLocations[0][0];
+          this._config.city = this.installedPpLocations[0]![0];
         }
         if (
           integration === "silam" &&
           !this._userConfig.location &&
           this.installedSilamLocations.length
         ) {
-          this._config.location = this.installedSilamLocations[0][0];
+          this._config.location = this.installedSilamLocations[0]![0];
         }
       }
 
@@ -574,7 +574,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       if (this._config.integration === "gpl" && this._hass) {
         const gplDiscovery = discoverGplSensors(this._hass, false);
         this.installedGplLocations = discoveryToLocations(gplDiscovery);
-        const gplConfigEntryId = this._config.location || (this.installedGplLocations.length ? this.installedGplLocations[0][0] : null);
+        const gplConfigEntryId = this._config.location || (this.installedGplLocations.length ? this.installedGplLocations[0]![0] : null);
         const allGplAllergens = discoverGplAllergens(this._hass, gplConfigEntryId as string, false);
         this.installedGplPlants = allGplAllergens.filter((k: string) => !GPL_BASE_ALLERGENS.includes(k));
       }
@@ -582,7 +582,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       if (this._config.integration === "gp" && this._hass) {
         const gpDiscovery = discoverGpSensors(this._hass, false);
         this.installedGpLocations = discoveryToLocations(gpDiscovery);
-        const gpConfigEntryId = this._config.location || (this.installedGpLocations.length ? this.installedGpLocations[0][0] : null);
+        const gpConfigEntryId = this._config.location || (this.installedGpLocations.length ? this.installedGpLocations[0]![0] : null);
         const allGpAllergens = discoverGpAllergens(this._hass, gpConfigEntryId as string, false);
         this.installedGpPlants = allGpAllergens.filter((k: string) => !GP_BASE_ALLERGENS.includes(k));
       }
@@ -622,7 +622,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     // Other per-integration state lists are only needed for the pick, which is
     // handled inside the shared module.
     const {
-      states: { pp: ppStates, dwd: dwdStates },
+      states: { pp: ppStates = [], dwd: dwdStates = [] },
       discovery: {
         silam: silamDiscovery,
         atmo: atmoDiscovery,
@@ -664,7 +664,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     this.installedGplLocations = discoveryToLocations(gplDiscovery);
 
     if (integration === "gpl") {
-      const gplConfigEntryId = this._config.location || (this.installedGplLocations.length ? this.installedGplLocations[0][0] : null);
+      const gplConfigEntryId = this._config.location || (this.installedGplLocations.length ? this.installedGplLocations[0]![0] : null);
       const allGplAllergens = discoverGplAllergens(hass, gplConfigEntryId as string, false);
       this.installedGplPlants = allGplAllergens.filter((k: string) => !GPL_BASE_ALLERGENS.includes(k));
     } else {
@@ -676,7 +676,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
     this.installedGpLocations = discoveryToLocations(gpDiscovery);
 
     if (integration === "gp") {
-      const gpConfigEntryId = this._config.location || (this.installedGpLocations.length ? this.installedGpLocations[0][0] : null);
+      const gpConfigEntryId = this._config.location || (this.installedGpLocations.length ? this.installedGpLocations[0]![0] : null);
       const allGpAllergens = discoverGpAllergens(hass, gpConfigEntryId as string, false);
       this.installedGpPlants = allGpAllergens.filter((k: string) => !GP_BASE_ALLERGENS.includes(k));
     } else {
@@ -922,7 +922,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                   /^sensor\.silam_pollen_(.*)_([^_]+)$/,
                 );
                 if (!match) return false;
-                const allergenSlug = match[2];
+                const allergenSlug = match[2] ?? "";
                 return SilamValidAllergenSlugs.has(allergenSlug);
               })
               .map((s) => {
@@ -930,7 +930,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                   /^sensor\.silam_pollen_(.*)_([^_]+)$/,
                 );
                 const rawLocation = match
-                  ? match[1].replace(/^[-\s]+/, "")
+                  ? (match[1] ?? "").replace(/^[-\s]+/, "")
                   : "";
                 const locationSlug = slugify(rawLocation);
 
@@ -978,7 +978,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
                 );
                 if (!match) return null;
 
-                const locationSlug = match[1];
+                const locationSlug = match[1] ?? "";
                 let title = s.attributes?.friendly_name || locationSlug;
 
                 // Clean up the title to show only the location
@@ -1074,63 +1074,63 @@ class PollenPrognosCardEditor extends PollenEditorBase {
           !this._userConfig.region_id &&
           this.installedDwdLocations.length
         ) {
-          this._config.region_id = this.installedDwdLocations[0][0];
+          this._config.region_id = this.installedDwdLocations[0]![0];
         }
         if (
           integration === "pp" &&
           !this._userConfig.city &&
           this.installedPpLocations.length
         ) {
-          this._config.city = this.installedPpLocations[0][0];
+          this._config.city = this.installedPpLocations[0]![0];
         }
         if (
           integration === "silam" &&
           !this._userConfig.location &&
           this.installedSilamLocations.length
         ) {
-          this._config.location = this.installedSilamLocations[0][0];
+          this._config.location = this.installedSilamLocations[0]![0];
         }
         if (
           integration === "kleenex" &&
           !this._userConfig.location &&
           this.installedKleenexLocations.length
         ) {
-          this._config.location = this.installedKleenexLocations[0][0];
+          this._config.location = this.installedKleenexLocations[0]![0];
         }
         if (
           integration === "atmo" &&
           !this._userConfig.location &&
           this.installedAtmoLocations.length
         ) {
-          this._config.location = this.installedAtmoLocations[0][0];
+          this._config.location = this.installedAtmoLocations[0]![0];
         }
         if (
           integration === "gpl" &&
           !this._userConfig.location &&
           this.installedGplLocations.length
         ) {
-          this._config.location = this.installedGplLocations[0][0];
+          this._config.location = this.installedGplLocations[0]![0];
         }
         if (
           integration === "gp" &&
           !this._userConfig.location &&
           this.installedGpLocations?.length
         ) {
-          this._config.location = this.installedGpLocations[0][0];
+          this._config.location = this.installedGpLocations[0]![0];
         }
         if (
           integration === "msw" &&
           !this._userConfig.location &&
           this.installedMswLocations?.length
         ) {
-          this._config.location = this.installedMswLocations[0][0];
+          this._config.location = this.installedMswLocations[0]![0];
         }
         if (
           integration === "irmkmi" &&
           !this._userConfig.location &&
           this.installedIrmkmiLocations?.length
         ) {
-          this._config.location = this.installedIrmkmiLocations[0][0];
+          this._config.location = this.installedIrmkmiLocations[0]![0];
         }
       }
 

--- a/src/rendering/level-circle-mixin.ts
+++ b/src/rendering/level-circle-mixin.ts
@@ -185,13 +185,13 @@ export const LevelCircleMixin = <T extends Constructor<LitElement>>(Base: T) =>
       if (this.config?.allergen_color_mode === "custom" && this.config?.allergen_colors) {
         const allergenColors = this.config.allergen_colors as string[];
         const clampedLevel = Math.max(0, Math.min(level, allergenColors.length - 1));
-        return allergenColors[clampedLevel] || allergenColors[0];
+        return allergenColors[clampedLevel] || allergenColors[0]!;
       }
 
       // Default: use default allergen colors (which includes empty color at index 0)
       const defaultColors = LEVELS_DEFAULTS.allergen_colors;
       const clampedLevel = Math.max(0, Math.min(level, defaultColors.length - 1));
-      return defaultColors[clampedLevel] || defaultColors[0];
+      return defaultColors[clampedLevel] || defaultColors[0]!;
     }
 
     /**
@@ -220,7 +220,7 @@ export const LevelCircleMixin = <T extends Constructor<LitElement>>(Base: T) =>
         (this.config?.levels_colors as string[]) || LEVELS_DEFAULTS.levels_colors;
       const colorIndex = level - 1; // Map level 1->0, 2->1, etc.
       const clampedIndex = Math.max(0, Math.min(colorIndex, colors.length - 1));
-      return colors[clampedIndex] || colors[0];
+      return colors[clampedIndex] || colors[0]!;
     }
 
     /**

--- a/src/utils/adapter-helpers.ts
+++ b/src/utils/adapter-helpers.ts
@@ -513,7 +513,7 @@ export function clampLevel<N = number>(
  */
 export function parseLocalDate(dateStr: unknown): Date | null {
   if (typeof dateStr !== "string") return null;
-  const [ymd] = dateStr.split("T");
+  const ymd = dateStr.split("T")[0] ?? "";
   const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
   if (!m) return null;
   const date = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
@@ -764,7 +764,8 @@ function getCanonicalPhraseIndex(phrases: PhraseMap): Record<string, string> {
   const isAlias = (k: string) =>
     Object.prototype.hasOwnProperty.call(ALLERGEN_TRANSLATION, k);
   for (const rawKey of Object.keys(phrases)) {
-    const value = phrases[rawKey];
+    // rawKey comes from Object.keys(phrases), so the lookup is always present.
+    const value = phrases[rawKey]!;
     const addCanon = (canon: unknown) => {
       if (typeof canon === "string" && canon && !(canon in idx))
         idx[canon] = value;
@@ -887,7 +888,7 @@ export function resolveManualEntity(
     const candidates = Object.keys(hass.states).filter((id) =>
       id.startsWith(base),
     );
-    if (candidates.length === 1) return candidates[0];
+    if (candidates.length === 1) return candidates[0]!;
   }
   return null;
 }
@@ -980,9 +981,11 @@ export function filterSensorsPostFetch(
         const m = id.match(/^sensor\.silam_pollen_(.*)_([^_]+)$/);
         if (!m || m[1] !== silamLoc) continue;
         const haSlug = m[2];
+        if (!haSlug) continue;
         for (const [, mapping] of Object.entries(silamMapping)) {
-          if (mapping[haSlug]) {
-            silamReverse[mapping[haSlug]] = haSlug;
+          const canon = mapping[haSlug];
+          if (canon) {
+            silamReverse[canon] = haSlug;
             break;
           }
         }
@@ -1498,7 +1501,8 @@ export function resolveLocationByKey(
     const sortedKeys = allNumeric
       ? keys.sort((a, b) => Number(a) - Number(b))
       : keys.sort();
-    const key = sortedKeys[0];
+    // locs.size > 0 was checked above, so sortedKeys[0] exists.
+    const key = sortedKeys[0]!;
     return [key, locs.get(key)!];
   }
 

--- a/src/utils/silam.ts
+++ b/src/utils/silam.ts
@@ -277,7 +277,7 @@ export function findSilamWeatherEntity(
   // 1. Testa suffixar för aktuell locale
   const suffixesLocale =
     silamAllergenMap.weather_suffixes?.[locale] ||
-    silamAllergenMap.weather_suffixes?.[locale?.split("-")[0]] ||
+    silamAllergenMap.weather_suffixes?.[locale?.split("-")[0] ?? ""] ||
     [];
   for (const suffix of suffixesLocale) {
     tried.add(suffix);

--- a/test/adapters/atmo.test.ts
+++ b/test/adapters/atmo.test.ts
@@ -67,7 +67,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("sets entity_id on each sensor dict", async () => {
@@ -76,7 +76,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.niveau_bouleau_paris");
+      expect(result[0]!.entity_id).toBe("sensor.niveau_bouleau_paris");
     });
 
     it("each day object has required properties", async () => {
@@ -84,7 +84,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const config = makeConfig({ location: "paris", allergens: ["birch"] });
 
       const result = await fetchForecast(hass, config);
-      const day = result[0].days[0];
+      const day = result[0]!.days[0]!;
 
       expect(day).toHaveProperty("name");
       expect(day).toHaveProperty("day");
@@ -106,10 +106,10 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days.length).toBe(2);
-      expect(result[0].days[0]).toBeDefined();
-      expect(result[0].days[1]).toBeDefined();
-      expect(result[0].days[2]).toBeUndefined();
+      expect(result[0]!.days.length).toBe(2);
+      expect(result[0]!.days[0]).toBeDefined();
+      expect(result[0]!.days[1]).toBeDefined();
+      expect(result[0]!.days[2]).toBeUndefined();
     });
 
     it("fills j+1 with state -1 when tomorrow entity is absent", async () => {
@@ -119,8 +119,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[1].state).toBe(-1);
-      expect(result[0].days[1].display_state).toBe(-1);
+      expect(result[0]!.days[1]!.state).toBe(-1);
+      expect(result[0]!.days[1]!.display_state).toBe(-1);
     });
   });
 
@@ -139,8 +139,8 @@ describe("ATMO adapter: fetchForecast", () => {
       // state normalized to the no-data sentinel (matches display_state) so the
       // ring, which reads state, renders the no-data pattern rather than a
       // misleading green level-0 ring for "Indisponible".
-      expect(result[0].days[0].state).toBe(-1);
-      expect(result[0].days[0].display_state).toBe(-1);
+      expect(result[0]!.days[0]!.state).toBe(-1);
+      expect(result[0]!.days[0]!.display_state).toBe(-1);
     });
 
     it("maps levels 1-6 to state=raw and display_state=raw", async () => {
@@ -154,8 +154,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
         const result = await fetchForecast(hass, config);
 
-        expect(result[0].days[0].state).toBe(level);
-        expect(result[0].days[0].display_state).toBe(level);
+        expect(result[0]!.days[0]!.state).toBe(level);
+        expect(result[0]!.days[0]!.display_state).toBe(level);
       }
     });
 
@@ -171,8 +171,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       // Événement (raw 7) is capped to 6 on both state and display_state so the
       // raw event code never leaves the adapter.
-      expect(result[0].days[0].state).toBe(6);
-      expect(result[0].days[0].display_state).toBe(6);
+      expect(result[0]!.days[0]!.state).toBe(6);
+      expect(result[0]!.days[0]!.display_state).toBe(6);
     });
 
     it("maps NaN/unavailable to state=-1 and display_state=-1", async () => {
@@ -195,8 +195,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state).toBe(-1);
-      expect(result[0].days[0].display_state).toBe(-1);
+      expect(result[0]!.days[0]!.state).toBe(-1);
+      expect(result[0]!.days[0]!.display_state).toBe(-1);
     });
 
     it("uses localized label for level 0 (Indisponible) in French UI", async () => {
@@ -215,7 +215,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state_text).toBe("Indisponible");
+      expect(result[0]!.days[0]!.state_text).toBe("Indisponible");
     });
 
     it("uses localized label for level 0 in non-French UI even when Libelle is French", async () => {
@@ -236,7 +236,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state_text).toBe("Otillgänglig");
+      expect(result[0]!.days[0]!.state_text).toBe("Otillgänglig");
     });
 
     it("uses localized label for level 7 (Événement) in French UI", async () => {
@@ -255,7 +255,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state_text).toBe("Événement");
+      expect(result[0]!.days[0]!.state_text).toBe("Événement");
     });
 
     it("uses localized label for level 7 in non-French UI", async () => {
@@ -274,7 +274,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state_text).toBe("Händelse");
+      expect(result[0]!.days[0]!.state_text).toBe("Händelse");
     });
   });
 
@@ -291,7 +291,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
         const result = await fetchForecast(hass, config);
 
-        expect(result[0].group).toBe("pollen");
+        expect(result[0]!.group).toBe("pollen");
       }
     });
 
@@ -304,7 +304,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].group).toBe("pollen");
+      expect(result[0]!.group).toBe("pollen");
     });
 
     it("sets group='pollution' for pollution allergens", async () => {
@@ -318,7 +318,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
         const result = await fetchForecast(hass, config);
 
-        expect(result[0].group).toBe("pollution");
+        expect(result[0]!.group).toBe("pollution");
       }
     });
 
@@ -331,7 +331,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].group).toBe("pollution");
+      expect(result[0]!.group).toBe("pollution");
     });
   });
 
@@ -376,8 +376,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].group).toBe("pollution");
-      expect(result[1].group).toBe("pollen");
+      expect(result[0]!.group).toBe("pollution");
+      expect(result[1]!.group).toBe("pollen");
     });
 
     it("sorts within pollen block by value_descending", async () => {
@@ -398,8 +398,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const pollenResults = result.filter((s) => s.group === "pollen");
       for (let i = 0; i < pollenResults.length - 1; i++) {
-        expect(pollenResults[i].days[0].display_state).toBeGreaterThanOrEqual(
-          pollenResults[i + 1].days[0].display_state as number,
+        expect(pollenResults[i]!.days[0]!.display_state).toBeGreaterThanOrEqual(
+          pollenResults[i + 1]!.days[0]!.display_state as number,
         );
       }
     });
@@ -422,8 +422,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const pollutionResults = result.filter((s) => s.group === "pollution");
       for (let i = 0; i < pollutionResults.length - 1; i++) {
-        expect(pollutionResults[i].days[0].display_state).toBeGreaterThanOrEqual(
-          pollutionResults[i + 1].days[0].display_state as number,
+        expect(pollutionResults[i]!.days[0]!.display_state).toBeGreaterThanOrEqual(
+          pollutionResults[i + 1]!.days[0]!.display_state as number,
         );
       }
     });
@@ -448,7 +448,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       const pollenResults = result.filter((s) => s.group === "pollen");
-      expect(pollenResults[0].allergenReplaced).toBe("allergy_risk");
+      expect(pollenResults[0]!.allergenReplaced).toBe("allergy_risk");
     });
 
     it("pins qualite_globale to top of pollution block when allergy_risk_top=true", async () => {
@@ -468,7 +468,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       const pollutionResults = result.filter((s) => s.group === "pollution");
-      expect(pollutionResults[0].allergenReplaced).toBe("qualite_globale");
+      expect(pollutionResults[0]!.allergenReplaced).toBe("qualite_globale");
     });
 
     it("does not pin when allergy_risk_top=false", async () => {
@@ -489,7 +489,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const pollenResults = result.filter((s) => s.group === "pollen");
       // allergy_risk has the lowest value so it should be last
-      expect(pollenResults[pollenResults.length - 1].allergenReplaced).toBe("allergy_risk");
+      expect(pollenResults[pollenResults.length - 1]!.allergenReplaced).toBe("allergy_risk");
     });
 
     it("pins both summaries to absolute top when sort_pollution_block=false", async () => {
@@ -524,7 +524,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.niveau_bouleau_paris");
+      expect(result[0]!.entity_id).toBe("sensor.niveau_bouleau_paris");
     });
 
     it("pollution allergens do not use niveau_ prefix", async () => {
@@ -533,7 +533,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.pm25_paris");
+      expect(result[0]!.entity_id).toBe("sensor.pm25_paris");
     });
 
     it("allergy_risk uses qualite_globale_pollen_ pattern", async () => {
@@ -542,7 +542,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.qualite_globale_pollen_paris");
+      expect(result[0]!.entity_id).toBe("sensor.qualite_globale_pollen_paris");
     });
 
     it("qualite_globale uses qualite_globale_ pattern (no pollen suffix)", async () => {
@@ -551,7 +551,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.qualite_globale_paris");
+      expect(result[0]!.entity_id).toBe("sensor.qualite_globale_paris");
     });
 
     it("forecast j+1 appends _j_1 to base entity ID", async () => {
@@ -564,8 +564,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state).toBe(3);
-      expect(result[0].days[1].state).toBe(2);
+      expect(result[0]!.days[0]!.state).toBe(3);
+      expect(result[0]!.days[1]!.state).toBe(2);
     });
 
     it("no2 maps to dioxyde_d_azote entity slug", async () => {
@@ -574,7 +574,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.dioxyde_d_azote_paris");
+      expect(result[0]!.entity_id).toBe("sensor.dioxyde_d_azote_paris");
     });
 
     it("so2 maps to dioxyde_de_soufre entity slug", async () => {
@@ -583,7 +583,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe("sensor.dioxyde_de_soufre_paris");
+      expect(result[0]!.entity_id).toBe("sensor.dioxyde_de_soufre_paris");
     });
   });
 
@@ -607,7 +607,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pfx_niveau_bouleau_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.pfx_niveau_bouleau_sfx");
     });
 
     it("pollution allergens in manual mode use bare slug stem", async () => {
@@ -628,7 +628,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pfx_pm25_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.pfx_pm25_sfx");
     });
 
     it("allergy_risk in manual mode uses qualite_globale_pollen stem", async () => {
@@ -649,7 +649,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pfx_qualite_globale_pollen_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.pfx_qualite_globale_pollen_sfx");
     });
 
     it("qualite_globale in manual mode uses qualite_globale stem", async () => {
@@ -670,7 +670,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pfx_qualite_globale_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.pfx_qualite_globale_sfx");
     });
 
     it("manual mode reads j+1 from {sensorId}_j_1", async () => {
@@ -695,8 +695,8 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state).toBe(3);
-      expect(result[0].days[1].state).toBe(5);
+      expect(result[0]!.days[0]!.state).toBe(3);
+      expect(result[0]!.days[1]!.state).toBe(5);
     });
   });
 
@@ -716,7 +716,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("includes allergens when any day meets pollen_threshold", async () => {
@@ -832,8 +832,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].display_state).toBeGreaterThanOrEqual(
-        result[1].days[0].display_state as number,
+      expect(result[0]!.days[0]!.display_state).toBeGreaterThanOrEqual(
+        result[1]!.days[0]!.display_state as number,
       );
     });
 
@@ -852,8 +852,8 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].display_state).toBeLessThanOrEqual(
-        result[1].days[0].display_state as number,
+      expect(result[0]!.days[0]!.display_state).toBeLessThanOrEqual(
+        result[1]!.days[0]!.display_state as number,
       );
     });
 
@@ -875,7 +875,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // alder (display_state=3) should be last
-      expect(result[result.length - 1].allergenReplaced).toBe("alder");
+      expect(result[result.length - 1]!.allergenReplaced).toBe("alder");
     });
   });
 
@@ -892,7 +892,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.niveau_bouleau_lyon");
+      expect(result[0]!.entity_id).toBe("sensor.niveau_bouleau_lyon");
     });
 
     it("auto-detects location from pollution entity IDs as fallback", async () => {
@@ -906,7 +906,7 @@ describe("ATMO adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pm25_marseille");
+      expect(result[0]!.entity_id).toBe("sensor.pm25_marseille");
     });
 
     it("returns empty array when no location and no entities to detect from", async () => {
@@ -937,7 +937,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenCapitalized).toBe("Mon Bouleau");
+      expect(result[0]!.allergenCapitalized).toBe("Mon Bouleau");
     });
 
     it("uses abbreviated allergenShort from phrases.short when allergens_abbreviated=true", async () => {
@@ -957,7 +957,7 @@ describe("ATMO adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenShort).toBe("Bou.");
+      expect(result[0]!.allergenShort).toBe("Bou.");
     });
   });
 });
@@ -1186,9 +1186,9 @@ describe("fetchForecast with prefixed entities", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(2);
-    expect(result[0].entity_id).toContain("toulouse_niveau_");
-    expect(result[0].days[0].state).toBeGreaterThan(0);
-    expect(result[0].days[1].state).toBeGreaterThan(0);
+    expect(result[0]!.entity_id).toContain("toulouse_niveau_");
+    expect(result[0]!.days[0]!.state).toBeGreaterThan(0);
+    expect(result[0]!.days[1]!.state).toBeGreaterThan(0);
   });
 
   it("reads j+1 forecast from {entity_id}_j_1 for prefixed entities", async () => {
@@ -1203,8 +1203,8 @@ describe("fetchForecast with prefixed entities", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].days[1].state).toBe(5);
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.days[1]!.state).toBe(5);
   });
 
   it("handles mixed prefixed and non-prefixed locations", async () => {
@@ -1215,9 +1215,9 @@ describe("fetchForecast with prefixed entities", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.niveau_bouleau_nice");
-    expect(result[0].days[0].state).toBe(4);
-    expect(result[0].days[1].state).toBe(2);
+    expect(result[0]!.entity_id).toBe("sensor.niveau_bouleau_nice");
+    expect(result[0]!.days[0]!.state).toBe(4);
+    expect(result[0]!.days[1]!.state).toBe(2);
   });
 });
 

--- a/test/adapters/dwd.test.ts
+++ b/test/adapters/dwd.test.ts
@@ -45,7 +45,7 @@ describe("DWD adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("graeser");
+    expect(result[0]!.allergenReplaced).toBe("graeser");
   });
 
   it("scales levels by factor of 2 (DWD 0-3 to display 0-6)", async () => {
@@ -58,12 +58,12 @@ describe("DWD adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     // DWD level 3 * 2 = 6
-    expect(result[0].days[0].display_state).toBe(6);
+    expect(result[0]!.days[0]!.display_state).toBe(6);
     // DWD level 1.5 * 2 = 3
-    expect(result[0].days[1].display_state).toBe(3);
+    expect(result[0]!.days[1]!.display_state).toBe(3);
     // DWD level 0 * 2 = 0
     // Note: day0.state stores the RAW level (not scaled)
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(3);
   });
 
   it("returns -1 for NaN values", async () => {
@@ -107,7 +107,7 @@ describe("DWD adapter: fetchForecast", () => {
     // DWD always builds 3 levels (today, tomorrow, day_after).
     // days_to_show only affects threshold filtering and padding, not output slicing.
     // All 3 valid days appear in output.
-    expect(result[0].days.length).toBe(3);
+    expect(result[0]!.days.length).toBe(3);
     expect(stubConfigDWD.days_to_show).toBe(2);
   });
 
@@ -125,7 +125,7 @@ describe("DWD adapter: fetchForecast", () => {
 
     // erle has level 1 (meets 0.5 threshold), birke has 0 (below)
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("erle");
+    expect(result[0]!.allergenReplaced).toBe("erle");
   });
 
   it("handles manual mode", async () => {
@@ -143,7 +143,7 @@ describe("DWD adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.custom_erle_end");
+    expect(result[0]!.entity_id).toBe("sensor.custom_erle_end");
   });
 
   it("sorts by value_descending by default", async () => {
@@ -159,7 +159,7 @@ describe("DWD adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBeGreaterThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeGreaterThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("each day object has DWD-specific display_state", async () => {
@@ -171,9 +171,9 @@ describe("DWD adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0]).toHaveProperty("display_state");
+    expect(result[0]!.days[0]).toHaveProperty("display_state");
     // display_state should be level * 2
-    expect(result[0].days[0].display_state).toBe(result[0].days[0].state * 2);
+    expect(result[0]!.days[0]!.display_state).toBe(result[0]!.days[0]!.state * 2);
   });
 
   it("entity_id is set on sensor dict", async () => {
@@ -185,7 +185,7 @@ describe("DWD adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.pollenflug_erle_50");
+    expect(result[0]!.entity_id).toBe("sensor.pollenflug_erle_50");
   });
 });
 
@@ -211,7 +211,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
     expect(result.locations.size).toBe(1);
 
     // In tier 3, the location key is the region ID string
-    const [locKey, loc] = [...result.locations.entries()][0];
+    const [locKey, loc] = [...result.locations.entries()][0]!;
     expect(locKey).toBe("50");
     expect(loc.entities.has("erle")).toBe(true);
     expect(loc.entities.has("birke")).toBe(true);
@@ -260,7 +260,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
     expect(result.tierUsed).toBe(2);
     expect(result.locations.size).toBe(1);
 
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("erle")).toBe(true);
     expect(loc.entities.has("birke")).toBe(true);
     expect(loc.entities.get("erle")).toBe("sensor.pollenflug_erle_50");
@@ -315,7 +315,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
 
     const result = discoverDwdSensors(hass);
 
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.label).toBe("Brandenburg und Berlin");
   });
 
@@ -347,7 +347,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
     };
 
     const result = discoverDwdSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.label).toBe("Brandenburg und Berlin");
   });
 
@@ -388,14 +388,14 @@ describe("DWD adapter: discoverDwdSensors", () => {
     };
 
     const result = discoverDwdSensors(hass);
-    const labels = [...result.locations.values()].map((l) => l.label).sort();
+    const labels = [...result.locations.values()]!.map((l) => l.label).sort();
     expect(labels).toEqual(["Bayern (121)", "Bayern (122)"]);
   });
 
   it("unique region label stays clean (no disambiguation suffix)", () => {
     const hass = makeHass("50", { erle: [1, 0, 0] });
     const result = discoverDwdSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     // Only one region 50 present; label stays bare.
     expect(loc.label).toBe("Brandenburg und Berlin");
   });
@@ -425,7 +425,7 @@ describe("DWD adapter: discoverDwdSensors", () => {
     };
 
     const result = discoverDwdSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.label).toBe("My custom region");
   });
 });
@@ -462,7 +462,7 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
     );
     const result = discoverDwdSensors(hass);
     expect(result.locations.size).toBe(1);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     // Entities are keyed by the normalizeDWD() output (German allergen
     // segment from the entity ID), matching the existing bare-shape tests
     // above.
@@ -482,7 +482,7 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
     );
     const result = discoverDwdSensors(hass);
     expect(result.locations.size).toBe(1);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.get("erle")).toBe("sensor.mystation_pollenflug_erle_50");
     expect(loc.entities.get("graeser")).toBe(
       "sensor.mystation_pollenflug_graeser_50",
@@ -524,7 +524,7 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
     });
     const result = await fetchForecast(hass, config);
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe(
+    expect(result[0]!.entity_id).toBe(
       `sensor.pollenflug_gefahrenindex_pollenflug_ambrosia_${PREFIXED_ZONE}`,
     );
     assertSensorShape(result[0], { minDays: 1 });
@@ -558,7 +558,7 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
       { erle: [2, 1, 0] },
     );
     const result = discoverDwdSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.get("erle")).toBe(
       "sensor.pollenflug_pollenflug_erle_121",
     );
@@ -577,7 +577,7 @@ describe("DWD adapter: device-prefixed entity IDs (#217)", () => {
     });
     const result = discoverDwdSensors(hass);
     expect(result.locations.size).toBe(1);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.get("erle")).toBe("sensor.pollenflug_erle_50");
     // No other entities should have leaked into the location's entity map.
     expect(loc.entities.size).toBe(1);

--- a/test/adapters/gp.test.ts
+++ b/test/adapters/gp.test.ts
@@ -124,7 +124,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
     const result = discoverGpSensors(hass);
 
     expect(result.locations.size).toBeGreaterThan(0);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
 
@@ -134,7 +134,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
       "sensor.google_pollen_weed": makeSensor("Weed", 1),
     });
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("trees_cat")).toBe(true);
     expect(loc.entities.has("weeds_cat")).toBe(true);
   });
@@ -144,7 +144,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
       "sensor.google_pollen_birch": makeSensor("Birch", 4),
     });
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("birch")).toBe(true);
     expect(loc.entities.get("birch")).toBe("sensor.google_pollen_birch");
   });
@@ -154,7 +154,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
       "sensor.google_pollen_cypress_pine": makeSensor("Cypress Pine", 2),
     });
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("cypress_pine")).toBe(true);
   });
 
@@ -163,7 +163,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
       "sensor.google_pollen_cottonwood": makeSensor("Cottonwood", 1),
     });
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("cottonwood")).toBe(true);
   });
 
@@ -175,7 +175,7 @@ describe("discoverGpSensors: prefix fallback path", () => {
     });
     const result = discoverGpSensors(hass);
     expect(result.locations.size).toBe(1);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.size).toBe(3);
   });
 
@@ -203,7 +203,7 @@ describe("discoverGpSensors: primary path (hass.entities)", () => {
     const result = discoverGpSensors(hass);
 
     expect(result.locations.size).toBeGreaterThan(0);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
 
@@ -245,7 +245,7 @@ describe("discoverGpSensors: primary path (hass.entities)", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.size).toBe(1);
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
@@ -330,7 +330,7 @@ describe("discoverGpSensors: unique_id classification", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("birch")).toBe(true);
     expect(loc.entities.has("trees_cat")).toBe(true);
     expect(loc.entities.has("weeds_cat")).toBe(true);
@@ -359,7 +359,7 @@ describe("discoverGpSensors: unique_id classification", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("graminales")).toBe(true);
     expect(loc.entities.has("grass_cat")).toBe(true);
     expect(loc.entities.size).toBe(2);
@@ -380,7 +380,7 @@ describe("discoverGpSensors: unique_id classification", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("cypress_pine")).toBe(true);
   });
 
@@ -399,7 +399,7 @@ describe("discoverGpSensors: unique_id classification", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("birch")).toBe(true);
   });
 
@@ -418,7 +418,7 @@ describe("discoverGpSensors: unique_id classification", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGpSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     // classifySensor lowercases display_name and looks it up directly in
     // GP_DISPLAY_NAME_MAP ("björk" -> "birch"). No slugify, no PP_ALIASES.
     expect(loc.entities.has("birch")).toBe(true);
@@ -461,7 +461,7 @@ describe("fetchForecast: basic shape", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 
   it("sets entity_id on each sensor dict", async () => {
@@ -475,7 +475,7 @@ describe("fetchForecast: basic shape", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].entity_id).toBe("sensor.google_pollen_birch");
+    expect(result[0]!.entity_id).toBe("sensor.google_pollen_birch");
   });
 
   it("each day object has required properties", async () => {
@@ -489,7 +489,7 @@ describe("fetchForecast: basic shape", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    const day = result[0].days[0];
+    const day = result[0]!.days[0]!;
 
     expect(day).toHaveProperty("name");
     expect(day).toHaveProperty("day");
@@ -516,9 +516,9 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[2]).toBeDefined();
-    expect(result[0].days[3]).toBeUndefined();
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[2]).toBeDefined();
+    expect(result[0]!.days[3]).toBeUndefined();
   });
 
   it("returns empty array when no matching sensors exist", async () => {
@@ -554,10 +554,10 @@ describe("fetchForecast: flat forecast attributes", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(2);
-    expect(result[0].days[1].state).toBe(4);
-    expect(result[0].days[2].state).toBe(1);
-    expect(result[0].days[3].state).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(2);
+    expect(result[0]!.days[1]!.state).toBe(4);
+    expect(result[0]!.days[2]!.state).toBe(1);
+    expect(result[0]!.days[3]!.state).toBe(3);
   });
 
   it("pads missing forecast days with state=-1", async () => {
@@ -573,10 +573,10 @@ describe("fetchForecast: flat forecast attributes", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].days[1].state).toBe(-1);
-    expect(result[0].days[2].state).toBe(-1);
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.days[1]!.state).toBe(-1);
+    expect(result[0]!.days[2]!.state).toBe(-1);
   });
 });
 
@@ -607,9 +607,9 @@ describe("fetchForecast: level scaling (0-5 to 0-6)", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state).toBe(nativeLevel);
-      expect(typeof result[0].days[0].state_text).toBe("string");
-      expect(result[0].days[0].state_text.length).toBeGreaterThan(0);
+      expect(result[0]!.days[0]!.state).toBe(nativeLevel);
+      expect(typeof result[0]!.days[0]!.state_text).toBe("string");
+      expect(result[0]!.days[0]!.state_text.length).toBeGreaterThan(0);
     });
   }
 
@@ -629,7 +629,7 @@ describe("fetchForecast: level scaling (0-5 to 0-6)", () => {
     const resultHigh = await fetchForecast(hassHigh, config);
     const resultLow = await fetchForecast(hassLow, config);
 
-    expect(resultHigh[0].days[0].state_text).not.toBe(resultLow[0].days[0].state_text);
+    expect(resultHigh[0]!.days[0]!.state_text).not.toBe(resultLow[0]!.days[0]!.state_text);
   });
 });
 
@@ -649,7 +649,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 
   it("returns state=-1 for negative index_value", async () => {
@@ -663,7 +663,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 
   it("clamps index_value above 5 to 5", async () => {
@@ -677,7 +677,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state).toBe(5);
+    expect(result[0]!.days[0]!.state).toBe(5);
   });
 
   it("returns state=-1 for undefined forecast attribute", async () => {
@@ -692,8 +692,8 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].days[1].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.days[1]!.state).toBe(-1);
   });
 });
 
@@ -715,7 +715,7 @@ describe("fetchForecast: threshold filtering", () => {
 
     const result = await fetchForecast(hass, config);
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 
   it("includes all allergens when pollen_threshold is 0", async () => {
@@ -802,8 +802,8 @@ describe("fetchForecast: sort_category_allergens_first", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenReplaced).toBe("oak");
-    expect(result[1].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("oak");
+    expect(result[1]!.allergenReplaced).toBe("grass_cat");
   });
 });
 
@@ -828,7 +828,7 @@ describe("fetchForecast: sorting modes", () => {
 
     const result = await fetchForecast(hass, config);
     for (let i = 0; i < result.length - 1; i++) {
-      expect(result[i].days[0].state).toBeLessThanOrEqual(result[i + 1].days[0].state);
+      expect(result[i]!.days[0]!.state).toBeLessThanOrEqual(result[i + 1]!.days[0]!.state);
     }
   });
 
@@ -847,9 +847,9 @@ describe("fetchForecast: sorting modes", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenReplaced).toBe("oak");
-    expect(result[1].allergenReplaced).toBe("birch");
-    expect(result[2].allergenReplaced).toBe("alder");
+    expect(result[0]!.allergenReplaced).toBe("oak");
+    expect(result[1]!.allergenReplaced).toBe("birch");
+    expect(result[2]!.allergenReplaced).toBe("alder");
   });
 });
 
@@ -876,6 +876,6 @@ describe("fetchForecast: user phrase overrides", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenCapitalized).toBe("My Custom Grass");
+    expect(result[0]!.allergenCapitalized).toBe("My Custom Grass");
   });
 });

--- a/test/adapters/gpl.test.ts
+++ b/test/adapters/gpl.test.ts
@@ -169,7 +169,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
     const result = discoverGplSensors(hass);
 
     expect(result.locations.size).toBeGreaterThan(0);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("grass_cat")).toBe(true);
     expect(loc.entities.get("grass_cat")).toBe("sensor.pollenlevels_grass");
   });
@@ -179,7 +179,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
       "sensor.pollenlevels_tree": makeTypeSensor("mdi:tree", 2),
     });
     const result = discoverGplSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("trees_cat")).toBe(true);
   });
 
@@ -188,7 +188,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
       "sensor.pollenlevels_weed": makeTypeSensor("mdi:flower-tulip", 1),
     });
     const result = discoverGplSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("weeds_cat")).toBe(true);
   });
 
@@ -197,7 +197,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
       "sensor.pollenlevels_birch": makePlantSensor("birch", 4),
     });
     const result = discoverGplSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("birch")).toBe(true);
     expect(loc.entities.get("birch")).toBe("sensor.pollenlevels_birch");
   });
@@ -212,7 +212,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
 
     // Attribution fallback groups everything under "default"
     expect(result.locations.size).toBe(1);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.size).toBe(3);
   });
 
@@ -228,7 +228,7 @@ describe("discoverGplSensors: attribution fallback path", () => {
       },
     });
     const result = discoverGplSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.size).toBe(1);
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
@@ -246,7 +246,7 @@ describe("discoverGplSensors: primary path (hass.entities)", () => {
     const result = discoverGplSensors(hass);
 
     expect(result.locations.size).toBeGreaterThan(0);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
 
@@ -374,7 +374,7 @@ describe("discoverGplSensors: primary path (hass.entities)", () => {
     };
     const hass: any = { ...createHass(statesMap), entities, devices: {} };
     const result = discoverGplSensors(hass);
-    const [, loc] = [...result.locations.entries()][0];
+    const [, loc] = [...result.locations.entries()][0]!;
     expect(loc.entities.size).toBe(1);
     expect(loc.entities.has("grass_cat")).toBe(true);
   });
@@ -509,7 +509,7 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 
   it("sets allergenCapitalized to a non-empty string", async () => {
@@ -524,8 +524,8 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(typeof result[0].allergenCapitalized).toBe("string");
-    expect(result[0].allergenCapitalized.length).toBeGreaterThan(0);
+    expect(typeof result[0]!.allergenCapitalized).toBe("string");
+    expect(result[0]!.allergenCapitalized.length).toBeGreaterThan(0);
   });
 
   it("sets allergenShort equal to allergenCapitalized when not abbreviated", async () => {
@@ -541,7 +541,7 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenShort).toBe(result[0].allergenCapitalized);
+    expect(result[0]!.allergenShort).toBe(result[0]!.allergenCapitalized);
   });
 
   it("day0 is defined and is the first element of days array", async () => {
@@ -556,8 +556,8 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0]).toBeDefined();
-    expect(result[0].days[0]).toBe(result[0].days[0]);
+    expect(result[0]!.days[0]).toBeDefined();
+    expect(result[0]!.days[0]).toBe(result[0]!.days[0]);
   });
 
   it("each day object has required properties", async () => {
@@ -571,7 +571,7 @@ describe("fetchForecast: basic shape", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    const day = result[0].days[0];
+    const day = result[0]!.days[0]!;
 
     expect(day).toHaveProperty("name");
     expect(day).toHaveProperty("day");
@@ -596,7 +596,7 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.pollenlevels_birch");
+    expect(result[0]!.entity_id).toBe("sensor.pollenlevels_birch");
   });
 
   it("respects days_to_show", async () => {
@@ -616,11 +616,11 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[0]).toBeDefined();
-    expect(result[0].days[1]).toBeDefined();
-    expect(result[0].days[2]).toBeDefined();
-    expect(result[0].days[3]).toBeUndefined();
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[0]).toBeDefined();
+    expect(result[0]!.days[1]).toBeDefined();
+    expect(result[0]!.days[2]).toBeDefined();
+    expect(result[0]!.days[3]).toBeUndefined();
   });
 
   it("returns empty array when no matching sensors exist", async () => {
@@ -672,10 +672,10 @@ describe("fetchForecast: level scaling (0-5 to 0-6)", () => {
       const result = await fetchForecast(hass, config);
 
       // state stores the raw (0-5) value
-      expect(result[0].days[0].state).toBe(nativeLevel);
+      expect(result[0]!.days[0]!.state).toBe(nativeLevel);
       // state_text should be a non-empty string (scaled level label)
-      expect(typeof result[0].days[0].state_text).toBe("string");
-      expect(result[0].days[0].state_text.length).toBeGreaterThan(0);
+      expect(typeof result[0]!.days[0]!.state_text).toBe("string");
+      expect(result[0]!.days[0]!.state_text.length).toBeGreaterThan(0);
     });
   }
 
@@ -695,7 +695,7 @@ describe("fetchForecast: level scaling (0-5 to 0-6)", () => {
     const resultHigh = await fetchForecast(hassHigh, config);
     const resultLow = await fetchForecast(hassLow, config);
 
-    expect(resultHigh[0].days[0].state_text).not.toBe(resultLow[0].days[0].state_text);
+    expect(resultHigh[0]!.days[0]!.state_text).not.toBe(resultLow[0]!.days[0]!.state_text);
   });
 });
 
@@ -716,7 +716,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 
   it("returns state=-1 for negative sensor state", async () => {
@@ -731,7 +731,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 
   it("clamps sensor state above 5 to 5", async () => {
@@ -746,7 +746,7 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(5);
+    expect(result[0]!.days[0]!.state).toBe(5);
   });
 
   it("returns state=-1 for forecast item with has_index=false", async () => {
@@ -764,8 +764,8 @@ describe("fetchForecast: NaN/negative/out-of-range handling", () => {
     const result = await fetchForecast(hass, config);
 
     // day0 has valid state=3, day1 has has_index=false -> state=-1
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].days[1].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.days[1]!.state).toBe(-1);
   });
 });
 
@@ -789,9 +789,9 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(2);
-    expect(result[0].days[1].state).toBe(4);
-    expect(result[0].days[2].state).toBe(1);
+    expect(result[0]!.days[0]!.state).toBe(2);
+    expect(result[0]!.days[1]!.state).toBe(4);
+    expect(result[0]!.days[2]!.state).toBe(1);
   });
 
   it("pads missing forecast days with state=-1", async () => {
@@ -807,10 +807,10 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].days[1].state).toBe(-1);
-    expect(result[0].days[2].state).toBe(-1);
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.days[1]!.state).toBe(-1);
+    expect(result[0]!.days[2]!.state).toBe(-1);
   });
 
   it("uses date field from forecast item when provided", async () => {
@@ -828,7 +828,7 @@ describe("fetchForecast: forecast data", () => {
     const result = await fetchForecast(hass, config);
 
     // day1's label is derived from the forecast date: offset 1 -> "Tomorrow"
-    expect(result[0].days[1].day).toBe("Tomorrow");
+    expect(result[0]!.days[1]!.day).toBe("Tomorrow");
   });
 
   // Issue #271: the sensor state is the value for the integration's last
@@ -850,11 +850,11 @@ describe("fetchForecast: forecast data", () => {
     const result = await fetchForecast(hass, config);
 
     // Today shows the item's value; the state belongs to yesterday
-    expect(result[0].days[0].day).toBe("Today");
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.days[0]!.day).toBe("Today");
+    expect(result[0]!.days[0]!.state).toBe(3);
     // Second column is a padded empty tomorrow, not a duplicate today
-    expect(result[0].days[1].day).toBe("Tomorrow");
-    expect(result[0].days[1].state).toBe(-1);
+    expect(result[0]!.days[1]!.day).toBe("Tomorrow");
+    expect(result[0]!.days[1]!.state).toBe(-1);
   });
 
   it("places a forecast item by its date and drops the day-old state (offset lag)", async () => {
@@ -872,10 +872,10 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].day).toBe("Today");
-    expect(result[0].days[0].state).toBe(-1);
-    expect(result[0].days[1].day).toBe("Tomorrow");
-    expect(result[0].days[1].state).toBe(4);
+    expect(result[0]!.days[0]!.day).toBe("Today");
+    expect(result[0]!.days[0]!.state).toBe(-1);
+    expect(result[0]!.days[1]!.day).toBe("Tomorrow");
+    expect(result[0]!.days[1]!.state).toBe(4);
   });
 
   it("uses the today-dated forecast item when the state is unavailable", async () => {
@@ -891,10 +891,10 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].day).toBe("Today");
-    expect(result[0].days[0].state).toBe(2);
-    expect(result[0].days[1].day).toBe("Tomorrow");
-    expect(result[0].days[1].state).toBe(-1);
+    expect(result[0]!.days[0]!.day).toBe("Today");
+    expect(result[0]!.days[0]!.state).toBe(2);
+    expect(result[0]!.days[1]!.day).toBe("Tomorrow");
+    expect(result[0]!.days[1]!.state).toBe(-1);
   });
 
   it("keeps the state as today and items on their dates when the data is fresh", async () => {
@@ -913,11 +913,11 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].day).toBe("Today");
-    expect(result[0].days[0].state).toBe(2);
-    expect(result[0].days[1].day).toBe("Tomorrow");
-    expect(result[0].days[1].state).toBe(4);
-    expect(result[0].days[2].state).toBe(1);
+    expect(result[0]!.days[0]!.day).toBe("Today");
+    expect(result[0]!.days[0]!.state).toBe(2);
+    expect(result[0]!.days[1]!.day).toBe("Tomorrow");
+    expect(result[0]!.days[1]!.state).toBe(4);
+    expect(result[0]!.days[2]!.state).toBe(1);
   });
 
   it("day0 state_text is the no_information label when level is -1", async () => {
@@ -939,7 +939,7 @@ describe("fetchForecast: forecast data", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state_text).toBe("N/A");
+    expect(result[0]!.days[0]!.state_text).toBe("N/A");
   });
 });
 
@@ -966,7 +966,7 @@ describe("fetchForecast: threshold filtering", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 
   it("includes all allergens when pollen_threshold is 0", async () => {
@@ -1088,8 +1088,8 @@ describe("fetchForecast: sort_category_allergens_first", () => {
     const result = await fetchForecast(hass, config);
 
     // oak(5) should come before grass_cat(1) with value_descending
-    expect(result[0].allergenReplaced).toBe("oak");
-    expect(result[1].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("oak");
+    expect(result[1]!.allergenReplaced).toBe("grass_cat");
   });
 });
 
@@ -1115,7 +1115,7 @@ describe("fetchForecast: sorting modes", () => {
     const result = await fetchForecast(hass, config);
 
     for (let i = 0; i < result.length - 1; i++) {
-      expect(result[i].days[0].state).toBeLessThanOrEqual(result[i + 1].days[0].state);
+      expect(result[i]!.days[0]!.state).toBeLessThanOrEqual(result[i + 1]!.days[0]!.state);
     }
   });
 
@@ -1136,7 +1136,7 @@ describe("fetchForecast: sorting modes", () => {
     const result = await fetchForecast(hass, config);
 
     const names = result.map((s) => s.allergenCapitalized);
-    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    const sorted = [...names]!.sort((a, b) => a.localeCompare(b));
     expect(names).toEqual(sorted);
   });
 
@@ -1156,9 +1156,9 @@ describe("fetchForecast: sorting modes", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("oak");
-    expect(result[1].allergenReplaced).toBe("birch");
-    expect(result[2].allergenReplaced).toBe("alder");
+    expect(result[0]!.allergenReplaced).toBe("oak");
+    expect(result[1]!.allergenReplaced).toBe("birch");
+    expect(result[2]!.allergenReplaced).toBe("alder");
   });
 });
 
@@ -1186,7 +1186,7 @@ describe("fetchForecast: user phrase overrides", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenCapitalized).toBe("My Custom Grass");
+    expect(result[0]!.allergenCapitalized).toBe("My Custom Grass");
   });
 });
 
@@ -1348,9 +1348,9 @@ describe("discoverGplSensors: v3 summary siblings don't collide on allergy_risk 
       dev1: { name: "Home", config_entries: ["entry_v3"] },
     });
     // Reduced frontend shape carries translation_key, not unique_id.
-    hass.entities["sensor.home_overall"].translation_key =
+    hass.entities["sensor.home_overall"]!.translation_key =
       "overall_pollen_risk_today";
-    hass.entities["sensor.home_top_types"].translation_key =
+    hass.entities["sensor.home_top_types"]!.translation_key =
       "top_pollen_types_today";
 
     const result = discoverGplSensors(hass);
@@ -1385,7 +1385,7 @@ describe("discoverGplSensors: summary sensor flows through to allergy_risk key",
       const base = makeHassPrimary(statesMap, entitiesMap, {
         dev1: { name: "Home", config_entries: ["entry-summary-1"] },
       });
-      base.entities["sensor.home_overall_pollen_risk_today"].unique_id =
+      base.entities["sensor.home_overall_pollen_risk_today"]!.unique_id =
         "cfg_entry_id_overall_pollen_risk_today";
       return base;
     })();
@@ -1423,7 +1423,7 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
     const hass = makeHassPrimary(statesMap, entitiesMap, {
       dev1: { name: "Home", config_entries: ["entry_a"] },
     });
-    hass.entities["sensor.home_overall_pollen_risk_today"].unique_id =
+    hass.entities["sensor.home_overall_pollen_risk_today"]!.unique_id =
       pinTopUnique;
     return hass;
   }
@@ -1440,7 +1440,7 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
     const result = await fetchForecast(hass, config);
     const ar = result.find((s) => s.allergenReplaced === "allergy_risk")!;
     expect(ar).toBeDefined();
-    expect(ar.days[0].state).toBe(3);
+    expect(ar.days[0]!.state).toBe(3);
   });
 
   it("renders day1..N as no-data sentinels (-1) since the summary has no forecast", async () => {
@@ -1454,12 +1454,12 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
 
     const result = await fetchForecast(hass, config);
     const ar = result.find((s) => s.allergenReplaced === "allergy_risk")!;
-    expect(ar.days[0].state).toBe(2);
+    expect(ar.days[0]!.state).toBe(2);
     // The card treats level=-1 as the fuzzy no-data variant (#228); padding
     // future days as -1 is what keeps the row from inventing fake values.
-    expect(ar.days[1].state).toBe(-1);
-    expect(ar.days[2].state).toBe(-1);
-    expect(ar.days[3].state).toBe(-1);
+    expect(ar.days[1]!.state).toBe(-1);
+    expect(ar.days[2]!.state).toBe(-1);
+    expect(ar.days[3]!.state).toBe(-1);
   });
 
   it("pins allergy_risk to position 0 when allergy_risk_top: true", async () => {
@@ -1472,7 +1472,7 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenReplaced).toBe("allergy_risk");
+    expect(result[0]!.allergenReplaced).toBe("allergy_risk");
   });
 
   it("leaves allergy_risk in its natural sort position when allergy_risk_top: false", async () => {
@@ -1489,8 +1489,8 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
-    expect(result[1].allergenReplaced).toBe("allergy_risk");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
+    expect(result[1]!.allergenReplaced).toBe("allergy_risk");
   });
 
   it("pre-v2.1.0 installs (no summary sensor) keep working", async () => {
@@ -1508,7 +1508,7 @@ describe("fetchForecast: allergy_risk summary row (#221)", () => {
 
     const result = await fetchForecast(hass, config);
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 });
 
@@ -1549,12 +1549,12 @@ describe("fetchForecast: summary block tagging and extras (#222)", () => {
     const hass = makeHassPrimary(statesMap, entitiesMap, {
       dev1: { name: "Home", config_entries: ["entry_a"] },
     });
-    hass.entities["sensor.home_overall_pollen_risk_today"].unique_id =
+    hass.entities["sensor.home_overall_pollen_risk_today"]!.unique_id =
       "entry_a_overall_pollen_risk_today";
     if (plants) {
-      hass.entities["sensor.home_plants_in_season_today"].unique_id =
+      hass.entities["sensor.home_plants_in_season_today"]!.unique_id =
         "entry_a_plants_in_season_today";
-      hass.entities["sensor.home_plants_in_season_today"].translation_key =
+      hass.entities["sensor.home_plants_in_season_today"]!.translation_key =
         "plants_in_season_today";
     }
     // Force the card language (detectLang reads hass.locale.language).
@@ -1674,7 +1674,7 @@ describe("fetchForecast: summary block tagging and extras (#222)", () => {
       plants: { state: "2", plant_codes: ["BIRCH", "PINE"] },
       language: "sv",
     });
-    delete hass.entities["sensor.home_plants_in_season_today"].unique_id;
+    delete hass.entities["sensor.home_plants_in_season_today"]!.unique_id;
     const config = makeConfig({
       allergens: ["allergy_risk"],
       pollen_threshold: 0,
@@ -1709,7 +1709,7 @@ describe("fetchForecast: summary block tagging and extras (#222)", () => {
       dev_types: { name: "Home types", config_entries: ["entry_a"] },
       dev_plants: { name: "Home plants", config_entries: ["entry_a"] },
     });
-    hass.entities["sensor.home_plants_in_season_today"].translation_key =
+    hass.entities["sensor.home_plants_in_season_today"]!.translation_key =
       "plants_in_season_today";
     hass.language = "sv";
     hass.locale = { language: "sv" };
@@ -1760,7 +1760,7 @@ describe("fetchForecast: summary block tagging and extras (#222)", () => {
         config_entries_subentries: { [PARENT]: [SUB_A] },
       },
     });
-    hass.entities["sensor.home_plants_in_season_today"].translation_key =
+    hass.entities["sensor.home_plants_in_season_today"]!.translation_key =
       "plants_in_season_today";
     hass.language = "sv";
     hass.locale = { language: "sv" };
@@ -1821,9 +1821,9 @@ describe("fetchForecast: summary block tagging and extras (#222)", () => {
         config_entries_subentries: { [PARENT]: [SUB_B] },
       },
     });
-    hass.entities["sensor.home_plants_in_season_today"].translation_key =
+    hass.entities["sensor.home_plants_in_season_today"]!.translation_key =
       "plants_in_season_today";
-    hass.entities["sensor.work_plants_in_season_today"].translation_key =
+    hass.entities["sensor.work_plants_in_season_today"]!.translation_key =
       "plants_in_season_today";
     hass.language = "sv";
     hass.locale = { language: "sv" };

--- a/test/adapters/irmkmi.test.ts
+++ b/test/adapters/irmkmi.test.ts
@@ -110,8 +110,8 @@ describe("IRMKMI adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state).toBe(expected);
-      expect(result[0].days[0].display_state).toBe(expected);
+      expect(result[0]!.days[0]!.state).toBe(expected);
+      expect(result[0]!.days[0]!.display_state).toBe(expected);
     }
   });
 
@@ -155,7 +155,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(1);
+    expect(result[0]!.days.length).toBe(1);
   });
 
   it("allergenReplaced matches canonical key", async () => {
@@ -164,7 +164,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("grass");
+    expect(result[0]!.allergenReplaced).toBe("grass");
   });
 
   it("entity_id is set correctly", async () => {
@@ -173,7 +173,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.home_mugwort_level");
+    expect(result[0]!.entity_id).toBe("sensor.home_mugwort_level");
   });
 
   it("pollen_threshold=0 includes green (level 0) allergens", async () => {
@@ -183,7 +183,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].days[0].state).toBe(0);
+    expect(result[0]!.days[0]!.state).toBe(0);
   });
 
   it("pollen_threshold>0 filters out green (level 0) allergens", async () => {
@@ -199,7 +199,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("oak");
+    expect(result[0]!.allergenReplaced).toBe("oak");
   });
 
   it("sorts by value_descending by default", async () => {
@@ -214,7 +214,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBeGreaterThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeGreaterThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("handles multiple allergens, hiding out-of-season (none) ones", async () => {
@@ -232,8 +232,8 @@ describe("IRMKMI adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass");
-    expect(result[0].days[0].state).toBe(4);
+    expect(result[0]!.allergenReplaced).toBe("grass");
+    expect(result[0]!.days[0]!.state).toBe(4);
   });
 
   it("stubConfigIRMKMI has days_to_show set to 1", () => {
@@ -261,7 +261,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
       const config = makeConfig({ allergens: ["birch"], pollen_threshold: 0 });
       const result = await fetchForecast(hass, config);
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state_text).toBe(expectedText);
+      expect(result[0]!.days[0]!.state_text).toBe(expectedText);
     }
   });
 
@@ -279,7 +279,7 @@ describe("IRMKMI adapter: fetchForecast", () => {
       },
     });
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state_text).toBe("Zeer hoog");
+    expect(result[0]!.days[0]!.state_text).toBe("Zeer hoog");
   });
 });
 
@@ -474,8 +474,8 @@ describe("IRMKMI adapter: registryless (tier-3) multi-location", () => {
       location: "saint_ghislain",
     } as any);
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.saint_ghislain_grasses_level");
-    expect(result[0].days[0].state).toBe(3); // red
+    expect(result[0]!.entity_id).toBe("sensor.saint_ghislain_grasses_level");
+    expect(result[0]!.days[0]!.state).toBe(3); // red
   });
 });
 
@@ -489,8 +489,8 @@ describe("IRMKMI adapter: fetchForecast (multi-location)", () => {
       location: SAINT_GHISLAIN_ENTRY,
     } as any);
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.saint_ghislain_grasses_level");
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.entity_id).toBe("sensor.saint_ghislain_grasses_level");
+    expect(result[0]!.days[0]!.state).toBe(3);
   });
 
   it("hides out-of-season allergens by default (only grass shows)", async () => {
@@ -500,7 +500,7 @@ describe("IRMKMI adapter: fetchForecast (multi-location)", () => {
       location: ANTWERP_ENTRY,
     } as any);
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass");
-    expect(result[0].days[0].state).toBe(4); // purple
+    expect(result[0]!.allergenReplaced).toBe("grass");
+    expect(result[0]!.days[0]!.state).toBe(4); // purple
   });
 });

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -177,7 +177,7 @@ describe("Kleenex adapter: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("sets entity_id to the source sensor entity_id", async () => {
@@ -194,7 +194,7 @@ describe("Kleenex adapter: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_trees");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_trees");
   });
 
   it("sets allergenCapitalized to a non-empty string", async () => {
@@ -211,8 +211,8 @@ describe("Kleenex adapter: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(typeof result[0].allergenCapitalized).toBe("string");
-    expect(result[0].allergenCapitalized.length).toBeGreaterThan(0);
+    expect(typeof result[0]!.allergenCapitalized).toBe("string");
+    expect(result[0]!.allergenCapitalized.length).toBeGreaterThan(0);
   });
 
   it("day0 is defined and is the same object as days[0]", async () => {
@@ -229,8 +229,8 @@ describe("Kleenex adapter: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0]).toBeDefined();
-    expect(result[0].days[0]).toBe(result[0].days[0]);
+    expect(result[0]!.days[0]).toBeDefined();
+    expect(result[0]!.days[0]).toBe(result[0]!.days[0]);
   });
 
   it("respects days_to_show", async () => {
@@ -249,9 +249,9 @@ describe("Kleenex adapter: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[2]).toBeDefined();
-    expect(result[0].days[3]).toBeUndefined();
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[2]).toBeDefined();
+    expect(result[0]!.days[3]).toBeUndefined();
   });
 });
 
@@ -275,7 +275,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(0);
+    expect(result[0]!.days[0]!.state).toBe(0);
   });
 
   it("maps trees PPM within low threshold (<=95) to level 1", async () => {
@@ -292,7 +292,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(1);
+    expect(result[0]!.days[0]!.state).toBe(1);
   });
 
   it("maps trees PPM within moderate threshold (96-207) to level 2", async () => {
@@ -309,7 +309,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
   });
 
   it("maps trees PPM within high threshold (208-703) to level 3", async () => {
@@ -326,7 +326,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(3);
   });
 
   it("maps trees PPM above high threshold (>703) to level 4", async () => {
@@ -343,7 +343,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(4);
+    expect(result[0]!.days[0]!.state).toBe(4);
   });
 
   // Grass thresholds: [29, 60, 341]
@@ -362,7 +362,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
     const result = await fetchForecast(hass, config);
 
     // 30 > 29 (low threshold) so level 2 (moderate)
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
   });
 
   // Weeds thresholds: [20, 77, 266]
@@ -381,9 +381,9 @@ describe("Kleenex adapter: PPM to level conversion", () => {
     const result = await fetchForecast(hass, config);
 
     // 15 <= 20 (low threshold) so level 1
-    expect(result[0].days[0].state).toBe(1);
+    expect(result[0]!.days[0]!.state).toBe(1);
     // The raw ppm measurement is kept for numeric_value_raw.
-    expect(result[0].days[0].raw_value).toBe(15);
+    expect(result[0]!.days[0]!.raw_value).toBe(15);
   });
 
   it("coerces 'unavailable' sensor state to level 0 for category sensors", async () => {
@@ -407,7 +407,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(0);
+    expect(result[0]!.days[0]!.state).toBe(0);
   });
 
   it("returns -1 for negative PPM values", async () => {
@@ -424,7 +424,7 @@ describe("Kleenex adapter: PPM to level conversion", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 });
 
@@ -460,8 +460,8 @@ describe("Kleenex adapter: level scaling (0-4 to 0-6)", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0].state).toBe(expectedRawLevel);
-      expect(typeof result[0].days[0].state_text).toBe("string");
+      expect(result[0]!.days[0]!.state).toBe(expectedRawLevel);
+      expect(typeof result[0]!.days[0]!.state_text).toBe("string");
     });
   }
 
@@ -486,7 +486,7 @@ describe("Kleenex adapter: level scaling (0-4 to 0-6)", () => {
     const resultHigh = await fetchForecast(hassHigh, config);
     const resultLow = await fetchForecast(hassLow, config);
 
-    expect(resultHigh[0].days[0].state_text).not.toBe(resultLow[0].days[0].state_text);
+    expect(resultHigh[0]!.days[0]!.state_text).not.toBe(resultLow[0]!.days[0]!.state_text);
   });
 });
 
@@ -506,7 +506,7 @@ describe("Kleenex adapter: category sensors", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("trees_cat");
+    expect(result[0]!.allergenReplaced).toBe("trees_cat");
   });
 
   it("includes grass_cat when included in allergens and grass sensor exists", async () => {
@@ -521,7 +521,7 @@ describe("Kleenex adapter: category sensors", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("grass_cat");
+    expect(result[0]!.allergenReplaced).toBe("grass_cat");
   });
 
   it("includes weeds_cat when included in allergens and weeds sensor exists", async () => {
@@ -536,7 +536,7 @@ describe("Kleenex adapter: category sensors", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("weeds_cat");
+    expect(result[0]!.allergenReplaced).toBe("weeds_cat");
   });
 
   it("skips category sensor when the corresponding _cat key is not in allergens", async () => {
@@ -566,7 +566,7 @@ describe("Kleenex adapter: category sensors", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
   });
 });
 
@@ -612,7 +612,7 @@ describe("Kleenex adapter: individual allergens from details", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("maps localized Dutch allergen names to canonical slugs", async () => {
@@ -631,7 +631,7 @@ describe("Kleenex adapter: individual allergens from details", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("skips individual allergens not in config.allergens", async () => {
@@ -670,7 +670,7 @@ describe("Kleenex adapter: individual allergens from details", () => {
     const result = await fetchForecast(hass, config);
 
     // 50 PPM for birch (trees category) <= 95 -> level 1
-    expect(result[0].days[0].state).toBe(1);
+    expect(result[0]!.days[0]!.state).toBe(1);
   });
 
   it("extracts forecast day data for individual allergens from forecast.details", async () => {
@@ -692,9 +692,9 @@ describe("Kleenex adapter: individual allergens from details", () => {
     const result = await fetchForecast(hass, config);
 
     // Today: 100 PPM <= 95? No: 100 > 95 so level 2
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
     // Tomorrow: 800 PPM > 703 -> level 4
-    expect(result[0].days[1].state).toBe(4);
+    expect(result[0]!.days[1]!.state).toBe(4);
   });
 });
 
@@ -722,7 +722,7 @@ describe("Kleenex adapter: sort_category_allergens_first", () => {
     const result = await fetchForecast(hass, config);
 
     // trees_cat should come first regardless of its lower value
-    expect(result[0].allergenReplaced).toBe("trees_cat");
+    expect(result[0]!.allergenReplaced).toBe("trees_cat");
     // Individual allergens should be sorted by value_descending among themselves
     const individualKeys = result.slice(1).map((s) => s.allergenReplaced);
     expect(individualKeys[0]).toBe("birch"); // 700 PPM > oak 200 PPM
@@ -748,8 +748,8 @@ describe("Kleenex adapter: sort_category_allergens_first", () => {
     const result = await fetchForecast(hass, config);
 
     // Without two-tiered sort, trees_cat (level 4) should sort before birch (level 1)
-    expect(result[0].allergenReplaced).toBe("trees_cat");
-    expect(result[1].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("trees_cat");
+    expect(result[1]!.allergenReplaced).toBe("birch");
   });
 
   it("preserves config order when sort is 'none'", async () => {
@@ -771,8 +771,8 @@ describe("Kleenex adapter: sort_category_allergens_first", () => {
     const result = await fetchForecast(hass, config);
 
     // Order in config: oak, birch
-    expect(result[0].allergenReplaced).toBe("oak");
-    expect(result[1].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("oak");
+    expect(result[1]!.allergenReplaced).toBe("birch");
   });
 });
 
@@ -865,7 +865,7 @@ describe("Kleenex adapter: user level names", () => {
     const result = await fetchForecast(hass, config);
 
     // Raw level 2 -> scaled level 3 -> customLevels[3] = "Medium"
-    expect(result[0].days[0].state_text).toBe("Medium");
+    expect(result[0]!.days[0]!.state_text).toBe("Medium");
   });
 
   it("accepts 5 custom level labels mapped via index positions [0,1,3,5,6]", async () => {
@@ -887,7 +887,7 @@ describe("Kleenex adapter: user level names", () => {
     const result = await fetchForecast(hass, config);
 
     // Raw level 2 -> scaled 3; 5-label map[2] = 3 -> customLevels[2] = "Moderate"
-    expect(result[0].days[0].state_text).toBe("Moderate");
+    expect(result[0]!.days[0]!.state_text).toBe("Moderate");
   });
 
   it("falls back to i18n default for empty string entries in 7-label array", async () => {
@@ -907,7 +907,7 @@ describe("Kleenex adapter: user level names", () => {
     const result = await fetchForecast(hass, config);
 
     // Level 0 -> scaled 0 -> customLevels[0] = "CustomZero"
-    expect(result[0].days[0].state_text).toBe("CustomZero");
+    expect(result[0]!.days[0]!.state_text).toBe("CustomZero");
   });
 });
 
@@ -933,7 +933,7 @@ describe("Kleenex adapter: manual mode", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe(
+    expect(result[0]!.entity_id).toBe(
       "sensor.kleenex_pollen_radar_mypfx_amsterdam_trees",
     );
   });
@@ -984,7 +984,7 @@ describe("Kleenex adapter: manual mode", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.map((s) => s.allergenReplaced)).toEqual(["trees_cat"]);
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_trees_v2");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_trees_v2");
   });
 
   it("uses only suffixed entities when entity_suffix is configured", async () => {
@@ -1014,8 +1014,8 @@ describe("Kleenex adapter: manual mode", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_birch_v2");
-    expect(result[0].days[0].value).toBe(200);
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_birch_v2");
+    expect(result[0]!.days[0]!.value).toBe(200);
   });
 
   it("issue #309 - collects sensors whose IDs lack the legacy domain slug", async () => {
@@ -1099,8 +1099,8 @@ describe("Kleenex adapter: location filtering", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toContain("amsterdam");
-    expect(result[0].entity_id).not.toContain("brussels");
+    expect(result[0]!.entity_id).toContain("amsterdam");
+    expect(result[0]!.entity_id).not.toContain("brussels");
   });
 
   it("returns empty array when no sensors match the configured location", async () => {
@@ -1210,7 +1210,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
 
     expect(result).toEqual([]);
     expect(warnSpy).toHaveBeenCalled();
-    const warnMessage = warnSpy.mock.calls[0][0];
+    const warnMessage = warnSpy.mock.calls[0]![0];
     expect(warnMessage).toContain("North America");
   });
 
@@ -1231,7 +1231,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     // The warn spy may be called for other reasons (e.g. adapter errors), but
     // the NA warning message must NOT appear.
     const naWarningCalled = warnSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarningCalled).toBe(false);
   });
@@ -1255,7 +1255,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     await fetchForecast(hass, config);
 
     const naWarningCalled = warnSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarningCalled).toBe(false);
   });
@@ -1283,7 +1283,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     await fetchForecast(hass, config);
 
     const naWarningCalled = warnSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarningCalled).toBe(false);
   });
@@ -1305,7 +1305,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     await fetchForecast(hass, config);
 
     const naWarningCalled = warnSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarningCalled).toBe(true);
   });
@@ -1327,7 +1327,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     await fetchForecast(hass, config);
 
     const naWarnings = warnSpy.mock.calls.filter(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarnings.length).toBe(1);
   });
@@ -1358,7 +1358,7 @@ describe("Kleenex adapter: NA-zone warning", () => {
     await fetchForecast(hass, config);
 
     const naWarningCalled = warnSpy.mock.calls.some(
-      (args) => typeof args[0] === "string" && args[0].includes("North America"),
+      (args) => typeof args[0] === "string" && args[0]!.includes("North America"),
     );
     expect(naWarningCalled).toBe(true);
   });
@@ -1384,13 +1384,13 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_birch");
     // 150 ppm for birch (trees category) is in range 96-207 -> raw level 2
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
     // Forecast day 1: 100 ppm -> raw level 2; day 2: 50 ppm -> raw level 1
-    expect(result[0].days[1].state).toBe(2);
-    expect(result[0].days[2].state).toBe(1);
+    expect(result[0]!.days[1]!.state).toBe(2);
+    expect(result[0]!.days[2]!.state).toBe(1);
   });
 
   it("Test 5b - DetailSensor result passes sensor shape contract", async () => {
@@ -1425,8 +1425,8 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_berk");
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_berk");
   });
 
   it("Test 6b - localized Italian DetailSensor slug 'betulla' normalizes to canonical allergen 'birch'", async () => {
@@ -1442,8 +1442,8 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_rome_betulla");
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_rome_betulla");
   });
 
   it("Test 7 - category sensor details (EU full data) wins over DetailSensor", async () => {
@@ -1465,10 +1465,10 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
     // Must use the category sensor value (250 ppm -> level 3), not DetailSensor (50 -> level 1).
-    expect(result[0].days[0].state).toBe(3);
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_trees");
+    expect(result[0]!.days[0]!.state).toBe(3);
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_trees");
   });
 
   it("Test 8 - entity with '_level' suffix is NOT treated as a DetailSensor", async () => {
@@ -1537,8 +1537,8 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_birch");
   });
 
   it("Test 9a - DetailSensor with non-numeric state ('unknown'/'unavailable') is skipped, not treated as 0 ppm", async () => {
@@ -1586,8 +1586,8 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe(
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe(
       "sensor.kleenex_pollen_radar_atlanta_georgia_birch",
     );
   });
@@ -1617,8 +1617,8 @@ describe("Kleenex adapter: DetailSensor fallback", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[0].entity_id).toBe(
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[0]!.entity_id).toBe(
       "sensor.kleenex_pollen_radar_atlanta_birch_v2",
     );
   });
@@ -1706,7 +1706,7 @@ describe("Kleenex adapter: discoverKleenex", () => {
 
     expect(discovery.tierUsed).toBe(1);
     expect(discovery.locations.size).toBe(1);
-    const [, loc] = [...discovery.locations][0];
+    const [, loc] = [...discovery.locations][0]!;
     expect(loc.label).toBe("Home");
     expect([...loc.entities.keys()].sort()).toEqual([
       "grass",

--- a/test/adapters/msw.test.ts
+++ b/test/adapters/msw.test.ts
@@ -99,8 +99,8 @@ describe("MSW adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state).toBe(expected);
-      expect(result[0].days[0].display_state).toBe(expected);
+      expect(result[0]!.days[0]!.state).toBe(expected);
+      expect(result[0]!.days[0]!.display_state).toBe(expected);
     }
   });
 
@@ -110,7 +110,7 @@ describe("MSW adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(1);
+    expect(result[0]!.days.length).toBe(1);
   });
 
   it("allergenReplaced matches canonical key", async () => {
@@ -119,7 +119,7 @@ describe("MSW adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("grass");
+    expect(result[0]!.allergenReplaced).toBe("grass");
   });
 
   it("entity_id is set correctly", async () => {
@@ -128,7 +128,7 @@ describe("MSW adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.pollen_alder_level_at_8000_za");
+    expect(result[0]!.entity_id).toBe("sensor.pollen_alder_level_at_8000_za");
   });
 
   it("skips allergen with unavailable / unknown state", async () => {
@@ -150,7 +150,7 @@ describe("MSW adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].days[0].state).toBe(0);
+    expect(result[0]!.days[0]!.state).toBe(0);
   });
 
   it("pollen_threshold>0 filters out None-level allergens", async () => {
@@ -166,7 +166,7 @@ describe("MSW adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("oak");
+    expect(result[0]!.allergenReplaced).toBe("oak");
   });
 
   it("sorts by value_descending by default", async () => {
@@ -181,7 +181,7 @@ describe("MSW adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBeGreaterThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeGreaterThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("handles multiple allergens", async () => {
@@ -234,7 +234,7 @@ describe("MSW adapter: fetchForecast", () => {
       const config = makeConfig({ allergens: ["birch"], pollen_threshold: 0 });
       const result = await fetchForecast(hass, config);
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state_text).toBe(expectedText);
+      expect(result[0]!.days[0]!.state_text).toBe(expectedText);
     }
   });
 
@@ -252,7 +252,7 @@ describe("MSW adapter: fetchForecast", () => {
       },
     });
     const result = await fetchForecast(hass, config);
-    expect(result[0].days[0].state_text).toBe("Extremt");
+    expect(result[0]!.days[0]!.state_text).toBe("Extremt");
   });
 });
 
@@ -435,7 +435,7 @@ describe("MSW adapter: fetchForecast (multi-station)", () => {
       location: BERN_ENTRY,
     } as any);
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.bern_pollen_birch_level_at_3000_pbe");
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.entity_id).toBe("sensor.bern_pollen_birch_level_at_3000_pbe");
+    expect(result[0]!.days[0]!.state).toBe(3);
   });
 });

--- a/test/adapters/peu.test.ts
+++ b/test/adapters/peu.test.ts
@@ -80,7 +80,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("sets allergenCapitalized to a non-empty string", async () => {
@@ -92,8 +92,8 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(typeof result[0].allergenCapitalized).toBe("string");
-      expect(result[0].allergenCapitalized.length).toBeGreaterThan(0);
+      expect(typeof result[0]!.allergenCapitalized).toBe("string");
+      expect(result[0]!.allergenCapitalized.length).toBeGreaterThan(0);
     });
 
     it("sets allergenShort equal to allergenCapitalized when not abbreviated", async () => {
@@ -106,7 +106,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenShort).toBe(result[0].allergenCapitalized);
+      expect(result[0]!.allergenShort).toBe(result[0]!.allergenCapitalized);
     });
 
     it("day0 is defined and mirrors the first days entry", async () => {
@@ -118,8 +118,8 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days[0]).toBeDefined();
-      expect(result[0].days[0]).toBe(result[0].days[0]);
+      expect(result[0]!.days[0]).toBeDefined();
+      expect(result[0]!.days[0]).toBe(result[0]!.days[0]);
     });
 
     it("each day object has required properties", async () => {
@@ -130,7 +130,7 @@ describe("PEU adapter: fetchForecast", () => {
       });
 
       const result = await fetchForecast(hass, config);
-      const day = result[0].days[0];
+      const day = result[0]!.days[0]!;
 
       expect(day).toHaveProperty("name");
       expect(day).toHaveProperty("day");
@@ -152,7 +152,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].entity_id).toBe(
+      expect(result[0]!.entity_id).toBe(
         "sensor.polleninformation_amsterdam_birch",
       );
     });
@@ -167,11 +167,11 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].days.length).toBe(3);
-      expect(result[0].days[0]).toBeDefined();
-      expect(result[0].days[1]).toBeDefined();
-      expect(result[0].days[2]).toBeDefined();
-      expect(result[0].days[3]).toBeUndefined();
+      expect(result[0]!.days.length).toBe(3);
+      expect(result[0]!.days[0]).toBeDefined();
+      expect(result[0]!.days[1]).toBeDefined();
+      expect(result[0]!.days[2]).toBeDefined();
+      expect(result[0]!.days[3]).toBeUndefined();
     });
   });
 
@@ -206,10 +206,10 @@ describe("PEU adapter: fetchForecast", () => {
         const result = await fetchForecast(hass, config);
 
         // state stores the native (0-4) value verbatim
-        expect(result[0].days[0].state).toBe(input >= 0 ? input : -1);
+        expect(result[0]!.days[0]!.state).toBe(input >= 0 ? input : -1);
         // state_text comes from card.levels5.0..4 keyed at the native index
-        expect(typeof result[0].days[0].state_text).toBe("string");
-        expect(result[0].days[0].state_text.length).toBeGreaterThan(0);
+        expect(typeof result[0]!.days[0]!.state_text).toBe("string");
+        expect(result[0]!.days[0]!.state_text.length).toBeGreaterThan(0);
       });
     }
 
@@ -234,7 +234,7 @@ describe("PEU adapter: fetchForecast", () => {
           pollen_threshold: 0,
         });
         const result = await fetchForecast(hass, config);
-        expect(result[0].days[0].state_text).toBe(expected);
+        expect(result[0]!.days[0]!.state_text).toBe(expected);
       }
     });
 
@@ -260,7 +260,7 @@ describe("PEU adapter: fetchForecast", () => {
           pollen_threshold: 0,
         });
         const result = await fetchForecast(hass, config);
-        expect(result[0].days[0].state_text).toBe(expected);
+        expect(result[0]!.days[0]!.state_text).toBe(expected);
       }
     });
 
@@ -276,8 +276,8 @@ describe("PEU adapter: fetchForecast", () => {
       const resultHigh = await fetchForecast(hassHigh, config);
       const resultLow = await fetchForecast(hassLow, config);
 
-      expect(resultHigh[0].days[0].state_text).not.toBe(
-        resultLow[0].days[0].state_text,
+      expect(resultHigh[0]!.days[0]!.state_text).not.toBe(
+        resultLow[0]!.days[0]!.state_text,
       );
     });
   });
@@ -317,7 +317,7 @@ describe("PEU adapter: fetchForecast", () => {
       // NaN level evaluates to -1, and level >= 0 is false, so day is skipped
       // The sensor still appears because pollen_threshold === 0
       expect(result.length).toBe(1);
-      expect(result[0].days.length).toBe(0);
+      expect(result[0]!.days.length).toBe(0);
     });
 
     it("returns -1 for negative level values (day is skipped)", async () => {
@@ -349,7 +349,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       // Negative level evaluates to -1, day is skipped
       expect(result.length).toBe(1);
-      expect(result[0].days.length).toBe(0);
+      expect(result[0]!.days.length).toBe(0);
     });
 
     it("clamps level above maxLevel (4) to 4", async () => {
@@ -380,7 +380,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // Level 10 clamped to maxLevel=4
-      expect(result[0].days[0].state).toBe(4);
+      expect(result[0]!.days[0]!.state).toBe(4);
     });
   });
 
@@ -418,7 +418,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe(
+      expect(result[0]!.entity_id).toBe(
         "sensor.polleninformation_amsterdam_allergy_risk_hourly",
       );
     });
@@ -434,7 +434,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe(
+      expect(result[0]!.entity_id).toBe(
         "sensor.polleninformation_amsterdam_allergy_risk",
       );
     });
@@ -481,7 +481,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("includes all allergens when pollen_threshold is 0", async () => {
@@ -536,8 +536,8 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       for (let i = 0; i < result.length - 1; i++) {
-        expect(result[i].days[0].state).toBeGreaterThanOrEqual(
-          result[i + 1].days[0].state,
+        expect(result[i]!.days[0]!.state).toBeGreaterThanOrEqual(
+          result[i + 1]!.days[0]!.state,
         );
       }
     });
@@ -558,8 +558,8 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       for (let i = 0; i < result.length - 1; i++) {
-        expect(result[i].days[0].state).toBeLessThanOrEqual(
-          result[i + 1].days[0].state,
+        expect(result[i]!.days[0]!.state).toBeLessThanOrEqual(
+          result[i + 1]!.days[0]!.state,
         );
       }
     });
@@ -580,7 +580,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       const names = result.map((s) => s.allergenCapitalized);
-      const sorted = [...names].sort((a, b) => a.localeCompare(b));
+      const sorted = [...names]!.sort((a, b) => a.localeCompare(b));
       expect(names).toEqual(sorted);
     });
 
@@ -600,7 +600,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       const names = result.map((s) => s.allergenCapitalized);
-      const sorted = [...names].sort((a, b) => b.localeCompare(a));
+      const sorted = [...names]!.sort((a, b) => b.localeCompare(a));
       expect(names).toEqual(sorted);
     });
 
@@ -620,9 +620,9 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // Original order (oak, grasses, birch) should be preserved
-      expect(result[0].allergenReplaced).toBe("oak");
-      expect(result[1].allergenReplaced).toBe("grasses");
-      expect(result[2].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("oak");
+      expect(result[1]!.allergenReplaced).toBe("grasses");
+      expect(result[2]!.allergenReplaced).toBe("birch");
     });
   });
 
@@ -645,7 +645,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenReplaced).toBe("allergy_risk");
+      expect(result[0]!.allergenReplaced).toBe("allergy_risk");
     });
 
     it("leaves order unchanged when allergy_risk_top is false", async () => {
@@ -664,7 +664,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // value_descending: birch(4) > grasses(3) > allergy_risk(1)
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("allergy_risk_top is a no-op when allergy_risk is already first", async () => {
@@ -681,7 +681,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenReplaced).toBe("allergy_risk");
+      expect(result[0]!.allergenReplaced).toBe("allergy_risk");
       expect(result.length).toBe(2);
     });
   });
@@ -708,8 +708,8 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].stale).toBe(true);
-      expect(result[0].days).toEqual([]);
+      expect(result[0]!.stale).toBe(true);
+      expect(result[0]!.days).toEqual([]);
     });
 
     it("includes staleSince when the attribute is present", async () => {
@@ -729,7 +729,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].staleSince).toBe("2024-05-01T00:00:00");
+      expect(result[0]!.staleSince).toBe("2024-05-01T00:00:00");
     });
 
     it("returns stale:true with empty days when forecast array is empty", async () => {
@@ -748,8 +748,8 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].stale).toBe(true);
-      expect(result[0].days).toEqual([]);
+      expect(result[0]!.stale).toBe(true);
+      expect(result[0]!.days).toEqual([]);
     });
 
     it("does not set stale:true when data_stale is false and forecast is present", async () => {
@@ -761,7 +761,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].stale).toBeUndefined();
+      expect(result[0]!.stale).toBeUndefined();
     });
   });
 
@@ -797,7 +797,7 @@ describe("PEU adapter: fetchForecast", () => {
       // Native level 2 -> "Medium" (was customLevels[3] under spread,
       // now customLevels[3] picked into native index 2 via the [0,1,3,5,6]
       // migration extraction; same user-visible outcome.)
-      expect(result[0].days[0].state_text).toBe("Medium");
+      expect(result[0]!.days[0]!.state_text).toBe("Medium");
     });
 
     it("accepts 5 custom level labels at native indices", async () => {
@@ -815,7 +815,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // Native level 2 -> customLevels[2] = "Moderate"
-      expect(result[0].days[0].state_text).toBe("Moderate");
+      expect(result[0]!.days[0]!.state_text).toBe("Moderate");
     });
 
     it("falls back to default level names for empty/null custom entries (7 labels)", async () => {
@@ -831,7 +831,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       // Native level 0 -> scaled level 0 -> customLevels[0] = "CustomZero"
-      expect(result[0].days[0].state_text).toBe("CustomZero");
+      expect(result[0]!.days[0]!.state_text).toBe("CustomZero");
     });
 
     it("falls back to default level names for empty/null custom entries (5 labels)", async () => {
@@ -849,8 +849,8 @@ describe("PEU adapter: fetchForecast", () => {
 
       // Native level 0 -> scaled level 0; customLevels[0] is "" -> fallback to i18n
       // Just verify it's a non-empty string (i18n fallback)
-      expect(typeof result[0].days[0].state_text).toBe("string");
-      expect(result[0].days[0].state_text.length).toBeGreaterThan(0);
+      expect(typeof result[0]!.days[0]!.state_text).toBe("string");
+      expect(result[0]!.days[0]!.state_text.length).toBeGreaterThan(0);
     });
   });
 
@@ -873,7 +873,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.mypfx_birch_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.mypfx_birch_sfx");
     });
 
     it("skips allergen when manual entity is not in hass.states", async () => {
@@ -917,7 +917,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.pfx_allergy_risk_hourly_sfx");
+      expect(result[0]!.entity_id).toBe("sensor.pfx_allergy_risk_hourly_sfx");
     });
 
     it("works without prefix and suffix (empty strings)", async () => {
@@ -935,7 +935,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.birch");
+      expect(result[0]!.entity_id).toBe("sensor.birch");
     });
   });
 
@@ -1021,7 +1021,7 @@ describe("PEU adapter: fetchForecast", () => {
       ]);
 
       const discovery = discoverPeuSensors(hass);
-      const [, loc] = [...discovery.locations.entries()][0];
+      const [, loc] = [...discovery.locations.entries()][0]!;
       expect(loc.label).toBe("Hamburg");
     });
 
@@ -1046,7 +1046,7 @@ describe("PEU adapter: fetchForecast", () => {
       ]);
 
       const discovery = discoverPeuSensors(hass);
-      const [, loc] = [...discovery.locations.entries()][0];
+      const [, loc] = [...discovery.locations.entries()][0]!;
       expect(loc.label).toBe("Hamburg");
     });
 
@@ -1092,7 +1092,7 @@ describe("PEU adapter: fetchForecast", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe(
+      expect(result[0]!.entity_id).toBe(
         "sensor.polleninformation_brussels_birch",
       );
     });
@@ -1130,7 +1130,7 @@ describe("PEU adapter: fetchForecast", () => {
 
       const result = await fetchForecast(hass, config);
 
-      expect(result[0].allergenCapitalized).toBe("My Custom Birch Name");
+      expect(result[0]!.allergenCapitalized).toBe("My Custom Birch Name");
     });
 
     it("uses custom no_information label for state_text when level is an unrecognized string", async () => {
@@ -1169,8 +1169,8 @@ describe("PEU adapter: fetchForecast", () => {
       // "unknown" is not null/undefined, so ?? keeps it; Number("unknown") = NaN;
       // indexToLevel(NaN) returns -1 => scaledLevel < 0 => state_text = noInfoLabel.
       expect(result.length).toBe(1);
-      expect(result[0].days.length).toBe(1);
-      expect(result[0].days[0].state_text).toBe("N/A");
+      expect(result[0]!.days.length).toBe(1);
+      expect(result[0]!.days[0]!.state_text).toBe("N/A");
     });
   });
 });

--- a/test/adapters/plu.test.ts
+++ b/test/adapters/plu.test.ts
@@ -44,19 +44,19 @@ describe("PLU adapter: fetchForecast", () => {
 
     const hass = makeHass({ birch: 0 });
     const result = await fetchForecast(hass, makeConfig(base));
-    expect(result[0].days[0].state).toBe(0); // 0 grains = level 0
+    expect(result[0]!.days[0]!.state).toBe(0); // 0 grains = level 0
 
     const hass2 = makeHass({ birch: 5 });
     const result2 = await fetchForecast(hass2, makeConfig(base));
-    expect(result2[0].days[0].state).toBe(1); // 5 < 11 = level 1 (low)
+    expect(result2[0]!.days[0]!.state).toBe(1); // 5 < 11 = level 1 (low)
 
     const hass3 = makeHass({ birch: 25 });
     const result3 = await fetchForecast(hass3, makeConfig(base));
-    expect(result3[0].days[0].state).toBe(2); // 11 <= 25 < 51 = level 2 (moderate)
+    expect(result3[0]!.days[0]!.state).toBe(2); // 11 <= 25 < 51 = level 2 (moderate)
 
     const hass4 = makeHass({ birch: 100 });
     const result4 = await fetchForecast(hass4, makeConfig(base));
-    expect(result4[0].days[0].state).toBe(3); // 100 >= 51 = level 3 (high)
+    expect(result4[0]!.days[0]!.state).toBe(3); // 100 >= 51 = level 3 (high)
   });
 
   it("returns -1 for NaN/negative values", async () => {
@@ -71,7 +71,7 @@ describe("PLU adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(-1);
+    expect(result[0]!.days[0]!.state).toBe(-1);
   });
 
   it("keeps the raw concentration in raw_value and shows the level by default", async () => {
@@ -82,8 +82,8 @@ describe("PLU adapter: fetchForecast", () => {
 
     // display_state is the calculated level (shown by default); the raw p/m3
     // concentration lives in raw_value (surfaced only via numeric_value_raw).
-    expect(result[0].days[0].raw_value).toBe(25);
-    expect(result[0].days[0].display_state).toBe(result[0].days[0].state);
+    expect(result[0]!.days[0]!.raw_value).toBe(25);
+    expect(result[0]!.days[0]!.display_state).toBe(result[0]!.days[0]!.state);
   });
 
   it("has PLU-specific extra day properties", async () => {
@@ -100,7 +100,7 @@ describe("PLU adapter: fetchForecast", () => {
     const config = makeConfig({ allergens: ["birch"] });
 
     const result = await fetchForecast(hass, config);
-    const day = result[0].days[0];
+    const day = result[0]!.days[0]!;
 
     expect(day).toHaveProperty("thresholds");
     expect(day.thresholds).toEqual({ moderate: 11, high: 51 });
@@ -115,7 +115,7 @@ describe("PLU adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(1);
+    expect(result[0]!.days.length).toBe(1);
   });
 
   it("pads days array to days_to_show with empty entries", async () => {
@@ -124,10 +124,10 @@ describe("PLU adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
+    expect(result[0]!.days.length).toBe(3);
     // Padded days should have state -1
-    expect(result[0].days[1].state).toBe(-1);
-    expect(result[0].days[2].state).toBe(-1);
+    expect(result[0]!.days[1]!.state).toBe(-1);
+    expect(result[0]!.days[2]!.state).toBe(-1);
   });
 
   it("resolves sensors via alias map (Latin name)", async () => {
@@ -141,7 +141,7 @@ describe("PLU adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.pollen_betula");
+    expect(result[0]!.entity_id).toBe("sensor.pollen_betula");
   });
 
   it("skips allergens not in PLU_SUPPORTED_ALLERGENS", async () => {
@@ -151,7 +151,7 @@ describe("PLU adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("stub config exposes manual-mode fields (location + prefix + suffix), no city/region_id", () => {
@@ -331,7 +331,7 @@ describe("PLU adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("sorts with locale-aware comparison for name sorting", async () => {
@@ -349,12 +349,12 @@ describe("PLU adapter: fetchForecast", () => {
     // PLU passes lang to localeCompare (unique among adapters)
     expect(result.length).toBe(2);
     const names = result.map((s) => s.allergenCapitalized);
-    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    const sorted = [...names]!.sort((a, b) => a.localeCompare(b));
     expect(names).toEqual(sorted);
   });
 
   it("PLU_SUPPORTED_ALLERGENS is alphabetically sorted", () => {
-    const sorted = [...PLU_SUPPORTED_ALLERGENS].sort();
+    const sorted = [...PLU_SUPPORTED_ALLERGENS]!.sort();
     expect(PLU_SUPPORTED_ALLERGENS).toEqual(sorted);
   });
 });

--- a/test/adapters/pp.test.ts
+++ b/test/adapters/pp.test.ts
@@ -48,7 +48,7 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("bjork");
+    expect(result[0]!.allergenReplaced).toBe("bjork");
   });
 
   it("resolves allergen display names via i18n", async () => {
@@ -61,8 +61,8 @@ describe("PP adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     // allergenCapitalized should be a non-empty string (i18n lookup or fallback)
-    expect(result[0].allergenCapitalized).toBeTruthy();
-    expect(typeof result[0].allergenCapitalized).toBe("string");
+    expect(result[0]!.allergenCapitalized).toBeTruthy();
+    expect(typeof result[0]!.allergenCapitalized).toBe("string");
   });
 
   it("returns correct number of days based on days_to_show", async () => {
@@ -75,11 +75,11 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(3);
-    expect(result[0].days[0]).toBeDefined();
-    expect(result[0].days[1]).toBeDefined();
-    expect(result[0].days[2]).toBeDefined();
-    expect(result[0].days[3]).toBeUndefined();
+    expect(result[0]!.days.length).toBe(3);
+    expect(result[0]!.days[0]).toBeDefined();
+    expect(result[0]!.days[1]).toBeDefined();
+    expect(result[0]!.days[2]).toBeDefined();
+    expect(result[0]!.days[3]).toBeUndefined();
   });
 
   it("clamps levels to 0-6 range, returns null for NaN", async () => {
@@ -93,14 +93,14 @@ describe("PP adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     // Level 8 should be clamped to 6
-    expect(result[0].days[0].state).toBe(6);
+    expect(result[0]!.days[0]!.state).toBe(6);
     // -1 and NaN produce null via clampLevel; with pollen_threshold 0 these
     // days still appear but carry the no-data sentinel state -1 (no info, not a
     // real level 0), so the render path shows the no-data pattern.
-    expect(result[0].days[1].state).toBe(-1);
-    expect(result[0].days[2].state).toBe(-1);
+    expect(result[0]!.days[1]!.state).toBe(-1);
+    expect(result[0]!.days[2]!.state).toBe(-1);
     // Valid level passes through
-    expect(result[0].days[3].state).toBe(3);
+    expect(result[0]!.days[3]!.state).toBe(3);
   });
 
   it("filters allergens below pollen_threshold", async () => {
@@ -118,7 +118,7 @@ describe("PP adapter: fetchForecast", () => {
 
     // Only Björk should pass (Al has all 0s, below threshold 1)
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("bjork");
+    expect(result[0]!.allergenReplaced).toBe("bjork");
   });
 
   it("includes all allergens when pollen_threshold is 0", async () => {
@@ -150,7 +150,7 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBeGreaterThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeGreaterThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("sorts by value_ascending", async () => {
@@ -166,7 +166,7 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBeLessThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeLessThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("respects user phrase overrides for allergen names", async () => {
@@ -185,7 +185,7 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenCapitalized).toBe("Custom Birch");
+    expect(result[0]!.allergenCapitalized).toBe("Custom Birch");
   });
 
   it("handles manual mode entity resolution", async () => {
@@ -203,7 +203,7 @@ describe("PP adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.my_prefix_bjork_suffix");
+    expect(result[0]!.entity_id).toBe("sensor.my_prefix_bjork_suffix");
   });
 
   it("auto-detects city from sensor entity IDs when city is empty", async () => {
@@ -219,7 +219,7 @@ describe("PP adapter: fetchForecast", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.pollen_goteborg_bjork");
+    expect(result[0]!.entity_id).toBe("sensor.pollen_goteborg_bjork");
   });
 
   it("each day object has required properties", async () => {
@@ -230,7 +230,7 @@ describe("PP adapter: fetchForecast", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    const day = result[0].days[0];
+    const day = result[0]!.days[0]!;
 
     expect(day).toHaveProperty("name");
     expect(day).toHaveProperty("day");
@@ -251,7 +251,7 @@ describe("PP adapter: fetchForecast", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].entity_id).toBe("sensor.pollen_stockholm_bjork");
+    expect(result[0]!.entity_id).toBe("sensor.pollen_stockholm_bjork");
   });
 });
 
@@ -353,7 +353,7 @@ describe("PP adapter: resolveEntityIds — device-based discovery", () => {
     ]);
 
     const discovery = PP.discoverPpSensors(hass);
-    const [, loc] = [...discovery.locations.entries()][0];
+    const [, loc] = [...discovery.locations.entries()][0]!;
     expect(loc.label).toBe("Visby");
   });
 
@@ -374,7 +374,7 @@ describe("PP adapter: resolveEntityIds — device-based discovery", () => {
     ]);
 
     const discovery = PP.discoverPpSensors(hass);
-    const [, loc] = [...discovery.locations.entries()][0];
+    const [, loc] = [...discovery.locations.entries()][0]!;
     expect(loc.label).toBe("My Visby card");
   });
 });

--- a/test/adapters/silam.test.ts
+++ b/test/adapters/silam.test.ts
@@ -331,7 +331,7 @@ describe("fetchForecast: basic shape", () => {
     });
 
     const result = await fetchForecast(hass, config);
-    const day = result[0].days[0];
+    const day = result[0]!.days[0]!;
 
     expect(day).toHaveProperty("name");
     expect(day).toHaveProperty("day");
@@ -353,7 +353,7 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenReplaced).toBe("birch");
+    expect(result[0]!.allergenReplaced).toBe("birch");
   });
 
   it("allergenCapitalized is a non-empty string", async () => {
@@ -366,8 +366,8 @@ describe("fetchForecast: basic shape", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].allergenCapitalized).toBeTruthy();
-    expect(typeof result[0].allergenCapitalized).toBe("string");
+    expect(result[0]!.allergenCapitalized).toBeTruthy();
+    expect(typeof result[0]!.allergenCapitalized).toBe("string");
   });
 });
 
@@ -387,9 +387,9 @@ describe("fetchForecast: level computation from grain counts", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
     // The raw grains/m3 measurement is kept for numeric_value_raw.
-    expect(result[0].days[0].raw_value).toBe(30);
+    expect(result[0]!.days[0]!.raw_value).toBe(30);
   });
 
   it("converts pollen_alder=5 to level 1 (between thresholds 1 and 10)", async () => {
@@ -403,7 +403,7 @@ describe("fetchForecast: level computation from grain counts", () => {
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days[0].state).toBe(1);
+    expect(result[0]!.days[0]!.state).toBe(1);
   });
 
   it("converts index=2 attribute to level 3 via indexToLevel", async () => {
@@ -418,7 +418,7 @@ describe("fetchForecast: level computation from grain counts", () => {
     const result = await fetchForecast(hass, config);
 
     // allergens: ["index"] normalizes to "allergy_risk" internally
-    expect(result[0].days[0].state).toBe(3);
+    expect(result[0]!.days[0]!.state).toBe(3);
   });
 });
 
@@ -441,11 +441,11 @@ describe("fetchForecast: daily forecast from entity.attributes.forecast", () => 
     const result = await fetchForecast(hass, config);
 
     // day0: current value 30 -> level 2
-    expect(result[0].days[0].state).toBe(2);
+    expect(result[0]!.days[0]!.state).toBe(2);
     // day1: forecast[0] pollen_birch=40 -> level 2
-    expect(result[0].days[1].state).toBe(2);
+    expect(result[0]!.days[1]!.state).toBe(2);
     // day2: forecast[1] pollen_birch=20 -> level 1
-    expect(result[0].days[2].state).toBe(1);
+    expect(result[0]!.days[2]!.state).toBe(1);
   });
 
   it("limits forecast to days_to_show", async () => {
@@ -459,8 +459,8 @@ describe("fetchForecast: daily forecast from entity.attributes.forecast", () => 
 
     const result = await fetchForecast(hass, config);
 
-    expect(result[0].days.length).toBe(2);
-    expect(result[0].days[2]).toBeUndefined();
+    expect(result[0]!.days.length).toBe(2);
+    expect(result[0]!.days[2]).toBeUndefined();
   });
 });
 
@@ -496,9 +496,9 @@ describe("fetchForecast: forecastEvent parameter", () => {
     const result = await fetchForecast(hass, config, forecastEvent as any);
 
     // day1 comes from forecastEvent.forecast[0]: pollen_birch=600 -> level 5
-    expect(result[0].days[1].state).toBe(5);
+    expect(result[0]!.days[1]!.state).toBe(5);
     // day2 comes from forecastEvent.forecast[1]: pollen_birch=1200 -> level 6
-    expect(result[0].days[2].state).toBe(6);
+    expect(result[0]!.days[2]!.state).toBe(6);
   });
 
   it("ignores forecastEvent when forecast array is absent", async () => {
@@ -515,7 +515,7 @@ describe("fetchForecast: forecastEvent parameter", () => {
     const result = await fetchForecast(hass, config, forecastEvent as any);
 
     expect(Array.isArray(result)).toBe(true);
-    expect(result[0].days.length).toBe(2);
+    expect(result[0]!.days.length).toBe(2);
   });
 });
 
@@ -589,7 +589,7 @@ describe("fetchForecast: sorting", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(2);
-    expect(result[0].days[0].state).toBeGreaterThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeGreaterThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("sorts by value_ascending", async () => {
@@ -609,7 +609,7 @@ describe("fetchForecast: sorting", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(2);
-    expect(result[0].days[0].state).toBeLessThanOrEqual(result[1].days[0].state);
+    expect(result[0]!.days[0]!.state).toBeLessThanOrEqual(result[1]!.days[0]!.state);
   });
 
   it("sort: 'none' preserves allergen order", async () => {
@@ -629,8 +629,8 @@ describe("fetchForecast: sorting", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(2);
-    expect(result[0].allergenReplaced).toBe("birch");
-    expect(result[1].allergenReplaced).toBe("alder");
+    expect(result[0]!.allergenReplaced).toBe("birch");
+    expect(result[1]!.allergenReplaced).toBe("alder");
   });
 });
 
@@ -658,7 +658,7 @@ describe("fetchForecast: index_top pinning", () => {
     const result = await fetchForecast(hass, config);
 
     // allergy_risk (index) must appear first regardless of sort order
-    expect(result[0].allergenReplaced).toBe("allergy_risk");
+    expect(result[0]!.allergenReplaced).toBe("allergy_risk");
   });
 
   it("does not rearrange when index_top is false", async () => {
@@ -681,7 +681,7 @@ describe("fetchForecast: index_top pinning", () => {
 
     // With index_top false and value_descending, birch (level 5) or alder (level 5)
     // should come first, not index
-    expect(result[0].allergenReplaced).not.toBe("allergy_risk");
+    expect(result[0]!.allergenReplaced).not.toBe("allergy_risk");
   });
 });
 
@@ -704,7 +704,7 @@ describe("fetchForecast: hourly mode", () => {
     const result = await fetchForecast(hass, config);
 
     // In hourly mode maxItems = min(forecastArr.length, days_to_show) = min(2, 2) = 2
-    expect(result[0].days.length).toBe(2);
+    expect(result[0]!.days.length).toBe(2);
   });
 
   it("uses datetime from forecast items for day labels in hourly mode", async () => {
@@ -720,7 +720,7 @@ describe("fetchForecast: hourly mode", () => {
     const result = await fetchForecast(hass, config);
 
     // Hourly label should be a time string (HH:MM format), not a weekday name
-    const label: any = result[0].days[0].day;
+    const label: any = result[0]!.days[0]!.day;
     expect(typeof label).toBe("string");
     expect(label.length).toBeGreaterThan(0);
   });
@@ -740,8 +740,8 @@ describe("fetchForecast: twice_daily mode", () => {
     const result = await fetchForecast(hass, config);
 
     // Even index = morning, odd = evening
-    expect(result[0].days[0].icon).toBe("mdi:weather-sunset-up");
-    expect(result[0].days[1].icon).toBe("mdi:weather-sunset-down");
+    expect(result[0]!.days[0]!.icon).toBe("mdi:weather-sunset-up");
+    expect(result[0]!.days[1]!.icon).toBe("mdi:weather-sunset-down");
   });
 });
 
@@ -798,7 +798,7 @@ describe("fetchForecast: manual mode", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.custom_birch_end");
+    expect(result[0]!.entity_id).toBe("sensor.custom_birch_end");
   });
 
   it("falls back to localized slug when canonical slug has no match", async () => {
@@ -845,7 +845,7 @@ describe("fetchForecast: manual mode", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].entity_id).toBe("sensor.custom_berk_end");
+    expect(result[0]!.entity_id).toBe("sensor.custom_berk_end");
   });
 
   describe("entity_weather override (#231)", () => {
@@ -877,7 +877,7 @@ describe("fetchForecast: manual mode", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state).toBe(2); // birch=30 -> level 2
+      expect(result[0]!.days[0]!.state).toBe(2); // birch=30 -> level 2
     });
 
     it("returns [] with a clear warning when entity_weather points at a missing entity", async () => {
@@ -945,7 +945,7 @@ describe("fetchForecast: manual mode", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].entity_id).toBe("sensor.custom_birch");
+      expect(result[0]!.entity_id).toBe("sensor.custom_birch");
     });
 
     it("warns when manual mode has neither entity_weather nor a discoverable weather entity", async () => {
@@ -1151,7 +1151,7 @@ describe("fetchForecast: manual mode", () => {
       const result = await fetchForecast(hass, config);
 
       expect(result.length).toBe(1);
-      expect(result[0].days[0].state).toBe(2);
+      expect(result[0]!.days[0]!.state).toBe(2);
     });
 
     it("still runs discovery when manual mode lacks entity_weather", async () => {
@@ -1205,7 +1205,7 @@ describe("fetchForecast: 'index' allergen alias", () => {
     const result = await fetchForecast(hass, config);
 
     expect(result.length).toBe(1);
-    expect(result[0].allergenReplaced).toBe("allergy_risk");
+    expect(result[0]!.allergenReplaced).toBe("allergy_risk");
   });
 
   it("uses pollen_index attribute as fallback when index is absent", async () => {
@@ -1228,7 +1228,7 @@ describe("fetchForecast: 'index' allergen alias", () => {
     const result = await fetchForecast(hass, config);
 
     // index=3 via indexToLevel(3) -> scale[3] = 5
-    expect(result[0].days[0].state).toBe(5);
+    expect(result[0]!.days[0]!.state).toBe(5);
   });
 });
 

--- a/test/golden-fixtures.ts
+++ b/test/golden-fixtures.ts
@@ -52,7 +52,10 @@ function ppHass(cityKey: string, allergenMap: Record<string, Array<number | null
 }
 
 // -- DWD ------------------------------------------------------------------
-function dwdHass(regionId: string, allergenMap: Record<string, number[]>) {
+function dwdHass(
+  regionId: string,
+  allergenMap: Record<string, [number, number, number]>,
+) {
   const states: Record<string, any> = {};
   for (const [allergen, [today, tomorrow, twoDays]] of Object.entries(allergenMap)) {
     states[`sensor.pollenflug_${allergen}_${regionId}`] = createDWDSensor(

--- a/test/utils/adapter-helpers.test.ts
+++ b/test/utils/adapter-helpers.test.ts
@@ -1121,7 +1121,7 @@ describe("findLocationBySlug", () => {
     // Extractor pulls out the city name from a known position
     const slugExtractor = (eid: string) => {
       const m = eid.match(/_([A-Z]+)_extra$/);
-      return m ? m[1].toLowerCase() : null;
+      return m ? m[1]!.toLowerCase() : null;
     };
 
     const result = findLocationBySlug(discovery, "nice", { slugExtractor })!;

--- a/test/utils/filter-post-fetch.test.ts
+++ b/test/utils/filter-post-fetch.test.ts
@@ -38,7 +38,7 @@ describe("filterSensorsPostFetch", () => {
       const available = ["sensor.silam_pollen_stockholm_birch"];
       const result = filterSensorsPostFetch(sensors, baseCfg, available, [], silamMapping);
       expect(result).toHaveLength(1);
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("drops sensors whose entity_id is NOT in availableSensors", () => {
@@ -80,7 +80,7 @@ describe("filterSensorsPostFetch", () => {
         const available = ["sensor.silam_pollen_stockholm_birch"];
         const result = filterSensorsPostFetch(sensors, cfg, available, hassKeys, silamMapping);
         expect(result).toHaveLength(1);
-        expect(result[0].allergenReplaced).toBe("birch");
+        expect(result[0]!.allergenReplaced).toBe("birch");
       });
 
       it("resolves localized HA slugs via reverse map", () => {
@@ -208,7 +208,7 @@ describe("filterSensorsPostFetch", () => {
       ];
       const result = filterSensorsPostFetch(sensors, cfg, [], [], silamMapping);
       expect(result).toHaveLength(1);
-      expect(result[0].allergenReplaced).toBe("birch");
+      expect(result[0]!.allergenReplaced).toBe("birch");
     });
 
     it("Kleenex: filters by normalized allergen name", () => {

--- a/test/utils/slugify.test.ts
+++ b/test/utils/slugify.test.ts
@@ -4,7 +4,7 @@ import { PP_POSSIBLE_CITIES } from "../../src/constants.js";
 
 describe("slugify: backward compatibility", () => {
   it("produces expected slugs for all 22 PP cities", () => {
-    const expected = [
+    const expected: Array<[string, string]> = [
       ["Borlänge", "borlange"],
       ["Bräkne-Hoby", "brakne_hoby"],
       ["Eskilstuna", "eskilstuna"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true,
     "useDefineForClassFields": false,
     "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "types": ["vite/client"]
   },
   "include": ["src", "test"],


### PR DESCRIPTION
Closes #306 (manual close needed after merge; PR targets dev).

Enables `noUncheckedIndexedAccess` in tsconfig and resolves all resulting type errors — 750 at the point of enablement (117 in `src/`, 633 in `test/`) down to 0. The flag was trialled and deliberately deferred during the 4.0.0 close-out (PR #298); this is the dedicated pass.

Structure: one commit enables the flag, then one commit per module cluster (utils, rendering, adapters, card, editor, tests). Fix style is type-level only — local guards and `??` fallbacks that preserve today's behaviour exactly, non-null assertions where the invariant is established by adjacent code (after length checks, padded arrays), no new `any`, no logic changes. Test-side fixes are compile-time-only assertions; the test count is the proof: every pre-existing test passes unchanged and golden snapshots are untouched.

One latent oddity found and neutralized along the way (adapters commit): the atmo classification loop could call `id.includes(undefined)` for a pollution allergen missing from `ATMO_ALLERGEN_MAP` — unreachable with the current constant set, now explicitly guarded.

Rebased twice during the cycle (onto #310/#312, then onto #311) with the new code from those branches given the same treatment; the guards live inside the matching module commits.

Verification: typecheck 0 errors, lint 0/0, 1436 tests passed, goldens untouched, gzip 211744 bytes within budget (+109 bytes over dev).

---

**Reviewer note (non-blocking):** the `x[clampedIndex] || x[0]!` sites in `level-circle-mixin.ts` assert a first element that an empty user-supplied `allergen_colors`/`levels_colors` array does not provide — behaviour is unchanged (returned `undefined` before this branch too), but the config boundary does not validate those array lengths. Follow-up candidate for a separate PR: fall back to `LEVELS_DEFAULTS` instead of index 0, or add a length guard at the boundary (both change empty-array behaviour, hence out of scope here).
