### PR TITLE
(kleenex) Trim detail names, scope manual prefix to one location, map 'Chenepod'

### DIFF
--- a/src/adapters/kleenex/constants.ts
+++ b/src/adapters/kleenex/constants.ts
@@ -77,6 +77,10 @@ export const KLEENEX_ALLERGEN_MAP: Record<string, string> = {
   ortie: "nettle",
 
   // Weeds - Italian (IT)
+  // The IT endpoint reports English allergen names, so the Italian aliases
+  // below are never exercised in practice -- but it misspells chenopod as
+  // "Chenepod" (Roma, Milano), which is the alias IT installs actually need.
+  chenepod: "chenopod",
   ambrosia: "ragweed",
   artemisia: "mugwort",
   chenopodio: "chenopod",

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -532,6 +532,25 @@ export function _resetManualScopeWarningsForTest(): void {
 }
 
 /**
+ * Tell the user, once per configuration, that a manual prefix matched more
+ * than one location and which one survived. Narrowing removes rows and renames
+ * the header, so it must never be a silent decision.
+ */
+function warnOnceAboutNarrowing(
+  prefix: string,
+  suffix: string,
+  kept: string,
+  dropped: string[],
+): void {
+  const warnKey = `${prefix}|${suffix}`;
+  if (MANUAL_SCOPE_WARNED_KEYS.has(warnKey)) return;
+  MANUAL_SCOPE_WARNED_KEYS.add(warnKey);
+  console.warn(
+    `[Kleenex] The configured entity_prefix '${prefix}' matches entities from several locations. Showing '${kept}' and ignoring: ${dropped.join(", ")}. Use a prefix that only matches the location you want, or switch from manual to a location-based config.`,
+  );
+}
+
+/**
  * Every slug a discovered location can reasonably be addressed by: its
  * discovery key (the config-entry instance slug), its label, and both device
  * names. A manual `entity_prefix` is minted from one of these, so they are what
@@ -554,6 +573,67 @@ function locationSlugCandidates(
   add(device?.name_by_user);
   add(device?.name);
   return out;
+}
+
+/** Every slug a *device* can be addressed by, for prefix-ownership matching. */
+function deviceSlugCandidates(
+  device: DeviceRegistryEntry | null | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  const add = (value: unknown): void => {
+    if (typeof value !== "string" || !value) return;
+    const slug = slugify(value);
+    if (slug) out.add(slug);
+  };
+  add(deviceIdentifierSlug(device));
+  add(device?.name_by_user);
+  add(device?.name);
+  return out;
+}
+
+/** Human-readable name for a device, for warnings and the header. */
+function deviceLabel(device: DeviceRegistryEntry | null | undefined): string {
+  const name = device?.name_by_user || device?.name;
+  if (!name) return "";
+  const m = /^Kleenex Pollen Radar\s*\((.+)\)\s*$/.exec(name);
+  return m?.[1]?.trim() || name;
+}
+
+/** Device ids of every Kleenex device in the registry. */
+function kleenexDeviceIds(hass: HomeAssistant): Set<string> {
+  const out = new Set<string>();
+  for (const [deviceId, device] of Object.entries(hass?.devices || {})) {
+    if (deviceIdentifierSlug(device)) out.add(deviceId);
+  }
+  return out;
+}
+
+/**
+ * The Kleenex device a manual `entity_prefix` was minted from, if any.
+ *
+ * Read from the device registry rather than from discovery, because discovery
+ * only sees devices with state-backed entities: when the intended config entry
+ * is down, its device is absent from discovery entirely, and deciding ownership
+ * on discovery alone would silently hand the prefix to whichever *other*
+ * location it happens to match (Codex round 2 on PR #315). Ownership must
+ * survive the owner having no data -- the card then shows its usual empty state
+ * for the right place instead of another city's forecast.
+ */
+function findPrefixOwnerDevice(
+  hass: HomeAssistant,
+  needle: string,
+): string | null {
+  if (!needle) return null;
+  let found: string | null = null;
+  for (const [deviceId, device] of Object.entries(hass?.devices || {})) {
+    if (!deviceIdentifierSlug(device)) continue;
+    if (!deviceSlugCandidates(device).has(needle)) continue;
+    // Two devices answering to the same slug cannot say which was meant; the
+    // discovery-based path below applies its own tie-breaks instead.
+    if (found) return null;
+    found = deviceId;
+  }
+  return found;
 }
 
 /** Outcome of scoping a manual-mode prefix match to a single location. */
@@ -609,7 +689,51 @@ export function scopeManualEntities(
   },
 ): KleenexManualScope {
   const { prefix, suffix = "", debug = false } = opts;
-  if (entityIds.length < 2 || !prefix) return { entityIds, label: null };
+  if (entityIds.length === 0 || !prefix) return { entityIds, label: null };
+
+  const needle = slugify(prefix.replace(/_+$/, ""));
+
+  // Step 1, registry-level: a device whose own slug is the prefix owns it,
+  // whether or not it currently has usable states. Everything belonging to
+  // another Kleenex device is dropped; entities with no registry entry, and
+  // entities on devices from other integrations, are none of our business and
+  // stay.
+  const ownerDeviceId = findPrefixOwnerDevice(hass, needle);
+  if (ownerDeviceId) {
+    const kleenexDevices = kleenexDeviceIds(hass);
+    const kept = entityIds.filter((eid) => {
+      const deviceId = hass?.entities?.[eid]?.device_id;
+      if (!deviceId || deviceId === ownerDeviceId) return true;
+      return !kleenexDevices.has(deviceId);
+    });
+    if (kept.length === entityIds.length) return { entityIds, label: null };
+
+    const droppedDevices = new Set<string>();
+    for (const eid of entityIds) {
+      if (kept.includes(eid)) continue;
+      const deviceId = hass?.entities?.[eid]?.device_id;
+      if (deviceId) droppedDevices.add(deviceId);
+    }
+    const ownerDevice = hass?.devices?.[ownerDeviceId];
+    const label = deviceLabel(ownerDevice) || null;
+    warnOnceAboutNarrowing(
+      prefix,
+      suffix,
+      label || ownerDeviceId,
+      [...droppedDevices].map(
+        (deviceId) => deviceLabel(hass?.devices?.[deviceId]) || deviceId,
+      ),
+    );
+    if (debug) {
+      console.debug(
+        `[Kleenex] Manual prefix owned by device '${ownerDeviceId}'`,
+        kept,
+      );
+    }
+    return { entityIds: kept, label };
+  }
+
+  if (entityIds.length < 2) return { entityIds, label: null };
 
   const discovery = opts.discovery ?? discoverKleenex(hass, debug);
   if (!discovery || discovery.locations.size < 2) {
@@ -642,10 +766,9 @@ export function scopeManualEntities(
   }
   if (scores.size < 2) return { entityIds, label: null };
 
-  // Step 1: does any candidate location's own slug equal the prefix? The
-  // prefix was minted from a device name, so this settles ownership without
-  // looking at entity names at all.
-  const needle = slugify(prefix.replace(/_+$/, ""));
+  // Step 2: no device owned the prefix outright, but a discovered location may
+  // still answer to it through its discovery key or label -- shapes the device
+  // registry alone does not carry.
   const owners = [...scores.keys()].filter((key) =>
     locationSlugCandidates(hass, key, discovery.locations.get(key)).has(needle),
   );
@@ -674,19 +797,14 @@ export function scopeManualEntities(
 
   const label = winner ? (discovery.locations.get(winner)?.label ?? null) : null;
 
-  // Narrowing removes rows and renames the header, so it is never silent: a
-  // user with two legacy locations and a broad prefix would otherwise see data
-  // disappear with no explanation anywhere.
-  const dropped = [...scores.keys()]
-    .filter((key) => key !== winner)
-    .map((key) => discovery.locations.get(key)?.label || key);
-  const warnKey = `${prefix}|${suffix}`;
-  if (!MANUAL_SCOPE_WARNED_KEYS.has(warnKey)) {
-    MANUAL_SCOPE_WARNED_KEYS.add(warnKey);
-    console.warn(
-      `[Kleenex] The configured entity_prefix '${prefix}' matches entities from several locations. Showing '${label || winner}' and ignoring: ${dropped.join(", ")}. Use a prefix that only matches the location you want, or switch from manual to a location-based config.`,
-    );
-  }
+  warnOnceAboutNarrowing(
+    prefix,
+    suffix,
+    label || winner || "",
+    [...scores.keys()]
+      .filter((key) => key !== winner)
+      .map((key) => discovery.locations.get(key)?.label || key),
+  );
   if (debug) {
     console.debug(`[Kleenex] Manual prefix narrowed to '${winner}'`, kept);
   }

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -79,6 +79,18 @@ export function canonicalAllergenFromSlug(
   return undefined;
 }
 
+/**
+ * Normalize an allergen name as reported inside `details[]` / `forecast[].details[]`.
+ *
+ * The feed is not whitespace-clean: the FR zone reports names like `"Poaceae "`,
+ * and an untrimmed lookup key matches neither KLEENEX_ALLERGEN_MAP nor the
+ * configured allergen list, so the row disappears without a trace. Returns an
+ * empty string for anything that isn't a usable name.
+ */
+export function normalizeDetailName(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim().toLowerCase() : "";
+}
+
 // Static reverse index: canonical allergen name -> Set of slugified alias
 // entity-suffixes. Built once from KLEENEX_ALLERGEN_MAP since the map is
 // module-level constant data.
@@ -163,7 +175,7 @@ function allergenFromUniqueId(
   if (typeof uniqueId !== "string" || !uniqueId) return null;
   const parts = uniqueId.split("-");
   if (parts.length < 2) return null;
-  const name = parts[parts.length - 2]?.trim().toLowerCase();
+  const name = normalizeDetailName(parts[parts.length - 2]);
   if (!name) return null;
   const canonical = KLEENEX_ALLERGEN_MAP[name];
   return canonical && !CATEGORY_KEYS.has(canonical) ? canonical : null;
@@ -192,7 +204,7 @@ function classifyDetailEntity(
   if (typeof friendly === "string") {
     const lastWord = friendly.trim().split(/\s+/).pop();
     if (lastWord) {
-      const byName = KLEENEX_ALLERGEN_MAP[lastWord.toLowerCase()];
+      const byName = KLEENEX_ALLERGEN_MAP[normalizeDetailName(lastWord)];
       if (byName && !CATEGORY_KEYS.has(byName)) return byName;
     }
   }

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -520,6 +520,31 @@ export function resolveKleenexLocationEntry(
   });
 }
 
+/**
+ * Every slug a discovered location can reasonably be addressed by: its
+ * discovery key (the config-entry instance slug), its label, and both device
+ * names. A manual `entity_prefix` is minted from one of these, so they are what
+ * prefix ownership is decided on.
+ */
+function locationSlugCandidates(
+  hass: HomeAssistant,
+  key: string,
+  loc: DiscoveredLocation | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  const add = (value: unknown): void => {
+    if (typeof value !== "string" || !value) return;
+    const slug = slugify(value);
+    if (slug) out.add(slug);
+  };
+  add(key);
+  add(loc?.label);
+  const device = loc?.deviceId ? hass.devices?.[loc.deviceId] : undefined;
+  add(device?.name_by_user);
+  add(device?.name);
+  return out;
+}
+
 /** Outcome of scoping a manual-mode prefix match to a single location. */
 export interface KleenexManualScope {
   /** The entity IDs the card should use, in the order they were given. */
@@ -541,12 +566,20 @@ export interface KleenexManualScope {
  * `hass.states` happened to list first (issue #309 follow-up).
  *
  * The rule, when the matched entities span more than one *discovered* location:
- * keep the location whose entity IDs have the least left over after the
- * configured prefix (and suffix) is removed. That is the location the prefix
- * was actually minted from -- `kleenex_pollen_` leaves `grass` on the renamed
- * Paris device but `radar_utrecht_grass` on the Utrecht one -- and it is a rule
- * a user can check by eye. Ties are broken on the total remainder and finally
- * on the location key, so the choice never depends on registry iteration order.
+ *
+ *   1. A prefix is minted from a device name, so the location whose own slug
+ *      (device name, user rename, discovery key or label) equals the prefix
+ *      owns it: `kleenex_pollen_` belongs to the device named "Kleenex pollen",
+ *      and `kleenex_pollen_radar_utrecht_` to "Kleenex Pollen Radar (Utrecht)".
+ *      This is independent of which entities happen to be enabled.
+ *   2. Only when no location's slug matches does the fallback apply: keep the
+ *      location whose entity IDs have the least left over after the prefix (and
+ *      suffix) is removed. It is a weaker signal, because the remainder is an
+ *      allergen name and one location may only have long-named detail sensors
+ *      enabled -- but it still beats merging two cities.
+ *
+ * Ties in either step are broken on the total remainder and finally on the
+ * location key, so the choice never depends on registry iteration order.
  *
  * Entities the registry knows nothing about (template sensors, an install whose
  * registry the frontend doesn't expose) are always kept: manual mode is the
@@ -598,11 +631,21 @@ export function scopeManualEntities(
   }
   if (scores.size < 2) return { entityIds, label: null };
 
+  // Step 1: does any candidate location's own slug equal the prefix? The
+  // prefix was minted from a device name, so this settles ownership without
+  // looking at entity names at all.
+  const needle = slugify(prefix.replace(/_+$/, ""));
+  const owners = [...scores.keys()].filter((key) =>
+    locationSlugCandidates(hass, key, discovery.locations.get(key)).has(needle),
+  );
+  const candidates =
+    owners.length > 0 ? new Set(owners) : new Set(scores.keys());
+
   let winner: string | null = null;
   let best: { min: number; total: number } | null = null;
-  for (const [key, score] of [...scores].sort(([a], [b]) =>
-    a < b ? -1 : a > b ? 1 : 0,
-  )) {
+  for (const [key, score] of [...scores]
+    .filter(([key]) => candidates.has(key))
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
     if (
       !best ||
       score.min < best.min ||

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -80,15 +80,20 @@ export function canonicalAllergenFromSlug(
 }
 
 /**
- * Normalize an allergen name as reported inside `details[]` / `forecast[].details[]`.
+ * Normalize an allergen name as reported by the integration, for lookups
+ * against KLEENEX_ALLERGEN_MAP and the configured allergen list.
  *
- * The feed is not whitespace-clean: the FR zone reports names like `"Poaceae "`,
- * and an untrimmed lookup key matches neither KLEENEX_ALLERGEN_MAP nor the
- * configured allergen list, so the row disappears without a trace. Returns an
- * empty string for anything that isn't a usable name.
+ * The feed is not whitespace-clean: the FR and IT zones report names like
+ * `"Poaceae "`, and an unnormalized key matches neither the alias map nor the
+ * config, so the row disappears without a trace. Leading/trailing whitespace is
+ * stripped, runs of inner whitespace collapse to a single space, and the result
+ * is lowercased. Every name-to-allergen lookup in this adapter goes through
+ * here, so a new upstream spelling only ever needs an alias, never a second
+ * normalization rule. Returns an empty string for anything unusable.
  */
 export function normalizeDetailName(raw: unknown): string {
-  return typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (typeof raw !== "string") return "";
+  return raw.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
 // Static reverse index: canonical allergen name -> Set of slugified alias

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -661,8 +661,8 @@ export interface KleenexManualScope {
   /** The entity IDs the card should use, in the order they were given. */
   entityIds: string[];
   /**
-   * Label of the location the match was narrowed to, or null when no narrowing
-   * happened (single location, or no registry information at all).
+   * Label of the location the match was narrowed to, or null when nothing was
+   * dropped and the input is returned as it came in.
    */
   label: string | null;
 }
@@ -676,27 +676,49 @@ export interface KleenexManualScope {
  * cities into one set of allergen rows and name the header after whichever one
  * `hass.states` happened to list first (issue #309 follow-up).
  *
- * The rule, when the matched entities span more than one *discovered* location:
+ * Three ordered steps, each with its own guard:
  *
- *   1. A prefix is minted from a device name, so the location whose own slug
- *      (device name, user rename, discovery key or label) equals the prefix
- *      owns it: `kleenex_pollen_` belongs to the device named "Kleenex pollen",
- *      and `kleenex_pollen_radar_utrecht_` to "Kleenex Pollen Radar (Utrecht)".
- *      This is independent of which entities happen to be enabled.
- *   2. Only when no location's slug matches does the fallback apply: keep the
- *      location whose entity IDs have the least left over after the prefix (and
- *      suffix) is removed. It is a weaker signal, because the remainder is an
- *      allergen name and one location may only have long-named detail sensors
- *      enabled -- but it still beats merging two cities.
+ *   1. Device registry (runs whenever at least one entity matched). A prefix is
+ *      minted from a device name, so a Kleenex device whose own slug -- its
+ *      identifier, name or user rename -- equals the prefix owns it:
+ *      `kleenex_pollen_` belongs to the device named "Kleenex pollen",
+ *      `kleenex_pollen_radar_utrecht_` to "Kleenex Pollen Radar (Utrecht)".
+ *      Everything belonging to another Kleenex device is then dropped, however
+ *      many entities that leaves -- including none. This step needs no
+ *      discovery at all, which is the point: an owner whose config entry is
+ *      down has no state-backed entities and is invisible to discovery, yet it
+ *      still owns its prefix. Membership follows discovery's own two signals, a
+ *      `kleenex_pollenradar` device identifier or an entity registry entry with
+ *      that platform, so a device exposed only the second way counts too.
+ *   2. Discovered locations (runs when no device owned the prefix, at least two
+ *      entities matched, and they span more than one discovered location). A
+ *      location may still answer to the prefix through its discovery key or
+ *      label -- shapes the device registry does not carry.
+ *   3. Remainder fallback (same guard as step 2, when no location's slug
+ *      matches either). Keep the location whose entity IDs have the least left
+ *      over after the prefix and suffix are removed. A weak signal, since the
+ *      remainder is an allergen name and a location may only have long-named
+ *      detail sensors enabled -- but it still beats merging two cities. Ties
+ *      here and in step 2 are broken on the total remainder and finally on the
+ *      location key, so the choice never depends on registry iteration order.
  *
- * Ties in either step are broken on the total remainder and finally on the
- * location key, so the choice never depends on registry iteration order.
+ * "Unattributable" means two different things, deliberately:
+ *   - unknown to the *entity registry* (template sensors, a frontend without
+ *     registry access): always kept. Manual mode is the fallback for exactly
+ *     those setups, and such an entity cannot be evidence of a second location.
+ *   - known to the registry but not placeable by *discovery* (the owner's own
+ *     entities while its entry is down): under step 1 these are simply the
+ *     owner's, and another location's entities are dropped even though nothing
+ *     replaces them.
  *
- * Entities the registry knows nothing about (template sensors, an install whose
- * registry the frontend doesn't expose) are always kept: manual mode is the
- * fallback for exactly those setups, and an unattributable entity cannot be
- * evidence of a second location. Consequently an install with at most one
- * discovered location behaves exactly as before.
+ * What is still guaranteed, now that step 1 can act on a single entity and can
+ * leave nothing behind: an entity that *nothing* can attribute -- no registry
+ * entry and no discovered location -- is never dropped, and no narrowing is
+ * reported (neither a label nor a warning) unless something actually was.
+ * Note that "no registry" does not by itself mean "untouched": tier-3 discovery
+ * attributes legacy `sensor.kleenex_pollen_radar_<location>_*` IDs by their
+ * slug, so a registry-less install holding two legacy locations is still
+ * narrowed to one.
  */
 export function scopeManualEntities(
   hass: HomeAssistant,

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -515,6 +515,117 @@ export function resolveKleenexLocationEntry(
   });
 }
 
+/** Outcome of scoping a manual-mode prefix match to a single location. */
+export interface KleenexManualScope {
+  /** The entity IDs the card should use, in the order they were given. */
+  entityIds: string[];
+  /**
+   * Label of the location the match was narrowed to, or null when no narrowing
+   * happened (single location, or no registry information at all).
+   */
+  label: string | null;
+}
+
+/**
+ * Narrow a manual-mode `entity_prefix` match to one location.
+ *
+ * A prefix is a substring test, so a prefix minted from a renamed device
+ * (`kleenex_pollen_`) also matches another config entry's legacy IDs
+ * (`sensor.kleenex_pollen_radar_utrecht_grass`). The card would then merge two
+ * cities into one set of allergen rows and name the header after whichever one
+ * `hass.states` happened to list first (issue #309 follow-up).
+ *
+ * The rule, when the matched entities span more than one *discovered* location:
+ * keep the location whose entity IDs have the least left over after the
+ * configured prefix (and suffix) is removed. That is the location the prefix
+ * was actually minted from -- `kleenex_pollen_` leaves `grass` on the renamed
+ * Paris device but `radar_utrecht_grass` on the Utrecht one -- and it is a rule
+ * a user can check by eye. Ties are broken on the total remainder and finally
+ * on the location key, so the choice never depends on registry iteration order.
+ *
+ * Entities the registry knows nothing about (template sensors, an install whose
+ * registry the frontend doesn't expose) are always kept: manual mode is the
+ * fallback for exactly those setups, and an unattributable entity cannot be
+ * evidence of a second location. Consequently an install with at most one
+ * discovered location behaves exactly as before.
+ */
+export function scopeManualEntities(
+  hass: HomeAssistant,
+  entityIds: string[],
+  opts: {
+    prefix: string;
+    suffix?: string;
+    discovery?: { locations: Map<string, DiscoveredLocation> };
+    debug?: boolean;
+  },
+): KleenexManualScope {
+  const { prefix, suffix = "", debug = false } = opts;
+  if (entityIds.length < 2 || !prefix) return { entityIds, label: null };
+
+  const discovery = opts.discovery ?? discoverKleenex(hass, debug);
+  if (!discovery || discovery.locations.size < 2) {
+    return { entityIds, label: null };
+  }
+
+  // entity_id -> location key, for the discovered locations only.
+  const locationOf = new Map<string, string>();
+  for (const [key, loc] of discovery.locations) {
+    for (const eid of loc.entities.values()) locationOf.set(eid, key);
+  }
+
+  const base = `sensor.${prefix}`;
+  // Per location: shortest and total remainder length after prefix and suffix.
+  const scores = new Map<string, { min: number; total: number }>();
+  for (const entityId of entityIds) {
+    const key = locationOf.get(entityId);
+    if (!key) continue;
+    let rest = entityId.startsWith(base)
+      ? entityId.slice(base.length)
+      : entityId;
+    if (suffix && rest.endsWith(suffix)) rest = rest.slice(0, -suffix.length);
+    const score = scores.get(key);
+    if (!score) {
+      scores.set(key, { min: rest.length, total: rest.length });
+    } else {
+      score.min = Math.min(score.min, rest.length);
+      score.total += rest.length;
+    }
+  }
+  if (scores.size < 2) return { entityIds, label: null };
+
+  let winner: string | null = null;
+  let best: { min: number; total: number } | null = null;
+  for (const [key, score] of [...scores].sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  )) {
+    if (
+      !best ||
+      score.min < best.min ||
+      (score.min === best.min && score.total < best.total)
+    ) {
+      winner = key;
+      best = score;
+    }
+  }
+
+  const kept = entityIds.filter((eid) => {
+    const key = locationOf.get(eid);
+    return !key || key === winner;
+  });
+
+  if (debug) {
+    console.debug(
+      `[Kleenex] Manual prefix '${prefix}' spans ${scores.size} locations (${[
+        ...scores.keys(),
+      ].join(", ")}); keeping '${winner}' and any unregistered entities`,
+      kept,
+    );
+  }
+
+  const label = winner ? (discovery.locations.get(winner)?.label ?? null) : null;
+  return { entityIds: kept, label };
+}
+
 /** One discovered Kleenex location, resolved against the card config. */
 export interface KleenexLocationMatch {
   locationKey: string;

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -240,17 +240,31 @@ function classifyKleenexEntity(
   return classifyKleenexEntityId(entityId);
 }
 
-/** Resolve a human-readable location label for a discovered device. */
-function resolveKleenexLabel(ctx: DiscoveryContext): string {
-  const device = ctx.device;
+/**
+ * The location name a device stands for: the user's own rename verbatim,
+ * otherwise the instance inside the default name "Kleenex Pollen Radar
+ * (<instance>)", which is what the user configured as the location. Null when
+ * the device carries no name at all.
+ *
+ * Both user-visible label paths go through here -- the discovered location
+ * label and the manual-scoping warning/header -- so an upstream change to the
+ * default naming cannot make them disagree.
+ */
+function deviceDisplayLabel(
+  device: DeviceRegistryEntry | null | undefined,
+): string | null {
   if (device?.name_by_user) return device.name_by_user;
   if (device?.name) {
-    // Default device name is "Kleenex Pollen Radar (<instance>)"; the instance
-    // is what the user configured as the location.
     const m = /^Kleenex Pollen Radar\s*\((.+)\)\s*$/.exec(device.name);
-    if (m?.[1]) return m[1].trim();
-    return device.name;
+    return m?.[1]?.trim() || device.name;
   }
+  return null;
+}
+
+/** Resolve a human-readable location label for a discovered device. */
+function resolveKleenexLabel(ctx: DiscoveryContext): string {
+  const fromDevice = deviceDisplayLabel(ctx.device);
+  if (fromDevice) return fromDevice;
 
   const friendly = ctx.state?.attributes?.friendly_name;
   if (typeof friendly === "string") {
@@ -591,14 +605,6 @@ function deviceSlugCandidates(
   return out;
 }
 
-/** Human-readable name for a device, for warnings and the header. */
-function deviceLabel(device: DeviceRegistryEntry | null | undefined): string {
-  const name = device?.name_by_user || device?.name;
-  if (!name) return "";
-  const m = /^Kleenex Pollen Radar\s*\((.+)\)\s*$/.exec(name);
-  return m?.[1]?.trim() || name;
-}
-
 /** Device ids of every Kleenex device in the registry. */
 function kleenexDeviceIds(hass: HomeAssistant): Set<string> {
   const out = new Set<string>();
@@ -715,13 +721,13 @@ export function scopeManualEntities(
       if (deviceId) droppedDevices.add(deviceId);
     }
     const ownerDevice = hass?.devices?.[ownerDeviceId];
-    const label = deviceLabel(ownerDevice) || null;
+    const label = deviceDisplayLabel(ownerDevice);
     warnOnceAboutNarrowing(
       prefix,
       suffix,
       label || ownerDeviceId,
       [...droppedDevices].map(
-        (deviceId) => deviceLabel(hass?.devices?.[deviceId]) || deviceId,
+        (deviceId) => deviceDisplayLabel(hass?.devices?.[deviceId]) || deviceId,
       ),
     );
     if (debug) {

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -65,9 +65,7 @@ const SLUGIFIED_ALIAS_MAP: Map<string, string> = (() => {
  * so `amsterdam_noord_bouleau` still resolves to `birch` when the location part
  * could not be stripped up front.
  */
-export function canonicalAllergenFromSlug(
-  suffix: string,
-): string | undefined {
+export function canonicalAllergenFromSlug(suffix: string): string | undefined {
   const direct = SLUGIFIED_ALIAS_MAP.get(suffix);
   if (direct) return direct;
   if (!suffix.includes("_")) return undefined;
@@ -398,9 +396,7 @@ export function kleenexSlugExtractor(entityId: string): string | null {
  * location's forecast -- so callers must stop instead.
  */
 export type KleenexIdentifierMatch =
-  | [string, DiscoveredLocation]
-  | "ambiguous"
-  | null;
+  [string, DiscoveredLocation] | "ambiguous" | null;
 
 export function matchKleenexLocationByIdentifier(
   hass: HomeAssistant,
@@ -690,6 +686,11 @@ export interface KleenexManualScope {
  *      still owns its prefix. Membership follows discovery's own two signals, a
  *      `kleenex_pollenradar` device identifier or an entity registry entry with
  *      that platform, so a device exposed only the second way counts too.
+ *      Everything this step decides on is the device link, so a registry entry
+ *      that has none is not "another device" to it and stays -- deliberately:
+ *      were the link ever missing wholesale, dropping would leave an empty card
+ *      where keeping degrades to the pre-narrowing behaviour. Such an entry is
+ *      still attributable to a location by step 2, which does drop it.
  *   2. Discovered locations (runs when no device owned the prefix, at least two
  *      entities matched, and they span more than one discovered location). A
  *      location may still answer to the prefix through its discovery key or
@@ -793,8 +794,10 @@ export function scopeManualEntities(
   //
   // The entity registry's device link is therefore tried first: it covers every
   // entity of a device, classified or not. The classified map is the second
-  // source (it also holds entities whose registry entry has no device), and the
-  // legacy ID slug the third, since tier-3 locations are keyed by exactly that.
+  // source, and the only one that reaches a registry entry with our platform and
+  // no device at all: discovery buckets those as "default", a key no entity ID
+  // spells, so neither the device link nor the slug can place them. The legacy
+  // ID slug is the third, since tier-3 locations are keyed by exactly that.
   const locationOf = new Map<string, string>();
   const locationOfDevice = new Map<string, string>();
   for (const [key, loc] of discovery.locations) {
@@ -860,7 +863,9 @@ export function scopeManualEntities(
     return !key || key === winner;
   });
 
-  const label = winner ? (discovery.locations.get(winner)?.label ?? null) : null;
+  const label = winner
+    ? (discovery.locations.get(winner)?.label ?? null)
+    : null;
 
   warnOnceAboutNarrowing(
     prefix,
@@ -973,9 +978,14 @@ function requestedCategories(cfg: CardConfig): Set<string> {
 function requestedIndividualAllergens(cfg: CardConfig): string[] {
   return ((cfg.allergens as string[] | undefined) || []).filter(
     (a) =>
-      !["trees_cat", "grass_cat", "weeds_cat", "trees", "grass", "weeds"].includes(
-        a,
-      ),
+      ![
+        "trees_cat",
+        "grass_cat",
+        "weeds_cat",
+        "trees",
+        "grass",
+        "weeds",
+      ].includes(a),
   );
 }
 
@@ -1031,7 +1041,9 @@ export function resolveEntityIds(
 
       sensorId = `sensor.${prefix}${category}${suffix}`;
       if (!hass.states[sensorId]) {
-        const possiblePrefixes = Object.entries(KLEENEX_LOCALIZED_CATEGORY_NAMES)
+        const possiblePrefixes = Object.entries(
+          KLEENEX_LOCALIZED_CATEGORY_NAMES,
+        )
           .filter(([, canonical]) => canonical === category)
           .map(([localPrefix]) => localPrefix);
 
@@ -1052,7 +1064,9 @@ export function resolveEntityIds(
         ? `sensor.kleenex_pollen_radar_${locationSlug}_${category}`
         : undefined;
       if (!sensorId || !hass.states[sensorId]) {
-        const possiblePrefixes = Object.entries(KLEENEX_LOCALIZED_CATEGORY_NAMES)
+        const possiblePrefixes = Object.entries(
+          KLEENEX_LOCALIZED_CATEGORY_NAMES,
+        )
           .filter(([, canonical]) => canonical === category)
           .map(([lp]) => lp);
 

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -689,8 +689,9 @@ export interface KleenexManualScope {
  *      Everything this step decides on is the device link, so a registry entry
  *      that has none is not "another device" to it and stays -- deliberately:
  *      were the link ever missing wholesale, dropping would leave an empty card
- *      where keeping degrades to the pre-narrowing behaviour. Such an entry is
- *      still attributable to a location by step 2, which does drop it.
+ *      where keeping degrades to the pre-narrowing behaviour. Kept by this step,
+ *      that is: on an install where no device owns the prefix, step 2 can
+ *      attribute such an entry and does drop it.
  *   2. Discovered locations (runs when no device owned the prefix, at least two
  *      entities matched, and they span more than one discovered location). A
  *      location may still answer to the prefix through its discovery key or

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -520,6 +520,17 @@ export function resolveKleenexLocationEntry(
   });
 }
 
+// Manual-mode narrowing is silent by design in the common case, but the one
+// time it drops data the user must hear about it. Dedup keyed on the config
+// identity, mirroring the NA-zone warning in forecast.ts, so a warning is
+// emitted once per configuration rather than on every HA state update.
+const MANUAL_SCOPE_WARNED_KEYS = new Set<string>();
+
+/** Test-only hook to clear the dedup state between cases. */
+export function _resetManualScopeWarningsForTest(): void {
+  MANUAL_SCOPE_WARNED_KEYS.clear();
+}
+
 /**
  * Every slug a discovered location can reasonably be addressed by: its
  * discovery key (the config-entry instance slug), its label, and both device
@@ -661,16 +672,25 @@ export function scopeManualEntities(
     return !key || key === winner;
   });
 
-  if (debug) {
-    console.debug(
-      `[Kleenex] Manual prefix '${prefix}' spans ${scores.size} locations (${[
-        ...scores.keys(),
-      ].join(", ")}); keeping '${winner}' and any unregistered entities`,
-      kept,
+  const label = winner ? (discovery.locations.get(winner)?.label ?? null) : null;
+
+  // Narrowing removes rows and renames the header, so it is never silent: a
+  // user with two legacy locations and a broad prefix would otherwise see data
+  // disappear with no explanation anywhere.
+  const dropped = [...scores.keys()]
+    .filter((key) => key !== winner)
+    .map((key) => discovery.locations.get(key)?.label || key);
+  const warnKey = `${prefix}|${suffix}`;
+  if (!MANUAL_SCOPE_WARNED_KEYS.has(warnKey)) {
+    MANUAL_SCOPE_WARNED_KEYS.add(warnKey);
+    console.warn(
+      `[Kleenex] The configured entity_prefix '${prefix}' matches entities from several locations. Showing '${label || winner}' and ignoring: ${dropped.join(", ")}. Use a prefix that only matches the location you want, or switch from manual to a location-based config.`,
     );
   }
+  if (debug) {
+    console.debug(`[Kleenex] Manual prefix narrowed to '${winner}'`, kept);
+  }
 
-  const label = winner ? (discovery.locations.get(winner)?.label ?? null) : null;
   return { entityIds: kept, label };
 }
 

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -782,17 +782,40 @@ export function scopeManualEntities(
     return { entityIds, label: null };
   }
 
-  // entity_id -> location key, for the discovered locations only.
+  // Attribution: which discovered location does an entity belong to?
+  //
+  // discovery.locations[].entities is keyed by classified allergen key and thus
+  // holds one entity per key -- a second sensor that classifies the same way
+  // (e.g. an English and a Dutch trees sensor on one device) is simply missing
+  // from it. Attributing from that map alone would leave such duplicates
+  // unattributed, and unattributed means "always kept", so a losing location
+  // could still leak entities into the result (Codex round 4 on PR #315).
+  //
+  // The entity registry's device link is therefore tried first: it covers every
+  // entity of a device, classified or not. The classified map is the second
+  // source (it also holds entities whose registry entry has no device), and the
+  // legacy ID slug the third, since tier-3 locations are keyed by exactly that.
   const locationOf = new Map<string, string>();
+  const locationOfDevice = new Map<string, string>();
   for (const [key, loc] of discovery.locations) {
     for (const eid of loc.entities.values()) locationOf.set(eid, key);
+    if (loc.deviceId) locationOfDevice.set(loc.deviceId, key);
   }
+  const attribute = (entityId: string): string | undefined => {
+    const deviceId = hass?.entities?.[entityId]?.device_id;
+    const byDevice = deviceId ? locationOfDevice.get(deviceId) : undefined;
+    if (byDevice) return byDevice;
+    const byClassification = locationOf.get(entityId);
+    if (byClassification) return byClassification;
+    const slug = kleenexSlugExtractor(entityId);
+    return slug && discovery.locations.has(slug) ? slug : undefined;
+  };
 
   const base = `sensor.${prefix}`;
   // Per location: shortest and total remainder length after prefix and suffix.
   const scores = new Map<string, { min: number; total: number }>();
   for (const entityId of entityIds) {
-    const key = locationOf.get(entityId);
+    const key = attribute(entityId);
     if (!key) continue;
     let rest = entityId.startsWith(base)
       ? entityId.slice(base.length)
@@ -833,7 +856,7 @@ export function scopeManualEntities(
   }
 
   const kept = entityIds.filter((eid) => {
-    const key = locationOf.get(eid);
+    const key = attribute(eid);
     return !key || key === winner;
   });
 

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -605,11 +605,24 @@ function deviceSlugCandidates(
   return out;
 }
 
-/** Device ids of every Kleenex device in the registry. */
+/**
+ * Device ids of every Kleenex device the registry knows, from both signals
+ * discovery itself accepts: a `kleenex_pollenradar` device identifier (tier 1)
+ * and an entity registry entry whose platform is ours (tier 2).
+ *
+ * A mixed registry exposes some devices only the second way. Recognising just
+ * the first would leave those devices outside the integration's membership, so
+ * scoping would treat their entities as somebody else's and keep them --
+ * merging two locations after all (Codex round 3 on PR #315).
+ */
 function kleenexDeviceIds(hass: HomeAssistant): Set<string> {
   const out = new Set<string>();
   for (const [deviceId, device] of Object.entries(hass?.devices || {})) {
     if (deviceIdentifierSlug(device)) out.add(deviceId);
+  }
+  for (const entry of Object.values(hass?.entities || {})) {
+    const deviceId = entry?.device_id;
+    if (deviceId && entry?.platform === PLATFORM) out.add(deviceId);
   }
   return out;
 }
@@ -631,8 +644,9 @@ function findPrefixOwnerDevice(
 ): string | null {
   if (!needle) return null;
   let found: string | null = null;
-  for (const [deviceId, device] of Object.entries(hass?.devices || {})) {
-    if (!deviceIdentifierSlug(device)) continue;
+  for (const deviceId of kleenexDeviceIds(hass)) {
+    const device = hass?.devices?.[deviceId];
+    if (!device) continue;
     if (!deviceSlugCandidates(device).has(needle)) continue;
     // Two devices answering to the same slug cannot say which was meant; the
     // discovery-based path below applies its own tie-breaks instead.

--- a/src/adapters/kleenex/forecast.ts
+++ b/src/adapters/kleenex/forecast.ts
@@ -21,6 +21,7 @@ import {
   CATEGORY_KEYS,
   DIAGNOSTIC_SUFFIXES,
   canonicalAllergenFromSlug,
+  normalizeDetailName,
   resolveKleenexLocation,
 } from "./discovery.js";
 import { ppmToLevel } from "./levels.js";
@@ -364,7 +365,7 @@ export async function fetchForecast(
 
     try {
       for (const detail of details) {
-        const allergenName = (detail.name as string)?.toLowerCase();
+        const allergenName = normalizeDetailName(detail.name);
         if (!allergenName) continue;
 
         const canonicalName =
@@ -444,7 +445,7 @@ export async function fetchForecast(
         }
 
         for (const detail of forecastDetails) {
-          const allergenName = (detail.name as string)?.toLowerCase();
+          const allergenName = normalizeDetailName(detail.name);
           if (!allergenName) continue;
 
           const canonicalName =

--- a/src/adapters/kleenex/forecast.ts
+++ b/src/adapters/kleenex/forecast.ts
@@ -23,6 +23,7 @@ import {
   canonicalAllergenFromSlug,
   normalizeDetailName,
   resolveKleenexLocation,
+  scopeManualEntities,
 } from "./discovery.js";
 import { ppmToLevel } from "./levels.js";
 
@@ -138,6 +139,19 @@ export async function fetchForecast(
       }
       return matches;
     });
+    // A prefix can straddle two config entries (`kleenex_pollen_` also matches
+    // another location's legacy `kleenex_pollen_radar_utrecht_*` IDs), which
+    // would merge two cities into one set of rows. Narrow to a single location
+    // when the registry can tell them apart.
+    const scoped = scopeManualEntities(
+      hass,
+      kleenexSensors.map((s) => s.entity_id),
+      { prefix: manualPrefix, suffix: manualSuffix, debug: !!debug },
+    );
+    if (scoped.entityIds.length !== kleenexSensors.length) {
+      const keep = new Set(scoped.entityIds);
+      kleenexSensors = kleenexSensors.filter((s) => keep.has(s.entity_id));
+    }
     if (debug) {
       console.debug(
         `[Kleenex] After manual mode filtering: ${kleenexSensors.length} sensors with prefix '${expectedPrefix}'`,

--- a/src/adapters/kleenex/index.ts
+++ b/src/adapters/kleenex/index.ts
@@ -20,6 +20,7 @@ export {
   classifyKleenexEntityId,
   normalizeDetailName,
   scopeManualEntities,
+  _resetManualScopeWarningsForTest,
 } from "./discovery.js";
 export { fetchForecast } from "./forecast.js";
 
@@ -92,6 +93,8 @@ export const autodetect: AdapterAutodetect = {
   // Manual mode's entity_prefix can straddle two config entries, so the header
   // narrows its candidate entities through the same rule fetchForecast uses;
   // otherwise the two can name and render different locations.
+  // The cast narrows the structural discovery type back to the device
+  // discovery Kleenex always produces, as in resolveLocation above.
   scopeManualEntities: (hass, entityIds, opts) =>
     scopeManualEntities(hass, entityIds, {
       ...opts,

--- a/src/adapters/kleenex/index.ts
+++ b/src/adapters/kleenex/index.ts
@@ -18,6 +18,8 @@ export {
   resolveKleenexLocationEntry,
   canonicalAllergenFromSlug,
   classifyKleenexEntityId,
+  normalizeDetailName,
+  scopeManualEntities,
 } from "./discovery.js";
 export { fetchForecast } from "./forecast.js";
 
@@ -26,6 +28,7 @@ import {
   kleenexSlugExtractor,
   resolveKleenexLocationEntry,
   classifyKleenexEntityId,
+  scopeManualEntities,
 } from "./discovery.js";
 import type { DiscoveredLocation } from "../../utils/adapter-helpers.js";
 import type { HomeAssistant } from "../../types/home-assistant.js";
@@ -86,4 +89,14 @@ export const autodetect: AdapterAutodetect = {
   // names would yield a header like "Kleenex pollen Date", so the card asks
   // the adapter which entity IDs are renderable before deriving a title.
   isRenderableEntity: (entityId) => classifyKleenexEntityId(entityId) !== null,
+  // Manual mode's entity_prefix can straddle two config entries, so the header
+  // narrows its candidate entities through the same rule fetchForecast uses;
+  // otherwise the two can name and render different locations.
+  scopeManualEntities: (hass, entityIds, opts) =>
+    scopeManualEntities(hass, entityIds, {
+      ...opts,
+      discovery: opts.discovery as
+        | { locations: Map<string, DiscoveredLocation> }
+        | undefined,
+    }),
 };

--- a/src/pollenprognos-card.ts
+++ b/src/pollenprognos-card.ts
@@ -1063,8 +1063,10 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             ? (cfg.location as string)
             : "";
         // One call into the adapter's own resolution rather than a candidate
-        // chain rebuilt here: the header can then never name a different
-        // location than the one the card renders data for.
+        // chain rebuilt here, so a location-based config resolves to the same
+        // place the card renders data for. Manual mode has no location to
+        // resolve; there the two are kept in step by the shared
+        // scopeManualEntities call further down instead.
         const kleenexResolved = kleenexWanted
           ? kleenexAutodetect?.resolveLocation?.(
               hass,
@@ -1097,13 +1099,35 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
               // header. fetchForecast filters its own collection the same way.
               const entitySuffix =
                 typeof cfg.entity_suffix === "string" ? cfg.entity_suffix : "";
-              const prefixed = Object.values(hass.states)
+              let prefixed = Object.values(hass.states)
                 .filter(isKleenexState)
                 .filter(
                   (s) =>
                     s.entity_id.startsWith(`sensor.${prefix}`) &&
                     (!entitySuffix || s.entity_id.endsWith(entitySuffix)),
                 );
+              // The prefix can also match another config entry's entities
+              // (`kleenex_pollen_` matches `kleenex_pollen_radar_utrecht_*`).
+              // The adapter narrows its own collection to one location; the
+              // header goes through the same function so it can never name a
+              // location other than the one the card renders.
+              const scope = kleenexAutodetect?.scopeManualEntities?.(
+                hass,
+                prefixed.map((s) => s.entity_id),
+                {
+                  prefix,
+                  suffix: entitySuffix,
+                  discovery: kleenexDiscovery,
+                  debug: this.debug,
+                },
+              );
+              if (scope && scope.entityIds.length !== prefixed.length) {
+                const keep = new Set(scope.entityIds);
+                prefixed = prefixed.filter((s) => keep.has(s.entity_id));
+              }
+              // A narrowed match resolved a device, so its label is a better
+              // header than anything scraped out of a friendly name.
+              if (scope?.label) title = scope.label;
               // The prefix also matches the diagnostic siblings (`..._date`,
               // `..._last_updated`), whose friendly names would yield a header
               // like "Kleenex pollen Date". Prefer an entity the adapter
@@ -1153,7 +1177,7 @@ class PollenPrognosCard extends LevelCircleMixin(LitElement) {
             }
           }
 
-          if (match) {
+          if (match && !title) {
             const attr = match.attributes;
             title =
               attr.location_name ||

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -155,6 +155,25 @@ export interface AdapterAutodetect {
    */
   isRenderableEntity?(entityId: string): boolean;
   /**
+   * Narrow a manual-mode prefix match to a single location, so the card renders
+   * and labels one place instead of merging two config entries whose entity ids
+   * happen to share a prefix (Kleenex). Returns the entity ids to keep and, when
+   * the narrowing actually happened, the label of the location that won.
+   *
+   * The adapter's `fetchForecast` applies the same function, so the header and
+   * the rendered data cannot pick different locations.
+   */
+  scopeManualEntities?(
+    hass: HomeAssistant,
+    entityIds: string[],
+    opts: {
+      prefix: string;
+      suffix?: string;
+      discovery?: AutodetectDiscovery;
+      debug?: boolean;
+    },
+  ): { entityIds: string[]; label: string | null };
+  /**
    * PLU exposes its allergen slug set so the driver can build the PP-vs-PLU
    * disambiguation context without PP importing PLU.
    */

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  scopeManualEntities,
+  _resetManualScopeWarningsForTest,
+} from "../../src/adapters/kleenex/index.js";
+import type { HomeAssistant } from "../../src/types/home-assistant.js";
+
+/**
+ * Invariant matrix for manual-mode prefix scoping.
+ *
+ * Two consecutive review findings hit the same function from different angles
+ * (remainder heuristic vs. an owner missing from discovery), so this file
+ * enumerates the whole space instead of chasing a third: prefix forms x owner
+ * modes x environments, with the invariants expressed once and applied to every
+ * valid cell. Invalid combinations are listed with the reason rather than
+ * silently omitted.
+ *
+ * Deliberate carve-out, decided when the narrowing rule was introduced:
+ * entities the registry cannot attribute (template sensors, installs whose
+ * registry the frontend does not expose) are never dropped -- manual mode is
+ * the fallback for exactly those setups. "Never mix locations" therefore means
+ * "never mix two registry-known locations"; unregistered entities may coexist
+ * with the one location that wins.
+ */
+
+const PARIS_DEVICE = {
+  identifiers: [["kleenex_pollenradar", "Paris"]],
+  config_entries: ["cfg_paris"],
+  name: "Kleenex Pollen Radar (Paris)",
+  name_by_user: "Kleenex pollen",
+};
+const UTRECHT_DEVICE = {
+  identifiers: [["kleenex_pollenradar", "Utrecht"]],
+  config_entries: ["cfg_utrecht"],
+  name: "Kleenex Pollen Radar (Utrecht)",
+  name_by_user: null,
+};
+
+const PARIS_IDS = [
+  "sensor.kleenex_pollen_trees",
+  "sensor.kleenex_pollen_grass",
+];
+// The same device with only a long-named detail sensor enabled. The remainder
+// after the prefix (26 characters) is longer than the colliding device's
+// "radar_utrecht_trees" (19), which is what defeated the first version of the
+// rule.
+const PARIS_LONG_IDS = ["sensor.kleenex_pollen_zeer_lange_naam_brandnetel"];
+const UTRECHT_IDS = [
+  "sensor.kleenex_pollen_radar_utrecht_trees",
+  "sensor.kleenex_pollen_radar_utrecht_grass",
+];
+const ROTTERDAM_DEVICE = {
+  identifiers: [["kleenex_pollenradar", "Rotterdam"]],
+  config_entries: ["cfg_rotterdam"],
+  name: "Kleenex Pollen Radar (Rotterdam)",
+  name_by_user: null,
+};
+const ROTTERDAM_IDS = ["sensor.kleenex_pollen_radar_rotterdam_trees"];
+
+/**
+ * How the owning config entry presents itself:
+ *  - available: registry entries and live states.
+ *  - unavailable: registry entries, states present but `unavailable`.
+ *  - no-states: registry entries, no state objects at all (entry down). This is
+ *    the mode discovery cannot see, since it only walks state-backed entities.
+ *  - absent: not in the registry at all (the user's own template sensors).
+ */
+type OwnerMode = "available" | "unavailable" | "no-states" | "absent";
+type Environment = "multi" | "multi-long" | "multi-legacy" | "single" | "bare";
+
+function entityEntry(deviceId: string, translationKey: string) {
+  return {
+    device_id: deviceId,
+    platform: "kleenex_pollenradar",
+    translation_key: translationKey,
+    unique_id: null,
+    entity_category: null,
+  };
+}
+
+function sensorState(entityId: string, state: string) {
+  return {
+    entity_id: entityId,
+    state,
+    attributes: {
+      friendly_name: entityId,
+      details: [{ name: "Birch", value: 10 }],
+      forecast: [],
+    },
+  };
+}
+
+/**
+ * Build a hass mock for one (environment, owner mode) pair.
+ *
+ * - multi: the renamed Paris device (the prefix owner) plus the legacy Utrecht
+ *   device whose entity IDs collide with the Paris prefix.
+ * - single: Paris only.
+ * - bare: no registry at all; both ID shapes exist as plain states, the way
+ *   template sensors or a frontend without registry access present themselves.
+ */
+function ownerIds(env: Environment): string[] {
+  return env === "multi-long" ? PARIS_LONG_IDS : PARIS_IDS;
+}
+
+function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
+  const states: Record<string, unknown> = {};
+  const entities: Record<string, unknown> = {};
+  const devices: Record<string, unknown> = {};
+  const paris = ownerIds(env);
+
+  if (env !== "bare") {
+    // Owner (Paris).
+    if (owner !== "absent") {
+      devices.dev_paris = PARIS_DEVICE;
+      paris.forEach((eid, i) => {
+        entities[eid] = entityEntry(
+          "dev_paris",
+          env === "multi-long" ? "detail_value" : i === 0 ? "trees" : "grass",
+        );
+      });
+    }
+    if (owner === "available" || owner === "absent") {
+      paris.forEach((eid) => (states[eid] = sensorState(eid, "100")));
+    } else if (owner === "unavailable") {
+      paris.forEach((eid) => (states[eid] = sensorState(eid, "unavailable")));
+    }
+    // owner === "no-states": registry entries only, no state objects.
+  } else {
+    paris.forEach((eid) => (states[eid] = sensorState(eid, "100")));
+  }
+
+  if (env === "multi-legacy") {
+    // A second legacy location, so a broad `kleenex_pollen_radar_` prefix
+    // matches two devices at once -- the case the narrowing warning exists for.
+    devices.dev_rotterdam = ROTTERDAM_DEVICE;
+    ROTTERDAM_IDS.forEach((eid) => {
+      states[eid] = sensorState(eid, "5");
+      entities[eid] = entityEntry("dev_rotterdam", "trees");
+    });
+  }
+
+  if (env !== "single") {
+    UTRECHT_IDS.forEach((eid, i) => {
+      states[eid] = sensorState(eid, "20");
+      if (env !== "bare") {
+        entities[eid] = entityEntry("dev_utrecht", i === 0 ? "trees" : "grass");
+      }
+    });
+    if (env !== "bare") devices.dev_utrecht = UTRECHT_DEVICE;
+  }
+
+  return {
+    states,
+    entities,
+    devices,
+    locale: { language: "en" },
+    language: "en",
+  } as unknown as HomeAssistant;
+}
+
+/** Same install, every registry/state object walked in the opposite order. */
+function reversed(hass: HomeAssistant): HomeAssistant {
+  const flip = (obj: Record<string, unknown>) =>
+    Object.fromEntries(Object.entries(obj).reverse());
+  const h = hass as unknown as Record<string, Record<string, unknown>>;
+  return {
+    ...hass,
+    states: flip(h.states!),
+    entities: flip(h.entities!),
+    devices: flip(h.devices!),
+  } as HomeAssistant;
+}
+
+const PREFIX_FORMS: { form: string; prefix: string; note: string }[] = [
+  {
+    form: "1-renamed-device-slug",
+    prefix: "kleenex_pollen_",
+    note: "exact slug of the renamed device",
+  },
+  {
+    form: "2-legacy-device-slug",
+    prefix: "kleenex_pollen_radar_utrecht_",
+    note: "exact slug of the legacy device",
+  },
+  {
+    form: "3-broad-legacy-prefix",
+    prefix: "kleenex_pollen_radar_",
+    note: "prefix of several locations' IDs, slug of none",
+  },
+  {
+    form: "4-truncated-non-slug",
+    prefix: "kleenex_pol",
+    note: "truncated, matches no device slug",
+  },
+  {
+    form: "5-non-slug-with-matches",
+    prefix: "kleenex_",
+    note: "matches every entity, slug of no device",
+  },
+];
+
+const ENVIRONMENTS: Environment[] = [
+  "multi",
+  "multi-long",
+  "multi-legacy",
+  "single",
+  "bare",
+];
+const OWNER_MODES: OwnerMode[] = [
+  "available",
+  "unavailable",
+  "no-states",
+  "absent",
+];
+
+/**
+ * Combinations that cannot exist. Listed rather than skipped silently, so the
+ * matrix documents its own shape.
+ */
+function invalidReason(env: Environment, owner: OwnerMode): string | null {
+  if (env === "bare" && owner !== "absent") {
+    return "a registry-less install has no registry entry for any device, so the owner can only be 'absent'";
+  }
+  if (owner === "absent" && env === "multi-long") {
+    return "the long-entity-name variant exists to stress the remainder heuristic, which only runs for registry-known devices";
+  }
+  return null;
+}
+
+/** Kleenex device each kept entity belongs to, when the registry knows one. */
+function devicesOf(hass: HomeAssistant, entityIds: string[]): Set<string> {
+  const out = new Set<string>();
+  const h = hass as unknown as {
+    entities: Record<string, { device_id?: string }>;
+  };
+  for (const eid of entityIds) {
+    const deviceId = h.entities?.[eid]?.device_id;
+    if (deviceId) out.add(deviceId);
+  }
+  return out;
+}
+
+function labelOf(deviceId: string): string {
+  if (deviceId === "dev_paris") return "Kleenex pollen";
+  if (deviceId === "dev_rotterdam") return "Rotterdam";
+  return "Utrecht";
+}
+
+describe("Kleenex manual-scope invariants (prefix forms x owner modes x environments)", () => {
+  beforeEach(() => {
+    _resetManualScopeWarningsForTest();
+  });
+
+  for (const env of ENVIRONMENTS) {
+    for (const owner of OWNER_MODES) {
+      const reason = invalidReason(env, owner);
+      if (reason) {
+        it(`${env}/${owner}: not a valid combination -- ${reason}`, () => {
+          expect(reason).toBeTruthy();
+        });
+        continue;
+      }
+
+      for (const { form, prefix, note } of PREFIX_FORMS) {
+        it(`${env}/${owner}/${form}: holds every invariant (${note})`, () => {
+          const hass = buildHass(env, owner);
+          const inputIds = Object.keys(
+            (hass as unknown as { states: Record<string, unknown> }).states,
+          );
+          const scope = scopeManualEntities(hass, inputIds, { prefix });
+
+          // Invariant: output is a subset of the input, order preserved.
+          expect(inputIds.filter((id) => scope.entityIds.includes(id))).toEqual(
+            scope.entityIds,
+          );
+
+          // Invariant: never two registry-known locations in one output.
+          const keptDevices = devicesOf(hass, scope.entityIds);
+          expect(keptDevices.size).toBeLessThanOrEqual(1);
+
+          // Invariant: the header names the location the data comes from.
+          if (scope.label) {
+            for (const deviceId of keptDevices) {
+              expect(labelOf(deviceId)).toBe(scope.label);
+            }
+          }
+
+          // Invariant: a registry-less install behaves exactly as before, i.e.
+          // pure prefix matching with no narrowing and no header override.
+          if (env === "bare") {
+            expect(scope.entityIds).toEqual(inputIds);
+            expect(scope.label).toBeNull();
+          }
+
+          // Invariant: when the registry knows an owner for this prefix, no
+          // other location's data may appear -- not even if the owner has no
+          // usable states of its own.
+          const multi = env.startsWith("multi");
+          if (multi && owner !== "absent" && form.startsWith("1-")) {
+            // Ownership survives the owner having no usable states: no other
+            // location's data may appear, however little the owner offers.
+            expect([...keptDevices]).not.toContain("dev_utrecht");
+            for (const eid of UTRECHT_IDS) {
+              expect(scope.entityIds).not.toContain(eid);
+            }
+          }
+          if (multi && form.startsWith("2-")) {
+            expect([...keptDevices]).not.toContain("dev_paris");
+          }
+
+          // Invariant: the outcome does not depend on registry/state iteration
+          // order.
+          _resetManualScopeWarningsForTest();
+          const flipped = reversed(hass);
+          const flippedIds = Object.keys(
+            (flipped as unknown as { states: Record<string, unknown> }).states,
+          );
+          const flippedScope = scopeManualEntities(flipped, flippedIds, {
+            prefix,
+          });
+          expect([...flippedScope.entityIds].sort()).toEqual(
+            [...scope.entityIds].sort(),
+          );
+          expect(flippedScope.label).toBe(scope.label);
+        });
+      }
+    }
+  }
+
+  // The load-bearing cells, pinned to concrete outcomes so a regression cannot
+  // satisfy the generic invariants by narrowing to nothing everywhere.
+  it("multi/available/renamed-slug keeps exactly the owner's entities", () => {
+    const hass = buildHass("multi", "available");
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_",
+    });
+    expect(scope.entityIds).toEqual(PARIS_IDS);
+    expect(scope.label).toBe("Kleenex pollen");
+  });
+
+  it("multi/absent-owner/renamed-slug keeps the unregistered entities", () => {
+    // The owner is not in the registry at all (template sensors). They must not
+    // be silenced -- that is the documented carve-out -- so the Utrecht rows
+    // ride along and no narrowing is claimed.
+    const hass = buildHass("multi", "absent");
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_",
+    });
+    for (const eid of PARIS_IDS) expect(scope.entityIds).toContain(eid);
+  });
+
+  it("multi/unavailable-owner/renamed-slug yields no foreign data", () => {
+    const hass = buildHass("multi", "unavailable");
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_",
+    });
+    expect(scope.entityIds).toEqual(PARIS_IDS);
+  });
+
+  it("multi-legacy/broad-prefix narrows to one legacy location and says so", () => {
+    // No device slug equals `kleenex_pollen_radar`, so the fallback decides:
+    // Utrecht's remainder ("utrecht_trees") is shorter than Rotterdam's. The
+    // point of the cell is that one location wins and the user is told.
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => void warnings.push(String(args[0]));
+    try {
+      const hass = buildHass("multi-legacy", "absent");
+      const ids = Object.keys((hass as any).states).filter((id) =>
+        id.startsWith("sensor.kleenex_pollen_radar_"),
+      );
+      const scope = scopeManualEntities(hass, ids, {
+        prefix: "kleenex_pollen_radar_",
+      });
+
+      expect(scope.entityIds).toEqual(UTRECHT_IDS);
+      expect(scope.label).toBe("Utrecht");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("Utrecht");
+      expect(warnings[0]).toContain("Rotterdam");
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  it("multi/legacy-slug picks the legacy device even though the other was renamed", () => {
+    const hass = buildHass("multi", "available");
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_radar_utrecht_",
+    });
+    expect(scope.entityIds).toEqual(UTRECHT_IDS);
+    expect(scope.label).toBe("Utrecht");
+  });
+});

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   scopeManualEntities,
+  discoverKleenex,
   _resetManualScopeWarningsForTest,
 } from "../../src/adapters/kleenex/index.js";
 import type { HomeAssistant } from "../../src/types/home-assistant.js";
@@ -61,6 +62,21 @@ const ROTTERDAM_IDS = ["sensor.kleenex_pollen_radar_rotterdam_trees"];
 // is missing from its location's entity map.
 const ROTTERDAM_DUPLICATE_ID = "sensor.kleenex_pollen_radar_rotterdam_bomen";
 
+/**
+ * A second renamed device ("Kleenex pollen zuid") with two entities that
+ * classify to the same key. Its IDs are not legacy-shaped, so neither the
+ * classified map (which keeps one entity per key) nor the legacy-slug step can
+ * place the duplicate -- only the entity registry's device link can.
+ */
+const ZUID_DEVICE = {
+  identifiers: [["kleenex_pollenradar", "Zuid"]],
+  config_entries: ["cfg_zuid"],
+  name: "Kleenex Pollen Radar (Zuid)",
+  name_by_user: "Kleenex pollen zuid",
+};
+const ZUID_IDS = ["sensor.kleenex_pollen_zuid_trees"];
+const ZUID_DUPLICATE_ID = "sensor.kleenex_pollen_zuid_bomen";
+
 /** The same devices as seen in a mixed registry: no identifiers, so they are
  * only recognisable through their entities' `platform` (discovery tier 2). */
 const PARIS_DEVICE_TIER2 = { ...PARIS_DEVICE, identifiers: [] };
@@ -80,6 +96,8 @@ type Environment =
   | "multi-long"
   | "multi-legacy"
   | "multi-duplicate-keys"
+  | "multi-duplicate-renamed"
+  | "device-less-owner"
   | "mixed-colliding-tier2"
   | "mixed-owner-tier2"
   | "single"
@@ -95,12 +113,12 @@ function entityEntry(deviceId: string, translationKey: string) {
   };
 }
 
-function sensorState(entityId: string, state: string) {
+function sensorState(entityId: string, state: string, friendlyName?: string) {
   return {
     entity_id: entityId,
     state,
     attributes: {
-      friendly_name: entityId,
+      friendly_name: friendlyName ?? entityId,
       details: [{ name: "Birch", value: 10 }],
       forecast: [],
     },
@@ -135,10 +153,26 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
   const entities: Record<string, unknown> = {};
   const devices: Record<string, unknown> = {};
   const paris = ownerIds(env);
+  // Entities on no device derive their location label from friendly_name, so
+  // the fixture has to carry realistic ones for that environment.
+  let parisFriendly = false;
 
   if (env !== "bare") {
-    // Owner (Paris).
-    if (owner !== "absent") {
+    // Owner (Paris). In the device-less environment its entities are in the
+    // registry with our platform but attached to no device at all, which is
+    // the only way an entity reaches discovery's "default" bucket.
+    if (owner !== "absent" && env === "device-less-owner") {
+      parisFriendly = true;
+      paris.forEach((eid, i) => {
+        entities[eid] = {
+          device_id: null,
+          platform: "kleenex_pollenradar",
+          translation_key: i === 0 ? "trees" : "grass",
+          unique_id: null,
+          entity_category: null,
+        };
+      });
+    } else if (owner !== "absent") {
       devices.dev_paris = identifierBacked(env).owner
         ? PARIS_DEVICE
         : PARIS_DEVICE_TIER2;
@@ -149,14 +183,30 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
         );
       });
     }
+    const friendlyFor = (index: number) =>
+      parisFriendly
+        ? `Kleenex pollen ${index === 0 ? "Trees" : "Grass"}`
+        : undefined;
     if (owner === "available" || owner === "absent") {
-      paris.forEach((eid) => (states[eid] = sensorState(eid, "100")));
+      paris.forEach((eid, i) => {
+        states[eid] = sensorState(eid, "100", friendlyFor(i));
+      });
     } else if (owner === "unavailable") {
-      paris.forEach((eid) => (states[eid] = sensorState(eid, "unavailable")));
+      paris.forEach((eid, i) => {
+        states[eid] = sensorState(eid, "unavailable", friendlyFor(i));
+      });
     }
     // owner === "no-states": registry entries only, no state objects.
   } else {
     paris.forEach((eid) => (states[eid] = sensorState(eid, "100")));
+  }
+
+  if (env === "multi-duplicate-renamed") {
+    devices.dev_zuid = ZUID_DEVICE;
+    [...ZUID_IDS, ZUID_DUPLICATE_ID].forEach((eid) => {
+      states[eid] = sensorState(eid, "7");
+      entities[eid] = entityEntry("dev_zuid", "trees");
+    });
   }
 
   if (env === "multi-legacy" || env === "multi-duplicate-keys") {
@@ -173,7 +223,7 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
     }
   }
 
-  if (env !== "single") {
+  if (env !== "single" && env !== "multi-duplicate-renamed") {
     UTRECHT_IDS.forEach((eid, i) => {
       states[eid] = sensorState(eid, "20");
       if (env !== "bare") {
@@ -219,7 +269,13 @@ interface PrefixForm {
   form: string;
   prefix: string;
   note: string;
-  owns: "owner" | "colliding" | null;
+  /**
+   * The device this prefix is the slug of, named concretely. The ownership
+   * invariant applies only when that device actually exists in the cell's
+   * registry -- naming a role instead ("the first colliding device") silently
+   * pointed the assertion at whichever device an environment happened to list.
+   */
+  ownsDevice: string | null;
 }
 
 const PREFIX_FORMS: PrefixForm[] = [
@@ -227,31 +283,31 @@ const PREFIX_FORMS: PrefixForm[] = [
     form: "1-renamed-device-slug",
     prefix: "kleenex_pollen_",
     note: "exact slug of the renamed device",
-    owns: "owner",
+    ownsDevice: "dev_paris",
   },
   {
     form: "2-legacy-device-slug",
     prefix: "kleenex_pollen_radar_utrecht_",
     note: "exact slug of the legacy device",
-    owns: "colliding",
+    ownsDevice: "dev_utrecht",
   },
   {
     form: "3-broad-legacy-prefix",
     prefix: "kleenex_pollen_radar_",
     note: "prefix of several locations' IDs, slug of none",
-    owns: null,
+    ownsDevice: null,
   },
   {
     form: "4-truncated-non-slug",
     prefix: "kleenex_pol",
     note: "truncated, matches no device slug",
-    owns: null,
+    ownsDevice: null,
   },
   {
     form: "5-non-slug-with-matches",
     prefix: "kleenex_",
     note: "matches every entity, slug of no device",
-    owns: null,
+    ownsDevice: null,
   },
 ];
 
@@ -302,6 +358,20 @@ const ENV_SPECS: Record<Environment, EnvSpec> = {
     collidingDevices: ["dev_utrecht", "dev_rotterdam"],
     tier3Locations: 2,
   },
+  "multi-duplicate-renamed": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_zuid"],
+    tier3Locations: 0,
+  },
+  "device-less-owner": {
+    // The owner's entities hang off no device, so no device slug can own a
+    // prefix here and every cell falls through to the discovery steps.
+    hasRegistry: true,
+    ownerDevice: null,
+    collidingDevices: ["dev_utrecht"],
+    tier3Locations: 1,
+  },
   "mixed-colliding-tier2": {
     hasRegistry: true,
     ownerDevice: "dev_paris",
@@ -328,18 +398,17 @@ const ENV_SPECS: Record<Environment, EnvSpec> = {
   },
 };
 
-/** The device the given prefix form is the slug of, in this cell. */
+/** The device the given prefix form is the slug of, if this cell has it. */
 function ownedDevice(
   spec: EnvSpec,
   owner: OwnerMode,
   form: PrefixForm,
 ): string | null {
-  if (form.owns === "owner") {
-    // An owner absent from the registry cannot be recognised as one.
-    return owner === "absent" ? null : spec.ownerDevice;
-  }
-  if (form.owns === "colliding") return spec.collidingDevices[0] ?? null;
-  return null;
+  const device = form.ownsDevice;
+  if (!device) return null;
+  // The owner device is only in the registry when the owner mode says so.
+  if (device === spec.ownerDevice) return owner === "absent" ? null : device;
+  return spec.collidingDevices.includes(device) ? device : null;
 }
 
 const ENVIRONMENTS: Environment[] = [
@@ -347,6 +416,8 @@ const ENVIRONMENTS: Environment[] = [
   "multi-long",
   "multi-legacy",
   "multi-duplicate-keys",
+  "multi-duplicate-renamed",
+  "device-less-owner",
   "mixed-colliding-tier2",
   "mixed-owner-tier2",
   "single",
@@ -376,20 +447,29 @@ function invalidReason(env: Environment, owner: OwnerMode): string | null {
   return null;
 }
 
-/** Kleenex device each kept entity belongs to, when the registry knows one. */
+/**
+ * The registry-known locations the given entities belong to: their device, or
+ * the shared device-less bucket for registry entries with our platform and no
+ * device (discovery keys those as "default"). Counting devices alone would miss
+ * a merge that involves the device-less bucket.
+ */
 function devicesOf(hass: HomeAssistant, entityIds: string[]): Set<string> {
   const out = new Set<string>();
   const h = hass as unknown as {
-    entities: Record<string, { device_id?: string }>;
+    entities: Record<string, { device_id?: string | null; platform?: string }>;
   };
   for (const eid of entityIds) {
-    const deviceId = h.entities?.[eid]?.device_id;
-    if (deviceId) out.add(deviceId);
+    const entry = h.entities?.[eid];
+    if (!entry) continue;
+    if (entry.device_id) out.add(entry.device_id);
+    else if (entry.platform === "kleenex_pollenradar") out.add("deviceless");
   }
   return out;
 }
 
 function labelOf(deviceId: string): string {
+  if (deviceId === "dev_zuid") return "Kleenex pollen zuid";
+  if (deviceId === "deviceless") return "Kleenex pollen";
   if (deviceId === "dev_paris") return "Kleenex pollen";
   if (deviceId === "dev_rotterdam") return "Rotterdam";
   return "Utrecht";
@@ -426,12 +506,24 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
           );
 
           // Invariant: never two registry-known locations in one output.
+          //
+          // Carve-out, same spirit as the unregistered one: the device-ownership
+          // step decides membership purely on the entity registry's device link,
+          // so a registry entry with our platform and no device at all is not
+          // "another device" to it and rides along. Deliberate -- were the link
+          // ever missing wholesale, dropping would leave an empty card, while
+          // keeping degrades to the pre-narrowing behaviour. The step's own
+          // cells below pin what it does keep.
+          const owned = ownedDevice(spec, owner, formSpec);
           const keptDevices = devicesOf(hass, scope.entityIds);
-          expect(keptDevices.size).toBeLessThanOrEqual(1);
+          const countedDevices = owned
+            ? new Set([...keptDevices].filter((id) => id !== "deviceless"))
+            : keptDevices;
+          expect(countedDevices.size).toBeLessThanOrEqual(1);
 
           // Invariant: the header names the location the data comes from.
           if (scope.label) {
-            for (const deviceId of keptDevices) {
+            for (const deviceId of countedDevices) {
               expect(labelOf(deviceId)).toBe(scope.label);
             }
           }
@@ -447,12 +539,17 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
           // Invariant: when a registry-known device owns this prefix, no other
           // location's entities may appear -- not even when the owner has no
           // usable states and contributes nothing itself.
-          const owned = ownedDevice(spec, owner, formSpec);
           if (owned) {
-            expect([...keptDevices].filter((id) => id !== owned)).toEqual([]);
+            expect([...countedDevices].filter((id) => id !== owned)).toEqual(
+              [],
+            );
             for (const eid of scope.entityIds) {
               const deviceId = (hass as any).entities?.[eid]?.device_id;
-              expect(deviceId === undefined || deviceId === owned).toBe(true);
+              expect(
+                deviceId === undefined ||
+                  deviceId === null ||
+                  deviceId === owned,
+              ).toBe(true);
             }
           }
 
@@ -525,6 +622,51 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
 
     expect(scope.entityIds).toEqual(UTRECHT_IDS);
     expect(scope.entityIds).not.toContain(ROTTERDAM_DUPLICATE_ID);
+  });
+
+  // Nagelfar round 5: the duplicate in the cell above sits on legacy-shaped IDs,
+  // so the legacy-slug step can place it and the device link is not what drops
+  // it. Here the losing device is renamed -- its IDs carry no legacy slug -- so
+  // the classified map (one entity per key) and the slug step both come up
+  // empty, and only the entity registry's device link can attribute it.
+  it("drops a duplicate on a renamed losing device, which only the device link can place", () => {
+    const hass = buildHass("multi-duplicate-renamed", "available");
+    const ids = Object.keys((hass as any).states);
+    expect(ids).toContain(ZUID_DUPLICATE_ID);
+
+    // Precondition: discovery's classified map does not hold the duplicate.
+    const discovery = discoverKleenex(hass);
+    const zuid = discovery.locations.get("zuid");
+    expect([...(zuid?.entities.values() ?? [])]).not.toContain(
+      ZUID_DUPLICATE_ID,
+    );
+    // Precondition: its ID is not legacy-shaped, so the slug step has no key.
+    expect(discovery.locations.has("kleenex_pollen_zuid")).toBe(false);
+
+    // A prefix no device slug answers to, so the device-ownership step stands
+    // aside and the attribution chain inside the discovery path decides.
+    const scope = scopeManualEntities(hass, ids, { prefix: "kleenex_pol" });
+
+    expect(scope.entityIds).toEqual(PARIS_IDS);
+    expect(scope.label).toBe("Kleenex pollen");
+  });
+
+  // The device-less bucket: registry entries with our platform and no device at
+  // all, which discovery keys as "default". Nothing but discovery's classified
+  // map can attribute those -- their IDs carry no legacy slug and there is no
+  // device to link -- so this cell is what keeps that step honest.
+  it("narrows to a device-less owner, which only the classified map can place", () => {
+    const hass = buildHass("device-less-owner", "available");
+    const ids = Object.keys((hass as any).states);
+
+    const discovery = discoverKleenex(hass);
+    expect(discovery.locations.get("default")?.entities.size).toBe(2);
+    expect(discovery.locations.has("kleenex_pollen")).toBe(false);
+
+    const scope = scopeManualEntities(hass, ids, { prefix: "kleenex_pollen_" });
+
+    expect(scope.entityIds).toEqual(PARIS_IDS);
+    for (const eid of UTRECHT_IDS) expect(scope.entityIds).not.toContain(eid);
   });
 
   it("drops duplicates of a losing location without any registry", () => {

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -57,6 +57,11 @@ const ROTTERDAM_DEVICE = {
 };
 const ROTTERDAM_IDS = ["sensor.kleenex_pollen_radar_rotterdam_trees"];
 
+/** The same devices as seen in a mixed registry: no identifiers, so they are
+ * only recognisable through their entities' `platform` (discovery tier 2). */
+const PARIS_DEVICE_TIER2 = { ...PARIS_DEVICE, identifiers: [] };
+const UTRECHT_DEVICE_TIER2 = { ...UTRECHT_DEVICE, identifiers: [] };
+
 /**
  * How the owning config entry presents itself:
  *  - available: registry entries and live states.
@@ -66,7 +71,14 @@ const ROTTERDAM_IDS = ["sensor.kleenex_pollen_radar_rotterdam_trees"];
  *  - absent: not in the registry at all (the user's own template sensors).
  */
 type OwnerMode = "available" | "unavailable" | "no-states" | "absent";
-type Environment = "multi" | "multi-long" | "multi-legacy" | "single" | "bare";
+type Environment =
+  | "multi"
+  | "multi-long"
+  | "multi-legacy"
+  | "mixed-colliding-tier2"
+  | "mixed-owner-tier2"
+  | "single"
+  | "bare";
 
 function entityEntry(deviceId: string, translationKey: string) {
   return {
@@ -103,6 +115,16 @@ function ownerIds(env: Environment): string[] {
   return env === "multi-long" ? PARIS_LONG_IDS : PARIS_IDS;
 }
 
+/** Whether each device carries `kleenex_pollenradar` identifiers in this env. */
+function identifierBacked(env: Environment): {
+  owner: boolean;
+  colliding: boolean;
+} {
+  if (env === "mixed-colliding-tier2") return { owner: true, colliding: false };
+  if (env === "mixed-owner-tier2") return { owner: false, colliding: true };
+  return { owner: true, colliding: true };
+}
+
 function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
   const states: Record<string, unknown> = {};
   const entities: Record<string, unknown> = {};
@@ -112,7 +134,9 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
   if (env !== "bare") {
     // Owner (Paris).
     if (owner !== "absent") {
-      devices.dev_paris = PARIS_DEVICE;
+      devices.dev_paris = identifierBacked(env).owner
+        ? PARIS_DEVICE
+        : PARIS_DEVICE_TIER2;
       paris.forEach((eid, i) => {
         entities[eid] = entityEntry(
           "dev_paris",
@@ -147,7 +171,11 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
         entities[eid] = entityEntry("dev_utrecht", i === 0 ? "trees" : "grass");
       }
     });
-    if (env !== "bare") devices.dev_utrecht = UTRECHT_DEVICE;
+    if (env !== "bare") {
+      devices.dev_utrecht = identifierBacked(env).colliding
+        ? UTRECHT_DEVICE
+        : UTRECHT_DEVICE_TIER2;
+    }
   }
 
   return {
@@ -204,6 +232,8 @@ const ENVIRONMENTS: Environment[] = [
   "multi",
   "multi-long",
   "multi-legacy",
+  "mixed-colliding-tier2",
+  "mixed-owner-tier2",
   "single",
   "bare",
 ];
@@ -221,6 +251,9 @@ const OWNER_MODES: OwnerMode[] = [
 function invalidReason(env: Environment, owner: OwnerMode): string | null {
   if (env === "bare" && owner !== "absent") {
     return "a registry-less install has no registry entry for any device, so the owner can only be 'absent'";
+  }
+  if (owner === "absent" && env === "mixed-owner-tier2") {
+    return "an owner known only through its entities' platform must have registry entries, so it cannot be absent from the registry";
   }
   if (owner === "absent" && env === "multi-long") {
     return "the long-entity-name variant exists to stress the remainder heuristic, which only runs for registry-known devices";

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -56,6 +56,10 @@ const ROTTERDAM_DEVICE = {
   name_by_user: null,
 };
 const ROTTERDAM_IDS = ["sensor.kleenex_pollen_radar_rotterdam_trees"];
+// A second entity on the same device that classifies to the same key ("bomen"
+// is the Dutch trees sensor). Discovery keeps one entity per key, so this one
+// is missing from its location's entity map.
+const ROTTERDAM_DUPLICATE_ID = "sensor.kleenex_pollen_radar_rotterdam_bomen";
 
 /** The same devices as seen in a mixed registry: no identifiers, so they are
  * only recognisable through their entities' `platform` (discovery tier 2). */
@@ -75,6 +79,7 @@ type Environment =
   | "multi"
   | "multi-long"
   | "multi-legacy"
+  | "multi-duplicate-keys"
   | "mixed-colliding-tier2"
   | "mixed-owner-tier2"
   | "single"
@@ -154,7 +159,7 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
     paris.forEach((eid) => (states[eid] = sensorState(eid, "100")));
   }
 
-  if (env === "multi-legacy") {
+  if (env === "multi-legacy" || env === "multi-duplicate-keys") {
     // A second legacy location, so a broad `kleenex_pollen_radar_` prefix
     // matches two devices at once -- the case the narrowing warning exists for.
     devices.dev_rotterdam = ROTTERDAM_DEVICE;
@@ -162,6 +167,10 @@ function buildHass(env: Environment, owner: OwnerMode): HomeAssistant {
       states[eid] = sensorState(eid, "5");
       entities[eid] = entityEntry("dev_rotterdam", "trees");
     });
+    if (env === "multi-duplicate-keys") {
+      states[ROTTERDAM_DUPLICATE_ID] = sensorState(ROTTERDAM_DUPLICATE_ID, "9");
+      entities[ROTTERDAM_DUPLICATE_ID] = entityEntry("dev_rotterdam", "trees");
+    }
   }
 
   if (env !== "single") {
@@ -232,6 +241,7 @@ const ENVIRONMENTS: Environment[] = [
   "multi",
   "multi-long",
   "multi-legacy",
+  "multi-duplicate-keys",
   "mixed-colliding-tier2",
   "mixed-owner-tier2",
   "single",
@@ -395,6 +405,58 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
   // "untouched". Tier-3 discovery attributes legacy IDs by their slug, so two
   // legacy locations are narrowed to one even with an empty registry -- what is
   // guaranteed is only that entities nothing can attribute survive.
+  // Codex round 4: discovery keeps one entity per classified key, so the losing
+  // location's duplicate was unattributed -- and unattributed means kept, which
+  // let its data overwrite the winner's allergen values downstream.
+  it("drops every entity of a losing location, duplicates included", () => {
+    const hass = buildHass("multi-duplicate-keys", "absent");
+    const ids = Object.keys((hass as any).states).filter((id) =>
+      id.startsWith("sensor.kleenex_pollen_radar_"),
+    );
+    expect(ids).toContain(ROTTERDAM_DUPLICATE_ID);
+
+    const scope = scopeManualEntities(hass, ids, {
+      prefix: "kleenex_pollen_radar_",
+    });
+
+    expect(scope.entityIds).toEqual(UTRECHT_IDS);
+    expect(scope.entityIds).not.toContain(ROTTERDAM_DUPLICATE_ID);
+  });
+
+  it("drops duplicates of a losing location without any registry", () => {
+    // Tier-3 discovery keys locations by the legacy ID slug, so the duplicate
+    // is placed by its own ID even though nothing else knows it.
+    const legacyState = (id: string, city: string) => ({
+      entity_id: id,
+      state: "1",
+      attributes: {
+        friendly_name: `Kleenex Pollen Radar (${city}) Trees`,
+        details: [],
+        forecast: [],
+      },
+    });
+    const hass = {
+      states: {
+        [UTRECHT_IDS[0]!]: legacyState(UTRECHT_IDS[0]!, "Utrecht"),
+        [ROTTERDAM_IDS[0]!]: legacyState(ROTTERDAM_IDS[0]!, "Rotterdam"),
+        [ROTTERDAM_DUPLICATE_ID]: legacyState(
+          ROTTERDAM_DUPLICATE_ID,
+          "Rotterdam",
+        ),
+      },
+      entities: {},
+      devices: {},
+      locale: { language: "en" },
+      language: "en",
+    } as unknown as HomeAssistant;
+
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_radar_",
+    });
+
+    expect(scope.entityIds).toEqual([UTRECHT_IDS[0]]);
+  });
+
   it("narrows two legacy locations even with an empty registry", () => {
     // Realistic friendly names, since a registry-less install has nothing else
     // to derive a label from.

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -358,6 +358,31 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
     expect(scope.entityIds).toEqual(PARIS_IDS);
   });
 
+  // Single-entity cells. 776a559 lowered the entry guard from "at least two
+  // matched entities" to "at least one", precisely so a lone entity from the
+  // wrong device can be filtered out: an empty card for the right location
+  // beats a populated one for the wrong city.
+  it("drops a lone entity that belongs to another location", () => {
+    const hass = buildHass("multi", "available");
+    const scope = scopeManualEntities(hass, [UTRECHT_IDS[0]!], {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.entityIds).toEqual([]);
+    expect(scope.label).toBe("Kleenex pollen");
+  });
+
+  it("keeps a lone entity that belongs to the owner", () => {
+    const hass = buildHass("multi", "available");
+    const scope = scopeManualEntities(hass, [PARIS_IDS[0]!], {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.entityIds).toEqual([PARIS_IDS[0]]);
+    // Nothing was narrowed, so no header override is claimed.
+    expect(scope.label).toBeNull();
+  });
+
   it("multi-legacy/broad-prefix narrows to one legacy location and says so", () => {
     // No device slug equals `kleenex_pollen_radar`, so the fallback decides:
     // Utrecht's remainder ("utrecht_trees") is shorter than Rotterdam's. The

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -391,6 +391,41 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
     expect(scope.entityIds).toEqual(PARIS_IDS);
   });
 
+  // The docstring's boundary claim, pinned: "no registry" does not imply
+  // "untouched". Tier-3 discovery attributes legacy IDs by their slug, so two
+  // legacy locations are narrowed to one even with an empty registry -- what is
+  // guaranteed is only that entities nothing can attribute survive.
+  it("narrows two legacy locations even with an empty registry", () => {
+    // Realistic friendly names, since a registry-less install has nothing else
+    // to derive a label from.
+    const legacyState = (id: string, city: string) => ({
+      entity_id: id,
+      state: "1",
+      attributes: {
+        friendly_name: `Kleenex Pollen Radar (${city}) Trees`,
+        details: [],
+        forecast: [],
+      },
+    });
+    const hass = {
+      states: {
+        [UTRECHT_IDS[0]!]: legacyState(UTRECHT_IDS[0]!, "Utrecht"),
+        [ROTTERDAM_IDS[0]!]: legacyState(ROTTERDAM_IDS[0]!, "Rotterdam"),
+      },
+      entities: {},
+      devices: {},
+      locale: { language: "en" },
+      language: "en",
+    } as unknown as HomeAssistant;
+
+    const scope = scopeManualEntities(hass, Object.keys((hass as any).states), {
+      prefix: "kleenex_pollen_radar_",
+    });
+
+    expect(scope.entityIds).toEqual([UTRECHT_IDS[0]]);
+    expect(scope.label).toBe("Utrecht");
+  });
+
   // Single-entity cells. 776a559 lowered the entry guard from "at least two
   // matched entities" to "at least one", precisely so a lone entity from the
   // wrong device can be filtered out: an empty card for the right location

--- a/test/adapters/kleenex-manual-scope-matrix.test.ts
+++ b/test/adapters/kleenex-manual-scope-matrix.test.ts
@@ -209,33 +209,138 @@ function reversed(hass: HomeAssistant): HomeAssistant {
   } as HomeAssistant;
 }
 
-const PREFIX_FORMS: { form: string; prefix: string; note: string }[] = [
+/**
+ * A prefix form, described by *what it is* rather than by its name: `owns`
+ * names the role of the device the prefix is the slug of, which is what decides
+ * whether the ownership invariant applies. Invariant selection reads these
+ * properties, never the form's name.
+ */
+interface PrefixForm {
+  form: string;
+  prefix: string;
+  note: string;
+  owns: "owner" | "colliding" | null;
+}
+
+const PREFIX_FORMS: PrefixForm[] = [
   {
     form: "1-renamed-device-slug",
     prefix: "kleenex_pollen_",
     note: "exact slug of the renamed device",
+    owns: "owner",
   },
   {
     form: "2-legacy-device-slug",
     prefix: "kleenex_pollen_radar_utrecht_",
     note: "exact slug of the legacy device",
+    owns: "colliding",
   },
   {
     form: "3-broad-legacy-prefix",
     prefix: "kleenex_pollen_radar_",
     note: "prefix of several locations' IDs, slug of none",
+    owns: null,
   },
   {
     form: "4-truncated-non-slug",
     prefix: "kleenex_pol",
     note: "truncated, matches no device slug",
+    owns: null,
   },
   {
     form: "5-non-slug-with-matches",
     prefix: "kleenex_",
     note: "matches every entity, slug of no device",
+    owns: null,
   },
 ];
+
+/**
+ * What each environment *is*, so the invariants below can be selected from
+ * properties instead of from the environment's name.
+ *
+ * This is not cosmetic. The first version gated the strongest invariant on
+ * `env.startsWith("multi")`, and the two mixed-registry environments added
+ * later silently opted out of it: a mutation that reverted half the tier-2 fix
+ * kept the whole suite green while the bug was demonstrably back. A new
+ * environment must now state its properties, and TypeScript will not let it be
+ * added without them.
+ */
+interface EnvSpec {
+  /** Any registry information at all (entity entries and/or devices). */
+  hasRegistry: boolean;
+  /** Device id of the device a prefix minted from a rename would belong to. */
+  ownerDevice: string | null;
+  /** Every other Kleenex device present, in the order they collide. */
+  collidingDevices: string[];
+  /** Locations discoverable from entity IDs alone (tier 3). */
+  tier3Locations: number;
+}
+
+const ENV_SPECS: Record<Environment, EnvSpec> = {
+  multi: {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht"],
+    tier3Locations: 1,
+  },
+  "multi-long": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht"],
+    tier3Locations: 1,
+  },
+  "multi-legacy": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht", "dev_rotterdam"],
+    tier3Locations: 2,
+  },
+  "multi-duplicate-keys": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht", "dev_rotterdam"],
+    tier3Locations: 2,
+  },
+  "mixed-colliding-tier2": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht"],
+    tier3Locations: 1,
+  },
+  "mixed-owner-tier2": {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: ["dev_utrecht"],
+    tier3Locations: 1,
+  },
+  single: {
+    hasRegistry: true,
+    ownerDevice: "dev_paris",
+    collidingDevices: [],
+    tier3Locations: 0,
+  },
+  bare: {
+    hasRegistry: false,
+    ownerDevice: null,
+    collidingDevices: [],
+    tier3Locations: 1,
+  },
+};
+
+/** The device the given prefix form is the slug of, in this cell. */
+function ownedDevice(
+  spec: EnvSpec,
+  owner: OwnerMode,
+  form: PrefixForm,
+): string | null {
+  if (form.owns === "owner") {
+    // An owner absent from the registry cannot be recognised as one.
+    return owner === "absent" ? null : spec.ownerDevice;
+  }
+  if (form.owns === "colliding") return spec.collidingDevices[0] ?? null;
+  return null;
+}
 
 const ENVIRONMENTS: Environment[] = [
   "multi",
@@ -305,7 +410,9 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
         continue;
       }
 
-      for (const { form, prefix, note } of PREFIX_FORMS) {
+      const spec = ENV_SPECS[env];
+      for (const formSpec of PREFIX_FORMS) {
+        const { form, prefix, note } = formSpec;
         it(`${env}/${owner}/${form}: holds every invariant (${note})`, () => {
           const hass = buildHass(env, owner);
           const inputIds = Object.keys(
@@ -329,27 +436,24 @@ describe("Kleenex manual-scope invariants (prefix forms x owner modes x environm
             }
           }
 
-          // Invariant: a registry-less install behaves exactly as before, i.e.
-          // pure prefix matching with no narrowing and no header override.
-          if (env === "bare") {
+          // Invariant: an install where nothing can attribute an entity --
+          // no registry, and too few tier-3 locations to tell them apart --
+          // is returned untouched, with no header override.
+          if (!spec.hasRegistry && spec.tier3Locations < 2) {
             expect(scope.entityIds).toEqual(inputIds);
             expect(scope.label).toBeNull();
           }
 
-          // Invariant: when the registry knows an owner for this prefix, no
-          // other location's data may appear -- not even if the owner has no
-          // usable states of its own.
-          const multi = env.startsWith("multi");
-          if (multi && owner !== "absent" && form.startsWith("1-")) {
-            // Ownership survives the owner having no usable states: no other
-            // location's data may appear, however little the owner offers.
-            expect([...keptDevices]).not.toContain("dev_utrecht");
-            for (const eid of UTRECHT_IDS) {
-              expect(scope.entityIds).not.toContain(eid);
+          // Invariant: when a registry-known device owns this prefix, no other
+          // location's entities may appear -- not even when the owner has no
+          // usable states and contributes nothing itself.
+          const owned = ownedDevice(spec, owner, formSpec);
+          if (owned) {
+            expect([...keptDevices].filter((id) => id !== owned)).toEqual([]);
+            for (const eid of scope.entityIds) {
+              const deviceId = (hass as any).entities?.[eid]?.device_id;
+              expect(deviceId === undefined || deviceId === owned).toBe(true);
             }
-          }
-          if (multi && form.startsWith("2-")) {
-            expect([...keptDevices]).not.toContain("dev_paris");
           }
 
           // Invariant: the outcome does not depend on registry/state iteration

--- a/test/adapters/kleenex-region-names.test.ts
+++ b/test/adapters/kleenex-region-names.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import {
+  fetchForecast,
+  stubConfigKleenex,
+  KLEENEX_ALLERGEN_MAP,
+  normalizeDetailName,
+} from "../../src/adapters/kleenex/index.js";
+import { createHass } from "../helpers.js";
+
+/**
+ * Every allergen name the Kleenex integration reports, per region and category.
+ *
+ * Source: live dump from an 8-location hass-test install on 2026-07-30,
+ * integration v1.6.1 (tmp/final-verify/detail-names.txt in the repo). The
+ * strings are verbatim, including the trailing space FR and IT put on
+ * "Poaceae " and the IT misspelling "Chenepod" -- normalizing them here would
+ * defeat the point of the matrix.
+ *
+ * The integration serves exactly five regions. US is a matrix case in its own
+ * right: its endpoint hardcodes empty details[], so no per-allergen name ever
+ * arrives and only the category totals are usable.
+ *
+ * A new upstream spelling belongs here as a row, alongside its alias in
+ * KLEENEX_ALLERGEN_MAP -- not as a one-off fix at the call site.
+ */
+const REGION_DETAIL_NAMES: Record<
+  string,
+  { source: string; trees: string[]; grass: string[]; weeds: string[] }
+> = {
+  fr: {
+    source: "Paris",
+    trees: [
+      "Noisetier",
+      "Orme",
+      "Pin",
+      "Aulne",
+      "Peuplier",
+      "Chêne",
+      "Platane",
+      "Bouleau",
+      "Cyprès",
+    ],
+    grass: ["Poaceae "],
+    weeds: ["Armoise", "Chénopodes", "Ambroisie", "Ortie"],
+  },
+  it: {
+    // The IT endpoint answers in English, so the Italian aliases in the map are
+    // never exercised by it -- but it misspells chenopod as "Chenepod".
+    source: "Roma, Milano",
+    trees: [
+      "Cypress",
+      "Plane",
+      "Alder",
+      // "Hazel" is listed twice by the IT endpoint; kept as dumped.
+      "Hazel",
+      "Hazel",
+      "Elm",
+      "Oak",
+      "Pine",
+      "Poplar",
+    ],
+    grass: ["Poaceae "],
+    weeds: ["Nettle", "Chenepod", "Mugwort", "Ragweed"],
+  },
+  nl: {
+    source: "Utrecht",
+    trees: [
+      "Hazelaar",
+      "Iep",
+      "Pijnboom",
+      "Els",
+      "Populier",
+      "Eik",
+      "Plataan",
+      "Berk",
+      "Cipres",
+    ],
+    grass: ["Poaceae"],
+    weeds: ["Bijvoet", "Ganzevoet", "Ambrosia", "Brandnetel"],
+  },
+  uk: {
+    source: "London",
+    trees: [
+      "Hazel",
+      "Elm",
+      "Pine",
+      "Alder",
+      "Poplar",
+      "Oak",
+      "Plane",
+      "Birch",
+      "Cypress",
+    ],
+    grass: ["Poaceae"],
+    weeds: ["Mugwort", "Chenopod", "Ragweed", "Nettle"],
+  },
+  us: {
+    source: "Atlanta, Boise, New York",
+    trees: [],
+    grass: [],
+    weeds: [],
+  },
+};
+
+const CATEGORIES = ["trees", "grass", "weeds"] as const;
+
+function detailSensor(
+  category: string,
+  names: string[],
+  value: number,
+): Record<string, unknown> {
+  return {
+    entity_id: `sensor.kleenex_pollen_radar_matrix_${category}`,
+    state: String(value),
+    attributes: {
+      details: names.map((name) => ({ name, value })),
+      forecast: [],
+    },
+  };
+}
+
+describe("Kleenex adapter: upstream allergen names per region", () => {
+  for (const [region, data] of Object.entries(REGION_DETAIL_NAMES)) {
+    for (const category of CATEGORIES) {
+      const names = data[category];
+      if (names.length === 0) continue;
+
+      it(`resolves every ${region}/${category} name to a canonical allergen (${data.source})`, () => {
+        const unresolved = names.filter(
+          (name) => !KLEENEX_ALLERGEN_MAP[normalizeDetailName(name)],
+        );
+        expect(unresolved).toEqual([]);
+      });
+    }
+  }
+
+  it("renders a row for every reported name, in every region", async () => {
+    for (const [region, data] of Object.entries(REGION_DETAIL_NAMES)) {
+      const allNames = CATEGORIES.flatMap((c) => data[c]);
+      if (allNames.length === 0) continue;
+
+      // Unresolvable names are the per-region tests' business; this one checks
+      // that everything which does resolve survives all the way to a row.
+      const expected = new Set(
+        allNames
+          .map((name) => KLEENEX_ALLERGEN_MAP[normalizeDetailName(name)])
+          .filter((key): key is string => !!key),
+      );
+      const states: Record<string, unknown> = {};
+      let value = 10;
+      for (const category of CATEGORIES) {
+        if (data[category].length === 0) continue;
+        const sensor = detailSensor(category, data[category], (value += 5));
+        states[sensor.entity_id as string] = sensor;
+      }
+
+      const result = await fetchForecast(createHass(states as any), {
+        ...stubConfigKleenex,
+        location: "matrix",
+        allergens: [...expected],
+        pollen_threshold: 0,
+      } as any);
+
+      const rendered = new Set(result.map((s) => s.allergenReplaced));
+      expect(
+        [...expected].filter((key) => !rendered.has(key)),
+        `region ${region} (${data.source}) lost allergen rows`,
+      ).toEqual([]);
+    }
+  });
+
+  // The US endpoint hardcodes empty details[], so the matrix has nothing to
+  // resolve there; the card is expected to fall back to category totals.
+  it("has no per-allergen names for us, and renders category totals instead", async () => {
+    expect(CATEGORIES.flatMap((c) => REGION_DETAIL_NAMES.us![c])).toEqual([]);
+
+    const states: Record<string, unknown> = {};
+    for (const category of CATEGORIES) {
+      const sensor = detailSensor(category, [], 40);
+      states[sensor.entity_id as string] = sensor;
+    }
+
+    const result = await fetchForecast(createHass(states as any), {
+      ...stubConfigKleenex,
+      location: "matrix",
+      allergens: ["trees_cat", "grass_cat", "weeds_cat"],
+      pollen_threshold: 0,
+    } as any);
+
+    expect(result.map((s) => s.allergenReplaced).sort()).toEqual([
+      "grass_cat",
+      "trees_cat",
+      "weeds_cat",
+    ]);
+  });
+
+  it("normalizes padding, inner whitespace runs and case", () => {
+    expect(normalizeDetailName("  Poaceae ")).toBe("poaceae");
+    expect(normalizeDetailName("Grand\u00A0 Plane")).toBe("grand plane");
+    expect(normalizeDetailName("\tNettle\n")).toBe("nettle");
+    expect(normalizeDetailName(undefined)).toBe("");
+    expect(normalizeDetailName(42)).toBe("");
+  });
+
+  // A key that isn't in normalized form can never be hit by a lookup, since
+  // every lookup normalizes its needle first. Catches an alias added with
+  // capitals or stray whitespace.
+  it("keeps every alias key in normalized form", () => {
+    const offending = Object.keys(KLEENEX_ALLERGEN_MAP).filter(
+      (key) => normalizeDetailName(key) !== key,
+    );
+    expect(offending).toEqual([]);
+  });
+});

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -4,6 +4,7 @@ import {
   stubConfigKleenex,
   resolveEntityIds,
   discoverKleenex,
+  scopeManualEntities,
 } from "../../src/adapters/kleenex/index.js";
 import { _resetNaWarningsForTest } from "../../src/adapters/kleenex/forecast.js";
 import {
@@ -2308,5 +2309,164 @@ describe("Kleenex adapter: whitespace in detail allergen names", () => {
     const birch = result.find((s) => s.allergenReplaced === "birch");
     expect(birch).toBeDefined();
     expect(birch!.days[1]!.value).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manual prefix spanning two config entries
+// ---------------------------------------------------------------------------
+describe("Kleenex adapter: manual prefix across locations", () => {
+  /**
+   * Two config entries as seen in the field: Paris on a renamed device
+   * ("Kleenex pollen" -> sensor.kleenex_pollen_*) and Utrecht on the legacy
+   * default naming (sensor.kleenex_pollen_radar_utrecht_*). The prefix
+   * `kleenex_pollen_` matches both.
+   */
+  function collidingEntries(): any[] {
+    const attrs = (ppm: number, name: string) => ({
+      details: [{ name, value: ppm }],
+      forecast: [],
+    });
+    return [
+      {
+        entityId: "sensor.kleenex_pollen_trees",
+        state: "200",
+        attributes: attrs(200, "Bouleau"),
+        platform: "kleenex_pollenradar",
+        translationKey: "trees",
+        deviceId: "dev_paris",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Paris)",
+          nameByUser: "Kleenex pollen",
+          identifiers: [["kleenex_pollenradar", "Paris"]],
+          configEntries: ["cfg_paris"],
+        },
+      },
+      {
+        entityId: "sensor.kleenex_pollen_grass",
+        state: "100",
+        attributes: attrs(100, "Poaceae"),
+        platform: "kleenex_pollenradar",
+        translationKey: "grass",
+        deviceId: "dev_paris",
+      },
+      {
+        entityId: "sensor.kleenex_pollen_radar_utrecht_trees",
+        state: "20",
+        attributes: attrs(20, "Berk"),
+        platform: "kleenex_pollenradar",
+        translationKey: "trees",
+        deviceId: "dev_utrecht",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Utrecht)",
+          identifiers: [["kleenex_pollenradar", "Utrecht"]],
+          configEntries: ["cfg_utrecht"],
+        },
+      },
+      {
+        entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+        state: "10",
+        attributes: attrs(10, "Grassen"),
+        platform: "kleenex_pollenradar",
+        translationKey: "grass",
+        deviceId: "dev_utrecht",
+      },
+    ];
+  }
+
+  const manualConfig = makeConfig({
+    location: "manual",
+    entity_prefix: "kleenex_pollen_",
+    allergens: ["trees_cat", "grass_cat"],
+    pollen_threshold: 0,
+  });
+
+  it("keeps only the location the prefix was minted from", async () => {
+    const hass = createHassWithRegistry(collidingEntries() as any);
+
+    const result = await fetchForecast(hass, manualConfig);
+
+    expect(result.length).toBe(2);
+    expect(result.map((s) => s.entity_id).sort()).toEqual([
+      "sensor.kleenex_pollen_grass",
+      "sensor.kleenex_pollen_trees",
+    ]);
+    // Paris values, not Utrecht's.
+    const trees = result.find((s) => s.allergenReplaced === "trees_cat");
+    expect(trees!.days[0]!.value).toBe(200);
+  });
+
+  it("scopeManualEntities reports the winning location's label", () => {
+    const hass = createHassWithRegistry(collidingEntries() as any);
+
+    const scope = scopeManualEntities(
+      hass,
+      Object.keys(hass.states),
+      { prefix: "kleenex_pollen_" },
+    );
+
+    expect(scope.label).toBe("Kleenex pollen");
+    expect(scope.entityIds).toEqual([
+      "sensor.kleenex_pollen_trees",
+      "sensor.kleenex_pollen_grass",
+    ]);
+  });
+
+  it("leaves a single-location install untouched", async () => {
+    const single = collidingEntries().slice(0, 2);
+    const hass = createHassWithRegistry(single as any);
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+    expect(scope.label).toBeNull();
+    expect(scope.entityIds.length).toBe(2);
+
+    const result = await fetchForecast(hass, manualConfig);
+    expect(result.length).toBe(2);
+  });
+
+  it("keeps entities the registry knows nothing about", async () => {
+    // A template sensor imitating the naming: unattributable, so it must not
+    // be dropped -- manual mode is the fallback for registry-less setups.
+    const hass = createHassWithRegistry(collidingEntries() as any);
+    (hass.states as any)["sensor.kleenex_pollen_weeds"] = {
+      entity_id: "sensor.kleenex_pollen_weeds",
+      state: "30",
+      attributes: { friendly_name: "Template weeds", details: [], forecast: [] },
+    };
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.entityIds).toContain("sensor.kleenex_pollen_weeds");
+    expect(scope.entityIds).not.toContain(
+      "sensor.kleenex_pollen_radar_utrecht_grass",
+    );
+  });
+
+  it("does not narrow when no matched entity is in the registry", () => {
+    // Registry-less install: two locations by naming convention only. Today's
+    // behaviour (pure prefix matching) must survive.
+    const hass = createHass({
+      "sensor.kleenex_pollen_trees": {
+        entity_id: "sensor.kleenex_pollen_trees",
+        state: "200",
+        attributes: { details: [], forecast: [] },
+      },
+      "sensor.kleenex_pollen_radar_utrecht_trees": {
+        entity_id: "sensor.kleenex_pollen_radar_utrecht_trees",
+        state: "20",
+        attributes: { details: [], forecast: [] },
+      },
+    });
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.label).toBeNull();
+    expect(scope.entityIds.length).toBe(2);
   });
 });

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -2474,6 +2474,107 @@ describe("Kleenex adapter: manual prefix across locations", () => {
     );
   });
 
+  // Codex P2 on PR #315: the remainder heuristic measures allergen-name length,
+  // so an install where the intended device has only a long-named detail sensor
+  // enabled lost to the colliding device's shorter `radar_utrecht_grass`.
+  // Ownership is now decided on the device slug, before any entity name is
+  // measured.
+  it("picks the device the prefix was minted from, however long its entity names are", async () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.kleenex_pollen_zeer_lange_naam_brandnetel",
+        state: "50",
+        attributes: { friendly_name: "Kleenex pollen Zeer lange naam brandnetel" },
+        platform: "kleenex_pollenradar",
+        translationKey: "detail_value",
+        uniqueId: "cfg_paris-Kleenex Pollen Radarweeds_details-Nettle-value",
+        deviceId: "dev_paris",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Paris)",
+          nameByUser: "Kleenex pollen",
+          identifiers: [["kleenex_pollenradar", "Paris"]],
+          configEntries: ["cfg_paris"],
+        },
+      },
+      {
+        entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+        state: "10",
+        attributes: { details: [], forecast: [] },
+        platform: "kleenex_pollenradar",
+        translationKey: "grass",
+        deviceId: "dev_utrecht",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Utrecht)",
+          identifiers: [["kleenex_pollenradar", "Utrecht"]],
+          configEntries: ["cfg_utrecht"],
+        },
+      },
+    ] as any);
+
+    // The remainder the old rule compared: 26 for Paris, 19 for Utrecht.
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.label).toBe("Kleenex pollen");
+    expect(scope.entityIds).toEqual([
+      "sensor.kleenex_pollen_zeer_lange_naam_brandnetel",
+    ]);
+
+    const result = await fetchForecast(
+      hass,
+      makeConfig({
+        location: "manual",
+        entity_prefix: "kleenex_pollen_",
+        allergens: ["nettle"],
+        pollen_threshold: 0,
+      }),
+    );
+    expect(result.map((s) => s.entity_id)).toEqual([
+      "sensor.kleenex_pollen_zeer_lange_naam_brandnetel",
+    ]);
+  });
+
+  it("gives a legacy prefix to the legacy device, not the renamed one", () => {
+    const hass = createHassWithRegistry([
+      {
+        entityId: "sensor.kleenex_pollen_grass",
+        state: "100",
+        attributes: { details: [], forecast: [] },
+        platform: "kleenex_pollenradar",
+        translationKey: "grass",
+        deviceId: "dev_paris",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Paris)",
+          nameByUser: "Kleenex pollen",
+          identifiers: [["kleenex_pollenradar", "Paris"]],
+          configEntries: ["cfg_paris"],
+        },
+      },
+      {
+        entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+        state: "10",
+        attributes: { details: [], forecast: [] },
+        platform: "kleenex_pollenradar",
+        translationKey: "grass",
+        deviceId: "dev_utrecht",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Utrecht)",
+          identifiers: [["kleenex_pollenradar", "Utrecht"]],
+          configEntries: ["cfg_utrecht"],
+        },
+      },
+    ] as any);
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_radar_utrecht_",
+    });
+
+    expect(scope.entityIds).toEqual([
+      "sensor.kleenex_pollen_radar_utrecht_grass",
+    ]);
+  });
+
   it("does not narrow when no matched entity is in the registry", () => {
     // Registry-less install: two locations by naming convention only. Today's
     // behaviour (pure prefix matching) must survive.

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -2614,6 +2614,96 @@ describe("Kleenex adapter: manual prefix across locations", () => {
     }
   });
 
+  /**
+   * The owning config entry is down: its device and entities are in the
+   * registry, but HA exposes no state objects for them (or only unavailable
+   * ones). Discovery, which only sees state-backed entities, therefore knows
+   * nothing about the owner.
+   */
+  function ownerWithoutStatesHass(withUnavailableStates: boolean): any {
+    const hass: any = createHassWithRegistry([
+      {
+        entityId: "sensor.kleenex_pollen_radar_utrecht_trees",
+        state: "20",
+        attributes: { details: [{ name: "Berk", value: 20 }], forecast: [] },
+        platform: "kleenex_pollenradar",
+        translationKey: "trees",
+        deviceId: "dev_utrecht",
+        deviceMeta: {
+          name: "Kleenex Pollen Radar (Utrecht)",
+          identifiers: [["kleenex_pollenradar", "Utrecht"]],
+          configEntries: ["cfg_utrecht"],
+        },
+      },
+    ] as any);
+
+    hass.devices.dev_paris = {
+      identifiers: [["kleenex_pollenradar", "Paris"]],
+      config_entries: ["cfg_paris"],
+      name: "Kleenex Pollen Radar (Paris)",
+      name_by_user: "Kleenex pollen",
+    };
+    for (const suffix of ["trees", "grass"]) {
+      const eid = `sensor.kleenex_pollen_${suffix}`;
+      hass.entities[eid] = {
+        device_id: "dev_paris",
+        platform: "kleenex_pollenradar",
+        translation_key: suffix,
+        unique_id: null,
+        entity_category: null,
+      };
+      if (withUnavailableStates) {
+        hass.states[eid] = {
+          entity_id: eid,
+          state: "unavailable",
+          attributes: { friendly_name: `Kleenex pollen ${suffix}` },
+        };
+      }
+    }
+    return hass;
+  }
+
+  // Codex round 2 on PR #315: with the owner missing from discovery, the early
+  // returns let every prefix match through, so `kleenex_pollen_` rendered
+  // Utrecht's forecast under a config meant for Paris. Ownership is decided on
+  // the device registry, which still knows the owner while its entry is down.
+  it("keeps ownership when the owning device has no usable states", async () => {
+    const hass = ownerWithoutStatesHass(false);
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.entityIds).toEqual([]);
+    expect(scope.label).toBe("Kleenex pollen");
+
+    const result = await fetchForecast(
+      hass,
+      makeConfig({
+        location: "manual",
+        entity_prefix: "kleenex_pollen_",
+        allergens: ["trees_cat", "birch"],
+        pollen_threshold: 0,
+      }),
+    );
+    // No data for the intended location beats another city's data.
+    expect(result).toEqual([]);
+  });
+
+  it("keeps ownership when the owning device's states are unavailable", () => {
+    const hass = ownerWithoutStatesHass(true);
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(scope.entityIds).toEqual([
+      "sensor.kleenex_pollen_trees",
+      "sensor.kleenex_pollen_grass",
+    ]);
+    expect(scope.label).toBe("Kleenex pollen");
+  });
+
   it("does not narrow when no matched entity is in the registry", () => {
     // Registry-less install: two locations by naming convention only. Today's
     // behaviour (pure prefix matching) must survive.

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -2260,3 +2260,53 @@ describe("Kleenex adapter: legacy slug via device identifier", () => {
     expect(map.size).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Allergen names with stray whitespace (FR zone)
+// ---------------------------------------------------------------------------
+describe("Kleenex adapter: whitespace in detail allergen names", () => {
+  // The FR feed reports detail entries as {"name": "Poaceae ", ...}. Without
+  // trimming, the lookup key is "poaceae " and matches neither
+  // KLEENEX_ALLERGEN_MAP nor config.allergens, so the row vanished silently.
+  it("resolves today's details when the name has a trailing space", async () => {
+    // The individual allergen only exists in details[], so nothing else can
+    // supply the row if the lookup key keeps its trailing space.
+    const entity = makeKleenexEntity("paris", "trees", 150, [
+      { name: "Bouleau ", value: 150 },
+    ]);
+    const hass = makeHassFromEntities([entity]);
+    const config = makeConfig({
+      location: "paris",
+      allergens: ["birch"],
+      pollen_threshold: 0,
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    const birch = result.find((s) => s.allergenReplaced === "birch");
+    expect(birch).toBeDefined();
+    expect(birch!.days[0]!.value).toBe(150);
+  });
+
+  it("resolves forecast-day details when the name has a leading space", async () => {
+    const entity = makeKleenexEntity(
+      "paris",
+      "trees",
+      0,
+      [],
+      [{ level: 2, details: [{ name: " Bouleau", value: 120 }] }],
+    );
+    const hass = makeHassFromEntities([entity]);
+    const config = makeConfig({
+      location: "paris",
+      allergens: ["birch"],
+      pollen_threshold: 0,
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    const birch = result.find((s) => s.allergenReplaced === "birch");
+    expect(birch).toBeDefined();
+    expect(birch!.days[1]!.value).toBe(120);
+  });
+});

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -5,6 +5,7 @@ import {
   resolveEntityIds,
   discoverKleenex,
   scopeManualEntities,
+  _resetManualScopeWarningsForTest,
 } from "../../src/adapters/kleenex/index.js";
 import { _resetNaWarningsForTest } from "../../src/adapters/kleenex/forecast.js";
 import {
@@ -2573,6 +2574,44 @@ describe("Kleenex adapter: manual prefix across locations", () => {
     expect(scope.entityIds).toEqual([
       "sensor.kleenex_pollen_radar_utrecht_grass",
     ]);
+  });
+
+  // Nagelfar round 1: narrowing removes rows and renames the header, so the one
+  // case where data disappears must say so without requiring debug: true.
+  it("warns exactly once per configuration when it narrows", () => {
+    _resetManualScopeWarningsForTest();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const hass = createHassWithRegistry(collidingEntries() as any);
+      const ids = Object.keys(hass.states);
+
+      scopeManualEntities(hass, ids, { prefix: "kleenex_pollen_" });
+      scopeManualEntities(hass, ids, { prefix: "kleenex_pollen_" });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = String(warn.mock.calls[0]![0]);
+      // Names both the location it kept and the one it dropped.
+      expect(message).toContain("Kleenex pollen");
+      expect(message).toContain("Utrecht");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("stays silent when nothing is narrowed", () => {
+    _resetManualScopeWarningsForTest();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const hass = createHassWithRegistry(collidingEntries().slice(0, 2) as any);
+
+      scopeManualEntities(hass, Object.keys(hass.states), {
+        prefix: "kleenex_pollen_",
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("does not narrow when no matched entity is in the registry", () => {

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -2289,6 +2289,34 @@ describe("Kleenex adapter: whitespace in detail allergen names", () => {
     expect(birch!.days[0]!.value).toBe(150);
   });
 
+  // Roma/Milano, verbatim from the live IT install: the endpoint answers in
+  // English, pads "Poaceae " with a trailing space and spells chenopod
+  // "Chenepod". All three had to hold for the Italian rows to render.
+  it("renders the Italian weeds and grass rows (English names, padded, Chenepod)", async () => {
+    const grass = makeKleenexEntity("roma", "grass", 75, [
+      { name: "Poaceae ", value: 75 },
+    ]);
+    const weeds = makeKleenexEntity("roma", "weeds", 187, [
+      { name: "Nettle", value: 173 },
+      { name: "Chenepod", value: 1 },
+      { name: "Mugwort", value: 1 },
+      { name: "Ragweed", value: 7 },
+    ]);
+    const hass = makeHassFromEntities([grass, weeds]);
+    const config = makeConfig({
+      location: "roma",
+      allergens: ["poaceae", "chenopod", "nettle"],
+      pollen_threshold: 0,
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    const byKey = new Map(result.map((s) => [s.allergenReplaced, s]));
+    expect([...byKey.keys()].sort()).toEqual(["chenopod", "nettle", "poaceae"]);
+    expect(byKey.get("poaceae")!.days[0]!.value).toBe(75);
+    expect(byKey.get("chenopod")!.days[0]!.value).toBe(1);
+  });
+
   it("resolves forecast-day details when the name has a leading space", async () => {
     const entity = makeKleenexEntity(
       "paris",

--- a/test/card/card-kleenex-header.test.ts
+++ b/test/card/card-kleenex-header.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { createHass } from "../helpers.js";
+import { createHass, createHassWithRegistry } from "../helpers.js";
 
 // The card is a LitElement, so this file installs the same minimal DOM shim as
 // the editor tests. Nothing is rendered; only the header label resolution in
@@ -161,6 +161,59 @@ function mixedSuffixHass(): any {
   });
 }
 
+/**
+ * Two config entries whose entity IDs collide under the prefix
+ * `kleenex_pollen_`: Paris on a renamed device, Utrecht on the legacy naming.
+ */
+function collidingLocationsHass(): any {
+  const attrs = { details: [], forecast: [] };
+  // Utrecht first: the pre-fix header picked whichever colliding entity
+  // hass.states listed first, so the order is what reproduced the bug.
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.kleenex_pollen_radar_utrecht_trees",
+      state: "20",
+      attributes: {
+        friendly_name: "Kleenex Pollen Radar (Utrecht) Trees",
+        ...attrs,
+      },
+      platform: "kleenex_pollenradar",
+      translationKey: "trees",
+      deviceId: "dev_utrecht",
+      deviceMeta: {
+        name: "Kleenex Pollen Radar (Utrecht)",
+        identifiers: [["kleenex_pollenradar", "Utrecht"]],
+        configEntries: ["cfg_utrecht"],
+      },
+    },
+    {
+      entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+      state: "10",
+      attributes: {
+        friendly_name: "Kleenex Pollen Radar (Utrecht) Grass",
+        ...attrs,
+      },
+      platform: "kleenex_pollenradar",
+      translationKey: "grass",
+      deviceId: "dev_utrecht",
+    },
+    {
+      entityId: "sensor.kleenex_pollen_trees",
+      state: "200",
+      attributes: { friendly_name: "Kleenex pollen Trees", ...attrs },
+      platform: "kleenex_pollenradar",
+      translationKey: "trees",
+      deviceId: "dev_paris",
+      deviceMeta: {
+        name: "Kleenex Pollen Radar (Paris)",
+        nameByUser: "Kleenex pollen",
+        identifiers: [["kleenex_pollenradar", "Paris"]],
+        configEntries: ["cfg_paris"],
+      },
+    },
+  ] as any);
+}
+
 let CardCtor: new () => {
   hass: unknown;
   setConfig: (config: Record<string, unknown>) => void;
@@ -242,6 +295,23 @@ describe("card header for Kleenex manual mode (issue #309)", () => {
       allergens: ["trees"],
     });
     card.hass = suffixedDiagnosticsFirstHass();
+
+    expect(card.header).toBe("Pollen forecast for Kleenex pollen");
+  });
+
+  // The prefix `kleenex_pollen_` also matches another config entry's legacy
+  // `kleenex_pollen_radar_utrecht_*` IDs, and Utrecht came first in
+  // hass.states, so the header named a location the card wasn't rendering.
+  it("names the location the prefix was minted from, not a colliding one", () => {
+    const card = new CardCtor();
+    card.setConfig({
+      type: "custom:pollenprognos-card",
+      integration: "kleenex",
+      location: "manual",
+      entity_prefix: "kleenex_pollen_",
+      allergens: ["trees"],
+    });
+    card.hass = collidingLocationsHass();
 
     expect(card.header).toBe("Pollen forecast for Kleenex pollen");
   });


### PR DESCRIPTION
Three bugs found during the empirical pre-beta1 verification against live Kleenex Pollen Radar v1.6.1 data across eight locations (NL/FR/UK/IT/US).

1. **Trim allergen names from details before lookup.** French and Italian category sensors deliver `"Poaceae "` with a trailing space; the lookup key was lowercased but never trimmed, so the grass row silently vanished for those locations. Names are now trimmed in both the current-day and forecast-day paths.

2. **Scope a manual `entity_prefix` to one location.** A manual prefix like `kleenex_pollen_` also matches legacy ids such as `kleenex_pollen_radar_utrecht_*`, so a multi-location install mixed sensors from every location and the header could name a different location than the data came from. When the matched entities span more than one discovered location, the adapter now keeps the location whose entity ids have the least remainder after stripping prefix and suffix (ties broken deterministically), and the header path resolves through the same function so title and data always agree. Entities the registry cannot attribute are always kept, and installs with fewer than two discovered locations are untouched, so registry-less setups (e.g. template sensors) behave exactly as before.

3. **Map the Italian `Chenepod` spelling to chenopod.** The Italian site spells chenopod with an `e`, and delivers English names, so the existing Italian aliases never apply; without this alias the chenopod row was silently dropped for Italian locations.

Each fix carries a test whose failure was manually confirmed against the unfixed code (removing the trim, disabling the scoping, and dropping the alias each reproduce the exact field symptom, including the `Pollen forecast for Utrecht` header on a Paris-prefix config).

Verification: typecheck 0 errors, lint 0/0, 1445 tests passed (8 new), goldens untouched, gzip 212727 bytes within budget.

---

**Review loop (5 Codex rounds + 6 local review rounds):** four Codex P2 findings (remainder-based ownership, unavailable owner, tier-2 membership, per-key attribution dedup) each fixed and absorbed into a descriptor-driven invariant matrix (5 prefix forms x owner modes x environments, 192 cells) that now mutation-binds every step of the scoping rule (M1-M10 all caught). Codex clean on 3b208fa; final commits are tests/documentation only. Empirically re-verified in hass-test against live Kleenex v1.6.1 data from 8 locations in 5 countries.

**Deferred (tracked for follow-up):** per-update discovery cost is shared with the atmo/gp/silam adapters and should be addressed for all four at once (see #311's deferred note); the Kleenex membership set adds one linear hass.entities sweep per manual-mode call, a candidate for the same memoization pass.

Final verification: typecheck 0 errors, lint 0/0, 1659 tests passed, goldens untouched, gzip 213675 bytes within budget.