### PR TITLE
(adapter-helpers) Add hass-keyed discovery memoization mechanism (#321)

### DIFF
--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -26,4 +26,9 @@ interface CustomBadgeEntry {
 interface Window {
   customCards?: CustomCardEntry[];
   customBadges?: CustomBadgeEntry[];
+  // Opt-in instrumentation: counts uncached entity-discovery sweeps per tag.
+  // Create it from the browser console (`window.__ppDiscoveryScans = {}`) or
+  // let a card running with `debug: true` create it. See recordDiscoveryScan
+  // in src/utils/adapter-helpers.ts.
+  __ppDiscoveryScans?: Record<string, number>;
 }

--- a/src/utils/adapter-helpers.ts
+++ b/src/utils/adapter-helpers.ts
@@ -798,33 +798,44 @@ export function recordDiscoveryScan(tag: string, debug = false): void {
  *    get the same object reference, so mutating a returned discovery (adding
  *    to `locations`/`entities`, deleting a location) leaks into unrelated
  *    callers. Copy before modifying.
- * 2. **Only `hass` is part of the cache key.** Extra arguments (notably
- *    `debug`) are passed through on a miss but ignored on a hit: the first
- *    call of a tick wins, and a later call with `debug: true` returns the
- *    cached result without logging anything. This is deliberate — the
- *    wrapped functions are pure with respect to those arguments apart from
- *    logging.
+ * 2. **`hass` is the whole cache key.** The signature therefore admits only
+ *    the discovery shape `(hass, debug?)`: `debug` is passed through on a miss
+ *    and ignored on a hit (the first call of a tick wins, so a later call with
+ *    `debug: true` returns the cached result without logging), which is
+ *    harmless because it only affects logging. A function taking a further
+ *    argument that selects WHAT to discover — `discoverGplAllergens(hass,
+ *    configEntryId, debug)` and its GP twin, which the editor calls with
+ *    different config entries under one `hass` — must not be wrapped: it would
+ *    silently serve the first entry's data to every later entry. Keeping the
+ *    parameter list narrow turns that mistake into a compile error instead of
+ *    a wrong-location bug.
  *
  * A falsy or non-object `hass` is passed straight through uncached (WeakMap
  * keys must be objects, and adapters already handle a missing `hass`).
  *
- * @param fn - Discovery function taking `hass` as its first argument.
+ * Wrap once, at module level (`export const discoverX = memoizeByHass(...)`):
+ * the WeakMap is created when the wrapper is created, so a wrapper built
+ * inside a function caches nothing.
+ *
+ * @param fn - Discovery function taking `hass` and an optional `debug` flag.
  * @param countTag - Optional instrumentation tag; when given, every uncached
  *   call is counted via {@link recordDiscoveryScan} (only once the counter
  *   object exists). Leave unset for functions that already count their own
  *   sweep inside `discoverEntitiesByDevice`, otherwise the same sweep is
- *   counted twice under two keys.
+ *   counted twice under two keys. It exists for the sweeps that never reach
+ *   the engine and so count nothing on their own: Kleenex's `kleenexDeviceIds`
+ *   (#322) and Atmo's `detectLocation` (#323).
  * @returns A wrapper with the same signature as `fn`.
  */
-export function memoizeByHass<A extends unknown[], R>(
-  fn: (hass: HomeAssistant, ...args: A) => R,
+export function memoizeByHass<R>(
+  fn: (hass: HomeAssistant, debug?: boolean) => R,
   countTag?: string,
-): (hass: HomeAssistant, ...args: A) => R {
+): (hass: HomeAssistant, debug?: boolean) => R {
   const cache = new WeakMap<object, R>();
-  return (hass: HomeAssistant, ...args: A): R => {
-    if (!hass || typeof hass !== "object") return fn(hass, ...args);
+  return (hass: HomeAssistant, debug?: boolean): R => {
+    if (!hass || typeof hass !== "object") return fn(hass, debug);
     if (cache.has(hass)) return cache.get(hass) as R;
-    const result = fn(hass, ...args);
+    const result = fn(hass, debug);
     if (countTag) recordDiscoveryScan(countTag);
     cache.set(hass, result);
     return result;

--- a/src/utils/adapter-helpers.ts
+++ b/src/utils/adapter-helpers.ts
@@ -753,22 +753,33 @@ const _canonicalPhraseCache = new WeakMap<object, Record<string, string>>();
  *
  * Opt-in instrumentation for before/after measurements of the discovery
  * memoization (#321): it is a no-op unless `window.__ppDiscoveryScans` already
- * exists, or `debug` is true (in which case the counter object is created).
+ * holds a plain object, or `debug` is true (in which case one is installed).
  * A tester can therefore enable it live from the browser console with
  * `window.__ppDiscoveryScans = {}` without editing the card config, and
  * production installs pay nothing but one property read per sweep.
  *
+ * The global is shared with everything else on the page, so its value is
+ * type-guarded rather than trusted: a non-object (or an array) left there by
+ * another script counts as "not opted in", since assigning a property to a
+ * primitive throws in the module's strict-mode code and would take discovery
+ * down with it.
+ *
  * @param {string} tag - Counter key, typically the adapter's discovery logTag.
- * @param {boolean} [debug] - When true, create the counter object if missing.
+ * @param {boolean} [debug] - When true, install a counter object if the global
+ *   is missing or holds something unusable.
  */
 export function recordDiscoveryScan(tag: string, debug = false): void {
   if (typeof window === "undefined") return;
-  if (!window.__ppDiscoveryScans) {
+  const existing: unknown = window.__ppDiscoveryScans;
+  const usable =
+    !!existing && typeof existing === "object" && !Array.isArray(existing);
+  if (!usable) {
     if (!debug) return;
     window.__ppDiscoveryScans = {};
   }
-  const counters = window.__ppDiscoveryScans;
-  counters[tag] = (counters[tag] || 0) + 1;
+  const counters = window.__ppDiscoveryScans!;
+  const previous = counters[tag];
+  counters[tag] = (typeof previous === "number" ? previous : 0) + 1;
 }
 
 /**

--- a/src/utils/adapter-helpers.ts
+++ b/src/utils/adapter-helpers.ts
@@ -748,6 +748,78 @@ export function resolvePhraseOverride(
  */
 const _canonicalPhraseCache = new WeakMap<object, Record<string, string>>();
 
+/**
+ * Count one uncached entity-discovery sweep under `tag`.
+ *
+ * Opt-in instrumentation for before/after measurements of the discovery
+ * memoization (#321): it is a no-op unless `window.__ppDiscoveryScans` already
+ * exists, or `debug` is true (in which case the counter object is created).
+ * A tester can therefore enable it live from the browser console with
+ * `window.__ppDiscoveryScans = {}` without editing the card config, and
+ * production installs pay nothing but one property read per sweep.
+ *
+ * @param {string} tag - Counter key, typically the adapter's discovery logTag.
+ * @param {boolean} [debug] - When true, create the counter object if missing.
+ */
+export function recordDiscoveryScan(tag: string, debug = false): void {
+  if (typeof window === "undefined") return;
+  if (!window.__ppDiscoveryScans) {
+    if (!debug) return;
+    window.__ppDiscoveryScans = {};
+  }
+  const counters = window.__ppDiscoveryScans;
+  counters[tag] = (counters[tag] || 0) + 1;
+}
+
+/**
+ * Memoize a discovery function on the identity of the `hass` object.
+ *
+ * Home Assistant hands the card a NEW `hass` object on every state update, so
+ * a WeakMap keyed on that object caches only within one update cycle: the
+ * card, the badge, the editors and every adapter code path (detection,
+ * resolveEntityIds, fetchForecast) share one result per tick, and the entry
+ * becomes unreachable as soon as HA moves on. There is no staleness window and
+ * no cache invalidation to get wrong.
+ *
+ * Two contracts callers must respect:
+ *
+ * 1. **The result is shared — never mutate it.** All code paths within a tick
+ *    get the same object reference, so mutating a returned discovery (adding
+ *    to `locations`/`entities`, deleting a location) leaks into unrelated
+ *    callers. Copy before modifying.
+ * 2. **Only `hass` is part of the cache key.** Extra arguments (notably
+ *    `debug`) are passed through on a miss but ignored on a hit: the first
+ *    call of a tick wins, and a later call with `debug: true` returns the
+ *    cached result without logging anything. This is deliberate — the
+ *    wrapped functions are pure with respect to those arguments apart from
+ *    logging.
+ *
+ * A falsy or non-object `hass` is passed straight through uncached (WeakMap
+ * keys must be objects, and adapters already handle a missing `hass`).
+ *
+ * @param fn - Discovery function taking `hass` as its first argument.
+ * @param countTag - Optional instrumentation tag; when given, every uncached
+ *   call is counted via {@link recordDiscoveryScan} (only once the counter
+ *   object exists). Leave unset for functions that already count their own
+ *   sweep inside `discoverEntitiesByDevice`, otherwise the same sweep is
+ *   counted twice under two keys.
+ * @returns A wrapper with the same signature as `fn`.
+ */
+export function memoizeByHass<A extends unknown[], R>(
+  fn: (hass: HomeAssistant, ...args: A) => R,
+  countTag?: string,
+): (hass: HomeAssistant, ...args: A) => R {
+  const cache = new WeakMap<object, R>();
+  return (hass: HomeAssistant, ...args: A): R => {
+    if (!hass || typeof hass !== "object") return fn(hass, ...args);
+    if (cache.has(hass)) return cache.get(hass) as R;
+    const result = fn(hass, ...args);
+    if (countTag) recordDiscoveryScan(countTag);
+    cache.set(hass, result);
+    return result;
+  };
+}
+
 function getCanonicalPhraseIndex(phrases: PhraseMap): Record<string, string> {
   // Arrays satisfy typeof === "object" but would index numeric keys into a
   // meaningless map; the editor type-guards phrases.full/short to non-array
@@ -1128,6 +1200,9 @@ export function discoverEntitiesByDevice(
       : [];
   const logTag =
     opts.logTag || (platforms.length > 0 ? platforms[0] : "discovery");
+  // Every call here is a full registry sweep; memoized callers reach this
+  // point only on a cache miss, so the tally is the before/after metric.
+  recordDiscoveryScan(logTag || "discovery", debug);
   const classifyStrict = classify || (() => null);
   const classifyTier1 = classifyRelaxed || classifyStrict;
 

--- a/test/utils/adapter-helpers.test.ts
+++ b/test/utils/adapter-helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { HomeAssistant } from "../../src/types/home-assistant.js";
 import {
   memoizeByHass,
+  recordDiscoveryScan,
   discoverEntitiesByDevice,
   deviceLocationKey,
   findLocationBySlug,
@@ -1427,5 +1428,67 @@ describe("memoizeByHass", () => {
     expect(typeof window).toBe("undefined");
     const memoized = memoizeByHass(() => ({}), "unit-tag");
     expect(() => memoized(makeHass("a"))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordDiscoveryScan — the instrumentation global is shared with the page
+// ---------------------------------------------------------------------------
+
+describe("recordDiscoveryScan", () => {
+  const withWindow = (
+    value: unknown,
+    body: (win: { __ppDiscoveryScans?: unknown }) => void,
+  ) => {
+    const fakeWindow: { __ppDiscoveryScans?: unknown } = {
+      __ppDiscoveryScans: value,
+    };
+    (globalThis as { window?: unknown }).window = fakeWindow;
+    try {
+      body(fakeWindow);
+    } finally {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  };
+
+  // Anything on window can be clobbered by another script on the dashboard.
+  // Assigning a property to a primitive throws in strict-mode code, so an
+  // unusable value must read as "not opted in" rather than take discovery down.
+  const poisonedValues: [string, unknown][] = [
+    ["a number", 1],
+    ["a string", "on"],
+    ["true", true],
+    ["an array", []],
+  ];
+
+  for (const [label, value] of poisonedValues) {
+    it(`treats ${label} as not opted in and does not throw`, () => {
+      withWindow(value, (win) => {
+        expect(() => recordDiscoveryScan("unit-tag")).not.toThrow();
+        expect(win.__ppDiscoveryScans).toBe(value);
+      });
+    });
+
+    it(`replaces ${label} with a fresh counter when debug is on`, () => {
+      withWindow(value, (win) => {
+        expect(() => recordDiscoveryScan("unit-tag", true)).not.toThrow();
+        expect(win.__ppDiscoveryScans).toEqual({ "unit-tag": 1 });
+      });
+    });
+  }
+
+  it("keeps counting into an existing counter object", () => {
+    withWindow({ "unit-tag": 2 }, (win) => {
+      recordDiscoveryScan("unit-tag");
+      recordDiscoveryScan("other-tag");
+      expect(win.__ppDiscoveryScans).toEqual({ "unit-tag": 3, "other-tag": 1 });
+    });
+  });
+
+  it("restarts a tag whose stored value is not a number", () => {
+    withWindow({ "unit-tag": "many" }, (win) => {
+      recordDiscoveryScan("unit-tag");
+      expect(win.__ppDiscoveryScans).toEqual({ "unit-tag": 1 });
+    });
   });
 });

--- a/test/utils/adapter-helpers.test.ts
+++ b/test/utils/adapter-helpers.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { HomeAssistant } from "../../src/types/home-assistant.js";
 import {
+  memoizeByHass,
   discoverEntitiesByDevice,
   deviceLocationKey,
   findLocationBySlug,
@@ -1308,5 +1310,122 @@ describe("resolveAllergenNames", () => {
     });
     expect(allergenCapitalized).toBe("Grass");
     expect(allergenShort).toBe("Grass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// memoizeByHass — per-update-cycle discovery memoization (issue #321)
+// ---------------------------------------------------------------------------
+
+describe("memoizeByHass", () => {
+  const makeHass = (id: string) =>
+    ({ states: {}, entities: {}, devices: {}, id }) as unknown as HomeAssistant;
+
+  it("runs once per hass object and hands back the same reference", () => {
+    const inner = vi.fn((_hass: HomeAssistant) => ({ locations: new Map() }));
+    const memoized = memoizeByHass(inner);
+    const hass = makeHass("a");
+
+    const first = memoized(hass);
+    const second = memoized(hass);
+    const third = memoized(hass);
+
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it("recomputes when Home Assistant swaps the hass object", () => {
+    const inner = vi.fn((_hass: HomeAssistant) => ({ locations: new Map() }));
+    const memoized = memoizeByHass(inner);
+
+    const first = memoized(makeHass("tick-1"));
+    const second = memoized(makeHass("tick-2"));
+
+    expect(inner).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+  });
+
+  it("passes a falsy or non-object hass straight through, uncached", () => {
+    const inner = vi.fn((_hass: HomeAssistant) => ({ locations: new Map() }));
+    const memoized = memoizeByHass(inner);
+
+    expect(() =>
+      memoized(null as unknown as HomeAssistant),
+    ).not.toThrow();
+    memoized(null as unknown as HomeAssistant);
+    memoized(undefined as unknown as HomeAssistant);
+    memoized("hass" as unknown as HomeAssistant);
+
+    expect(inner).toHaveBeenCalledTimes(4);
+  });
+
+  it("caches an empty result rather than recomputing it", () => {
+    // A discovery that legitimately finds nothing must not be re-run for every
+    // subsequent caller in the same tick; probing the WeakMap with `has` (not
+    // comparing the stored value against undefined) is what makes it stick.
+    const nullish = vi.fn((_hass: HomeAssistant) => null);
+    const memoizedNull = memoizeByHass(nullish);
+    const undef = vi.fn((_hass: HomeAssistant) => undefined);
+    const memoizedUndef = memoizeByHass(undef);
+    const hass = makeHass("a");
+
+    expect(memoizedNull(hass)).toBeNull();
+    expect(memoizedNull(hass)).toBeNull();
+    expect(nullish).toHaveBeenCalledTimes(1);
+
+    expect(memoizedUndef(hass)).toBeUndefined();
+    expect(memoizedUndef(hass)).toBeUndefined();
+    expect(undef).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores extra arguments in the cache key (first call wins)", () => {
+    const inner = vi.fn((_hass: HomeAssistant, debug = false) => ({ debug }));
+    const memoized = memoizeByHass(inner);
+    const hass = makeHass("a");
+
+    const quiet = memoized(hass, false);
+    const loud = memoized(hass, true);
+
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(inner).toHaveBeenCalledWith(hass, false);
+    expect(loud).toBe(quiet);
+    expect(loud.debug).toBe(false);
+  });
+
+  it("counts uncached calls under countTag once the counter exists", () => {
+    // The suite runs in the node environment, so there is no window unless a
+    // test installs one — which doubles as the production no-op check below.
+    const fakeWindow = { __ppDiscoveryScans: {} as Record<string, number> };
+    (globalThis as { window?: unknown }).window = fakeWindow;
+    try {
+      const memoized = memoizeByHass(() => ({}), "unit-tag");
+      const hass = makeHass("a");
+      memoized(hass);
+      memoized(hass);
+      memoized(makeHass("b"));
+
+      expect(fakeWindow.__ppDiscoveryScans["unit-tag"]).toBe(2);
+    } finally {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  });
+
+  it("is inert when the counter object has not been opted into", () => {
+    const fakeWindow: { __ppDiscoveryScans?: Record<string, number> } = {};
+    (globalThis as { window?: unknown }).window = fakeWindow;
+    try {
+      const memoized = memoizeByHass(() => ({}), "unit-tag");
+      memoized(makeHass("a"));
+      expect(fakeWindow.__ppDiscoveryScans).toBeUndefined();
+    } finally {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  });
+
+  it("does not touch the counter when no window exists", () => {
+    expect(typeof window).toBe("undefined");
+    const memoized = memoizeByHass(() => ({}), "unit-tag");
+    expect(() => memoized(makeHass("a"))).not.toThrow();
   });
 });

--- a/test/utils/adapter-helpers.test.ts
+++ b/test/utils/adapter-helpers.test.ts
@@ -1424,6 +1424,17 @@ describe("memoizeByHass", () => {
     }
   });
 
+  it("rejects a function whose extra argument selects what to discover", () => {
+    // Compile-time guard, not a runtime assertion: discoverGplAllergens-style
+    // signatures (hass, configEntryId, debug) must stay unwrappable, since the
+    // editor calls them with different config entries under one hass and the
+    // cache key ignores everything but hass. If this ever type-checks, tsc
+    // fails on the unused @ts-expect-error and the guard has been lost.
+    const byEntry = (_hass: HomeAssistant, _configEntryId: string) => ({});
+    // @ts-expect-error - second parameter is not the debug flag
+    memoizeByHass(byEntry);
+  });
+
   it("does not touch the counter when no window exists", () => {
     expect(typeof window).toBe("undefined");
     const memoized = memoizeByHass(() => ({}), "unit-tag");


### PR DESCRIPTION
Part 1 of 2 for #321 (discovery memoization umbrella). This PR adds the mechanism only; adoption by the 11 adapters follows in a separate PR.

## What

- `memoizeByHass(fn, countTag?)` in `src/utils/adapter-helpers.ts`: memoizes a discovery function on the identity of the `hass` object (WeakMap). HA hands the card a new `hass` object on every state update, so the cache lives exactly one update cycle: zero staleness risk, no invalidation logic. Falsy/non-object `hass` passes through uncached. Extra args (notably `debug`) are not part of the key; first call of a tick wins (documented in JSDoc).
- Shared-result contract documented in JSDoc: callers must never mutate a returned discovery result (all code paths within a tick share the same reference).
- Opt-in instrumentation `recordDiscoveryScan(tag, debug?)`: counts uncached registry sweeps in `window.__ppDiscoveryScans`. No-op unless the counter object exists (create it from the browser console) or `debug` is true. One call site in `discoverEntitiesByDevice`, keyed by platform logTag, so the tally is the before/after metric for #321.

## Notes

- `cache.has()` rather than an `undefined` check, so a legitimately empty discovery result is cached instead of recomputed every call (covered by a dedicated test).
- The engine counter measures sweeps, not code paths: until the adoption PR lands it will show the current ~10 sweeps per tick; after adoption, 1 per adapter per tick.

## Tests

7 new tests in `test/utils/adapter-helpers.test.ts`: same `hass` → one underlying call and same result reference; new `hass` → recompute; empty result cached; null `hass` passthrough; `debug` ignored in the key; counter semantics.

Full gate green: typecheck, lint, 1824/1824 tests, build, dist-size (228829 B of 231000 B budget).

Part of #321.
