### PR TITLE
(perf) Memoize adapter discovery per update cycle (#321)

### DIFF
--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -374,7 +374,7 @@ function detectLocationUncached(
  */
 const detectLocation = memoizeByHass(
   detectLocationUncached,
-  "ATMO-detectLocation",
+  "ATMO:detectLocation",
 );
 
 /**

--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -313,7 +313,10 @@ export function findAtmoLocationBySlug(
  * Detect location slug from available Atmo France entities.
  * Legacy fallback for slug-based configs without hass.entities.
  */
-function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
+function detectLocationUncached(
+  hass: HomeAssistant,
+  debug = false,
+): string | null {
   // Try pollen entities first (most reliable pattern)
   for (const id of Object.keys(hass.states)) {
     const m = id.match(
@@ -363,6 +366,16 @@ function detectLocation(hass: HomeAssistant, debug: boolean): string | null {
   }
   return null;
 }
+
+/**
+ * Memoized per HA update cycle (#321). This scan never reaches
+ * discoverEntitiesByDevice -- it walks hass.states itself, up to three times --
+ * so it carries its own counter tag rather than being tallied under "ATMO".
+ */
+const detectLocation = memoizeByHass(
+  detectLocationUncached,
+  "ATMO-detectLocation",
+);
 
 /**
  * Build entity ID for an allergen at a given location.

--- a/src/adapters/atmo.ts
+++ b/src/adapters/atmo.ts
@@ -28,6 +28,7 @@ import {
   isConfigEntryId,
   coerceBool,
   type DiscoveredLocation,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 
 // The subset of the discovery result atmo uses (config-entry keyed locations).
@@ -257,7 +258,7 @@ function resolveAtmoLabel(
  *   2. Entity-registry: hass.entities filtered by platform === "atmofrance"
  *   3. Regex fallback: hass.states scanned for known Atmo entity patterns
  */
-export function discoverAtmoSensors(
+function discoverAtmoSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): AtmoDiscovery {
@@ -282,6 +283,13 @@ export function discoverAtmoSensors(
 
   return { locations };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverAtmoSensors = memoizeByHass(discoverAtmoSensorsUncached);
 
 /**
  * Resolve a legacy slug-style location (e.g. "nice") to its config_entry_id

--- a/src/adapters/dwd.ts
+++ b/src/adapters/dwd.ts
@@ -14,6 +14,7 @@ import {
   resolveAllergenNames,
   discoverEntitiesByDevice,
   type DeviceDiscovery,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 import {
   createEntityResolver,
@@ -153,7 +154,7 @@ function extractRegionLabel(entityId: string): string | null {
  * In tier 3 the region ID (numeric suffix) is used as the location key so that
  * cfg.region_id = "50" matches entities like sensor.pollenflug_erle_50.
  */
-export function discoverDwdSensors(
+function discoverDwdSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): DeviceDiscovery {
@@ -245,6 +246,13 @@ export function discoverDwdSensors(
 
   return { locations, tierUsed };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverDwdSensors = memoizeByHass(discoverDwdSensorsUncached);
 
 /**
  * Path 3 template fallback. Rebuilt around DWD_ENTITY_ID_RE so it accepts the

--- a/src/adapters/gp/discovery.ts
+++ b/src/adapters/gp/discovery.ts
@@ -11,6 +11,7 @@ import {
   resolveLocationByKey,
   isConfigEntryId,
   type DiscoveredLocation,
+  memoizeByHass,
 } from "../../utils/adapter-helpers.js";
 import { cleanDeviceLabel } from "../../utils/device-label.js";
 import {
@@ -118,7 +119,7 @@ export function classifySensor(
  *
  * Returns: { locations: Map<configEntryId, { label, entities: Map<allergenKey, entityId> }> }
  */
-export function discoverGpSensors(
+function discoverGpSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): GpDiscovery {
@@ -192,6 +193,13 @@ export function discoverGpSensors(
 
   return { locations };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverGpSensors = memoizeByHass(discoverGpSensorsUncached);
 
 /**
  * Get available allergen keys for a given location.

--- a/src/adapters/gpl/discovery.ts
+++ b/src/adapters/gpl/discovery.ts
@@ -11,6 +11,7 @@ import {
   resolveLocationByKey,
   isConfigEntryId,
   type DiscoveredLocation,
+  memoizeByHass,
 } from "../../utils/adapter-helpers.js";
 import { cleanDeviceLabel } from "../../utils/device-label.js";
 
@@ -117,7 +118,7 @@ export function isGplDataSensor(state: HassEntity | undefined): boolean {
  * Tier 2: entity registry scan filtering by entry.platform === "pollenlevels".
  * Tier 3: attribution scan -- filters states by isGoogleAttribution().
  */
-export function discoverGplSensors(
+function discoverGplSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): GplDiscovery {
@@ -184,6 +185,13 @@ export function discoverGplSensors(
 
   return { locations };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverGplSensors = memoizeByHass(discoverGplSensorsUncached);
 
 /**
  * Get available allergen keys for a given location (config_entry_id).

--- a/src/adapters/irmkmi.ts
+++ b/src/adapters/irmkmi.ts
@@ -49,6 +49,7 @@ import {
   deviceLocationKey,
   type DiscoveryContext,
   type DiscoveredLocation,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 
 // The subset of the discovery result irmkmi uses (config-entry keyed locations).
@@ -180,7 +181,7 @@ function resolveIrmkmiLabel(ctx: DiscoveryContext): string {
  *   2. Entity registry: hass.entities filtered by platform === "irm_kmi".
  *   3. Regex fallback: hass.states scanned for the level-entity pattern.
  */
-export function discoverIrmkmiSensors(
+function discoverIrmkmiSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): IrmkmiDiscovery {
@@ -209,6 +210,13 @@ export function discoverIrmkmiSensors(
 
   return { locations };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverIrmkmiSensors = memoizeByHass(discoverIrmkmiSensorsUncached);
 
 /**
  * Map allergen keys from config to irm-kmi-ha entity IDs for the resolved

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -619,7 +619,7 @@ function deviceSlugCandidates(
  * scoping would treat their entities as somebody else's and keep them --
  * merging two locations after all (Codex round 3 on PR #315).
  */
-function kleenexDeviceIds(hass: HomeAssistant): Set<string> {
+function kleenexDeviceIdsUncached(hass: HomeAssistant): Set<string> {
   const out = new Set<string>();
   for (const [deviceId, device] of Object.entries(hass?.devices || {})) {
     if (deviceIdentifierSlug(device)) out.add(deviceId);
@@ -630,6 +630,17 @@ function kleenexDeviceIds(hass: HomeAssistant): Set<string> {
   }
   return out;
 }
+
+/**
+ * Memoized per HA update cycle (#321). Both callers below run it on the same
+ * hass, and it sweeps the device and entity registries without going through
+ * discoverEntitiesByDevice, hence its own counter tag. The returned Set is
+ * shared -- read it, never add to it.
+ */
+const kleenexDeviceIds = memoizeByHass(
+  kleenexDeviceIdsUncached,
+  "kleenex-devices",
+);
 
 /**
  * The Kleenex device a manual `entity_prefix` was minted from, if any.

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -639,7 +639,7 @@ function kleenexDeviceIdsUncached(hass: HomeAssistant): Set<string> {
  */
 const kleenexDeviceIds = memoizeByHass(
   kleenexDeviceIdsUncached,
-  "kleenex-devices",
+  "Kleenex:deviceIds",
 );
 
 /**

--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -15,6 +15,7 @@ import {
   type DeviceDiscovery,
   type DiscoveredLocation,
   type DiscoveryContext,
+  memoizeByHass,
 } from "../../utils/adapter-helpers.js";
 import {
   INDIVIDUAL_TO_CATEGORY,
@@ -337,7 +338,7 @@ function buildIdentifierKeys(hass: HomeAssistant): Map<string, string> {
  * onto a category key are already rejected by the classifier, so a category
  * sensor can never be displaced by a detail sensor.
  */
-export function discoverKleenex(
+function discoverKleenexUncached(
   hass: HomeAssistant,
   debug = false,
 ): DeviceDiscovery {
@@ -364,6 +365,13 @@ export function discoverKleenex(
     logTag: "Kleenex",
   });
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverKleenex = memoizeByHass(discoverKleenexUncached);
 
 /**
  * Extract the legacy location slug from an entity ID

--- a/src/adapters/msw.ts
+++ b/src/adapters/msw.ts
@@ -43,6 +43,7 @@ import {
   resolveLocationByKey,
   type DiscoveryContext,
   type DiscoveredLocation,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 
 // The subset of the discovery result msw uses (config-entry keyed locations).
@@ -164,7 +165,7 @@ function resolveMswLabel(ctx: DiscoveryContext): string {
  *   2. Entity registry: hass.entities filtered by platform === "swissweather".
  *   3. Regex fallback: hass.states scanned for the level-entity pattern.
  */
-export function discoverMswSensors(
+function discoverMswSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): MswDiscovery {
@@ -186,6 +187,13 @@ export function discoverMswSensors(
 
   return { locations };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverMswSensors = memoizeByHass(discoverMswSensorsUncached);
 
 /**
  * Map allergen keys from config to hass-swissweather entity IDs for the

--- a/src/adapters/peu.ts
+++ b/src/adapters/peu.ts
@@ -19,6 +19,7 @@ import {
   normalizeManualPrefix,
   resolveLocationByKey,
   type DeviceDiscovery,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 import {
   createEntityResolver,
@@ -203,7 +204,7 @@ function extractPeuLocationLabel(eid: string): string | null {
  * is stored under its own key so that mode-mapping in resolveEntityIds can
  * look it up directly.
  */
-export function discoverPeuSensors(
+function discoverPeuSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): DeviceDiscovery {
@@ -279,6 +280,13 @@ export function discoverPeuSensors(
 
   return { locations, tierUsed };
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverPeuSensors = memoizeByHass(discoverPeuSensorsUncached);
 
 function detectLocation(cfg: CardConfig, hass: HomeAssistant): string {
   if (cfg.location === "manual") return "";

--- a/src/adapters/plu.ts
+++ b/src/adapters/plu.ts
@@ -21,6 +21,7 @@ import {
   normalizeManualPrefix,
   resolveManualEntity,
   type DeviceDiscovery,
+  memoizeByHass,
 } from "../utils/adapter-helpers.js";
 import { PLU_LEVEL_INDICES } from "./base.js";
 
@@ -114,7 +115,7 @@ function classifyPluEntity(eid: string): string | null {
  * typical HA custom-integration naming convention. "pollenlu" is included as a
  * defensive alternative.
  */
-export function discoverPluSensors(
+function discoverPluSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): DeviceDiscovery {
@@ -133,6 +134,13 @@ export function discoverPluSensors(
     logTag: "PLU",
   });
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverPluSensors = memoizeByHass(discoverPluSensorsUncached);
 
 // Default thresholds per allergen (fallback when sensor attributes are missing)
 const DEFAULT_THRESHOLDS: Record<string, { moderate: number; high: number }> = {

--- a/src/adapters/pp.ts
+++ b/src/adapters/pp.ts
@@ -15,6 +15,7 @@ import {
   clampLevel,
   resolveAllergenNames,
   discoverEntitiesByDevice,
+  memoizeByHass,
   isConfigEntryId,
   parseLocalDate,
   type DeviceDiscovery,
@@ -145,7 +146,7 @@ function extractAllergenKeyFromEntityId(entityId: string): string | null {
  * (regex fallback) will still provide discovery. Pass an array like
  * ["pollenprognos", "other_name"] to support multiple platform names.
  */
-export function discoverPpSensors(
+function discoverPpSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): DeviceDiscovery {
@@ -214,6 +215,13 @@ export function discoverPpSensors(
 
   return { locations, tierUsed };
 }
+
+/**
+ * Memoized per HA update cycle (#321): the card, the badge, the editor and the
+ * fetch path all reach discovery within one tick and now share one sweep. The
+ * returned object is shared -- callers must not mutate it.
+ */
+export const discoverPpSensors = memoizeByHass(discoverPpSensorsUncached);
 
 function detectCity(cfg: CardConfig, hass: HomeAssistant): string {
   if (cfg.city === "manual") return "";

--- a/src/pollenprognos-editor.ts
+++ b/src/pollenprognos-editor.ts
@@ -430,7 +430,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         // PP: use discovery helper, fall back to PP_POSSIBLE_CITIES filter.
         // Sort by label alphabetically so the dropdown order is stable across
         // HA restarts (Map iteration order tracks hass-registry insertion).
-        const ppDiscovery = discoverPpSensors(this._hass, false);
+        const ppDiscovery = discoverPpSensors(this._hass, this.debug);
         if (ppDiscovery.locations.size > 0) {
           this.installedPpLocations = Array.from(ppDiscovery.locations.entries())
             .map(([key, loc]) => [key, loc.label] as InstalledLocation)
@@ -464,7 +464,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         // DWD: use discovery helper, fall back to regex-based region IDs.
         // Sort numerically for region-ID keys (legacy tier 3) and by label
         // for config_entry_id keys (tier 1/2), so the dropdown is stable.
-        const dwdDiscovery = discoverDwdSensors(this._hass, false);
+        const dwdDiscovery = discoverDwdSensors(this._hass, this.debug);
         if (dwdDiscovery.locations.size > 0) {
           const entries = Array.from(dwdDiscovery.locations.entries())
             .map(([key, loc]) => [key, loc.label] as InstalledLocation);
@@ -506,7 +506,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
         // always reassigns (fallback or empty) on the next hass tick, so a
         // stale list cannot outlive one update cycle.
         if (integration === "silam") {
-          const silamDiscovery = discoverSilamSensors(this._hass, false);
+          const silamDiscovery = discoverSilamSensors(this._hass, this.debug);
           if (silamDiscovery.locations.size > 0) {
             this.installedSilamLocations = discoveryToLocations(silamDiscovery);
           }
@@ -573,7 +573,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       // GPL discovery: run here too because set hass() may fire before setConfig()
       // and auto-detect the wrong integration (e.g., SILAM) if multiple integrations are installed.
       if (this._config.integration === "gpl" && this._hass) {
-        const gplDiscovery = discoverGplSensors(this._hass, false);
+        const gplDiscovery = discoverGplSensors(this._hass, this.debug);
         this.installedGplLocations = discoveryToLocations(gplDiscovery);
         const gplConfigEntryId = this._config.location || (this.installedGplLocations.length ? this.installedGplLocations[0]![0] : null);
         const allGplAllergens = discoverGplAllergens(this._hass, gplConfigEntryId as string, false);
@@ -581,7 +581,7 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
       // GP discovery
       if (this._config.integration === "gp" && this._hass) {
-        const gpDiscovery = discoverGpSensors(this._hass, false);
+        const gpDiscovery = discoverGpSensors(this._hass, this.debug);
         this.installedGpLocations = discoveryToLocations(gpDiscovery);
         const gpConfigEntryId = this._config.location || (this.installedGpLocations.length ? this.installedGpLocations[0]![0] : null);
         const allGpAllergens = discoverGpAllergens(this._hass, gpConfigEntryId as string, false);
@@ -589,13 +589,13 @@ class PollenPrognosCardEditor extends PollenEditorBase {
       }
       // MSW discovery (same rationale as GPL/GP).
       if (this._config.integration === "msw" && this._hass) {
-        const md = discoverMswSensors(this._hass, false);
+        const md = discoverMswSensors(this._hass, this.debug);
         this.installedMswLocations = discoveryToLocations(md);
       }
 
       // IRM KMI discovery (same rationale as GPL/GP/MSW).
       if (this._config.integration === "irmkmi" && this._hass) {
-        const id = discoverIrmkmiSensors(this._hass, false);
+        const id = discoverIrmkmiSensors(this._hass, this.debug);
         this.installedIrmkmiLocations = discoveryToLocations(id);
       }
 

--- a/src/utils/adapter-helpers.ts
+++ b/src/utils/adapter-helpers.ts
@@ -819,8 +819,9 @@ export function recordDiscoveryScan(tag: string, debug = false): void {
  *
  * @param fn - Discovery function taking `hass` and an optional `debug` flag.
  * @param countTag - Optional instrumentation tag; when given, every uncached
- *   call is counted via {@link recordDiscoveryScan} (only once the counter
- *   object exists). Leave unset for functions that already count their own
+ *   call is counted via {@link recordDiscoveryScan}, with `debug` forwarded so
+ *   a debug-enabled call installs the counter object exactly as the engine's
+ *   own tally does. Leave unset for functions that already count their own
  *   sweep inside `discoverEntitiesByDevice`, otherwise the same sweep is
  *   counted twice under two keys. It exists for the sweeps that never reach
  *   the engine and so count nothing on their own: Kleenex's `kleenexDeviceIds`
@@ -836,7 +837,7 @@ export function memoizeByHass<R>(
     if (!hass || typeof hass !== "object") return fn(hass, debug);
     if (cache.has(hass)) return cache.get(hass) as R;
     const result = fn(hass, debug);
-    if (countTag) recordDiscoveryScan(countTag);
+    if (countTag) recordDiscoveryScan(countTag, debug);
     cache.set(hass, result);
     return result;
   };

--- a/src/utils/silam.ts
+++ b/src/utils/silam.ts
@@ -3,6 +3,7 @@ import {
   discoverEntitiesByDevice,
   isConfigEntryId,
   deviceLocationKey,
+  memoizeByHass,
 } from "./adapter-helpers.js";
 import type { DiscoveryContext } from "./adapter-helpers.js";
 import type { HomeAssistant } from "../types/home-assistant.js";
@@ -85,7 +86,7 @@ function stripSilamPrefix(
   return stripped || name;
 }
 
-export function discoverSilamSensors(
+function discoverSilamSensorsUncached(
   hass: HomeAssistant,
   debug = false,
 ): SilamDiscovery {
@@ -191,6 +192,13 @@ export function discoverSilamSensors(
 
   return result;
 }
+
+/**
+ * Memoized per HA update cycle (#321): every code path that reaches
+ * discovery within one tick shares a single sweep. The returned object is
+ * shared -- callers must not mutate it.
+ */
+export const discoverSilamSensors = memoizeByHass(discoverSilamSensorsUncached);
 
 /**
  * Resolve a discovered location from pre-computed discovery data.

--- a/test/adapters/discovery-memoization.test.ts
+++ b/test/adapters/discovery-memoization.test.ts
@@ -1,0 +1,607 @@
+/**
+ * Per-update-cycle discovery memoization: the adoption contract (#321).
+ *
+ * PR A added memoizeByHass (unit-tested in test/utils/adapter-helpers.test.ts);
+ * this file asserts that every adapter actually adopted it, and that adopting
+ * it did not change what discovery returns. The invariant is identical for all
+ * eleven adapters, so it is table-driven rather than scattered across the
+ * per-adapter test files: an adapter added without memoization cannot pass this
+ * table, and a reader sees the whole surface in one place.
+ *
+ * Two independent instruments, deliberately both:
+ *
+ *   1. vi.spyOn(helpers, "discoverEntitiesByDevice") counts the actual registry
+ *      sweeps the adapters make. It sees the engine, so it proves the cache hit
+ *      rather than merely trusting the wrapper.
+ *   2. window.__ppDiscoveryScans (recordDiscoveryScan) counts the two sweeps
+ *      that never reach the engine and therefore cannot be spied on: Kleenex's
+ *      kleenexDeviceIds ("Kleenex:deviceIds", #322) and Atmo's detectLocation
+ *      ("ATMO:detectLocation", #323). Both are module-private, so the counter
+ *      the instrumentation exists for is the only honest way to observe them.
+ *      The tests run under the node environment, so `window` is stubbed in.
+ *
+ * A hass object must never be shared between test cases here: memoization keys
+ * on object identity, so a reused fixture would hand a later case a cache hit
+ * from an earlier one and make a broken adapter look memoized. Every case
+ * builds its own hass; the "new tick" half clones with a spread, which is
+ * exactly what HA does semantically (same data, new object).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { HomeAssistant } from "../../src/types/home-assistant.js";
+import * as helpers from "../../src/utils/adapter-helpers.js";
+import {
+  createHass,
+  createHassWithRegistry,
+  createPPSensor,
+  GPL_ATTRIBUTION,
+} from "../helpers.js";
+
+import { discoverPpSensors } from "../../src/adapters/pp.js";
+import { discoverDwdSensors } from "../../src/adapters/dwd.js";
+import { discoverPeuSensors } from "../../src/adapters/peu.js";
+import { discoverPluSensors } from "../../src/adapters/plu.js";
+import { discoverMswSensors } from "../../src/adapters/msw.js";
+import { discoverIrmkmiSensors } from "../../src/adapters/irmkmi.js";
+import { discoverAtmoSensors } from "../../src/adapters/atmo.js";
+import { discoverGpSensors } from "../../src/adapters/gp/index.js";
+import { discoverGplSensors } from "../../src/adapters/gpl/index.js";
+import { discoverKleenex } from "../../src/adapters/kleenex/index.js";
+import { discoverSilamSensors } from "../../src/utils/silam.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures: one registry-backed install per adapter
+// ---------------------------------------------------------------------------
+// Entity-ID and attribute shapes mirror each adapter's own test file, the same
+// way test/golden-fixtures.ts does. Each fixture is wired through the entity
+// registry so discovery reaches the engine on tier 1/2 rather than the
+// tier-3 fallback (which PLU and SILAM disable entirely).
+
+function ppHass(): HomeAssistant {
+  // Forecast attributes included so the cross-cycle test below can run a real
+  // fetchForecast rather than one that bails out early.
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.pollen_stockholm_bjork",
+      state: "3",
+      attributes: createPPSensor([3, 2, 1]).attributes,
+      deviceId: "dev_pp",
+      platform: "pollenprognos",
+      deviceMeta: {
+        name: "Pollenprognos Stockholm",
+        configEntries: ["cfg_pp"],
+      },
+    },
+    {
+      entityId: "sensor.pollen_stockholm_gras",
+      state: "1",
+      attributes: createPPSensor([1, 0, 0]).attributes,
+      deviceId: "dev_pp",
+      platform: "pollenprognos",
+    },
+  ]);
+}
+
+function dwdHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.pollenflug_birke_50",
+      state: "2",
+      deviceId: "dev_dwd",
+      platform: "dwd_pollenflug",
+      deviceMeta: {
+        name: "Pollenflug Gefahrenindex",
+        configEntries: ["cfg_dwd"],
+      },
+    },
+    {
+      entityId: "sensor.pollenflug_erle_50",
+      state: "1",
+      deviceId: "dev_dwd",
+      platform: "dwd_pollenflug",
+    },
+  ]);
+}
+
+function peuHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.polleninformation_vienna_birch",
+      state: "2",
+      deviceId: "dev_peu",
+      platform: "polleninformation",
+      deviceMeta: {
+        name: "Polleninformation (Vienna)",
+        configEntries: ["cfg_peu"],
+      },
+    },
+    {
+      entityId: "sensor.polleninformation_vienna_grass",
+      state: "1",
+      deviceId: "dev_peu",
+      platform: "polleninformation",
+    },
+  ]);
+}
+
+function pluHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.pollen_birch",
+      state: "2",
+      deviceId: "dev_plu",
+      platform: "pollen_lu",
+      deviceMeta: { name: "Pollen.lu", configEntries: ["cfg_plu"] },
+    },
+    {
+      entityId: "sensor.pollen_grasses",
+      state: "1",
+      deviceId: "dev_plu",
+      platform: "pollen_lu",
+    },
+  ]);
+}
+
+function mswHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.pollen_birch_level_at_8000_za",
+      state: "strong",
+      deviceId: "dev_msw",
+      platform: "swissweather",
+      deviceMeta: { name: "MeteoSwiss at 8000-ZA", configEntries: ["cfg_msw"] },
+    },
+    {
+      entityId: "sensor.pollen_grasses_level_at_8000_za",
+      state: "weak",
+      deviceId: "dev_msw",
+      platform: "swissweather",
+    },
+  ]);
+}
+
+function irmkmiHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.home_birch_level",
+      state: "green",
+      deviceId: "dev_irm",
+      platform: "irm_kmi",
+      deviceMeta: { name: "IRM KMI Home", configEntries: ["cfg_irm"] },
+    },
+    {
+      entityId: "sensor.home_grasses_level",
+      state: "yellow",
+      deviceId: "dev_irm",
+      platform: "irm_kmi",
+    },
+  ]);
+}
+
+function atmoHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.niveau_bouleau_paris",
+      state: "2",
+      attributes: { Libellé: "" },
+      deviceId: "dev_atmo",
+      platform: "atmofrance",
+      deviceMeta: { name: "Atmo France Paris", configEntries: ["cfg_atmo"] },
+    },
+    {
+      entityId: "sensor.niveau_graminees_paris",
+      state: "1",
+      attributes: { Libellé: "" },
+      deviceId: "dev_atmo",
+      platform: "atmofrance",
+    },
+  ]);
+}
+
+function gpHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.google_pollen_birch",
+      state: "Moderate",
+      attributes: {
+        display_name: "Birch",
+        index_value: 2,
+        category: "Moderate",
+        device_class: "enum",
+      },
+      deviceId: "dev_gp",
+      platform: "google_pollen",
+      deviceMeta: { name: "Google Pollen Home", configEntries: ["cfg_gp"] },
+    },
+    {
+      entityId: "sensor.google_pollen_grass",
+      state: "Low",
+      attributes: {
+        display_name: "Grass",
+        index_value: 1,
+        category: "Low",
+        device_class: "enum",
+      },
+      deviceId: "dev_gp",
+      platform: "google_pollen",
+    },
+  ]);
+}
+
+function gplHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.pollen_birch_home",
+      state: "2",
+      attributes: { code: "BIRCH", attribution: GPL_ATTRIBUTION, forecast: [] },
+      deviceId: "dev_gpl",
+      platform: "pollenlevels",
+      deviceMeta: { name: "Pollen Levels Home", configEntries: ["cfg_gpl"] },
+    },
+    {
+      entityId: "sensor.pollen_grass_home",
+      state: "1",
+      attributes: {
+        code: "GRAMINALES",
+        attribution: GPL_ATTRIBUTION,
+        forecast: [],
+      },
+      deviceId: "dev_gpl",
+      platform: "pollenlevels",
+    },
+  ]);
+}
+
+function kleenexHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+      state: "12",
+      attributes: { details: [], forecast: [] },
+      deviceId: "dev_kleenex",
+      platform: "kleenex_pollenradar",
+      deviceMeta: {
+        name: "Kleenex Pollen Radar (Utrecht)",
+        identifiers: [["kleenex_pollenradar", "utrecht"]],
+        configEntries: ["cfg_kleenex"],
+      },
+    },
+    {
+      entityId: "sensor.kleenex_pollen_radar_utrecht_trees",
+      state: "8",
+      attributes: { details: [], forecast: [] },
+      deviceId: "dev_kleenex",
+      platform: "kleenex_pollenradar",
+    },
+  ]);
+}
+
+/**
+ * Two Kleenex locations whose entity IDs share a prefix: the shape manual-mode
+ * scoping exists for (issue #309 follow-up), and the only one that reaches
+ * kleenexDeviceIds.
+ */
+function kleenexTwoLocationHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.kleenex_pollen_grass",
+      state: "12",
+      attributes: { details: [], forecast: [] },
+      deviceId: "dev_home",
+      platform: "kleenex_pollenradar",
+      deviceMeta: {
+        name: "Kleenex pollen",
+        identifiers: [["kleenex_pollenradar", "home"]],
+        configEntries: ["cfg_home"],
+      },
+    },
+    {
+      entityId: "sensor.kleenex_pollen_radar_utrecht_grass",
+      state: "8",
+      attributes: { details: [], forecast: [] },
+      deviceId: "dev_utrecht",
+      platform: "kleenex_pollenradar",
+      deviceMeta: {
+        name: "Kleenex Pollen Radar (Utrecht)",
+        identifiers: [["kleenex_pollenradar", "utrecht"]],
+        configEntries: ["cfg_utrecht"],
+      },
+    },
+  ]);
+}
+
+/**
+ * An Atmo install whose only entities are forecast-day ones. Discovery skips
+ * them (isRelevant excludes `_j_N`), so resolution falls through to the legacy
+ * slug path -- the one detectLocation scans hass.states for.
+ */
+function atmoForecastOnlyHass(): HomeAssistant {
+  return createHass({
+    "sensor.niveau_bouleau_paris_j_1": {
+      entity_id: "sensor.niveau_bouleau_paris_j_1",
+      state: "2",
+      attributes: { Libellé: "" },
+    },
+    "sensor.niveau_graminees_paris_j_1": {
+      entity_id: "sensor.niveau_graminees_paris_j_1",
+      state: "1",
+      attributes: { Libellé: "" },
+    },
+  });
+}
+
+function silamHass(): HomeAssistant {
+  return createHassWithRegistry([
+    {
+      entityId: "sensor.silam_pollen_stockholm_birch",
+      state: "30",
+      deviceId: "dev_silam",
+      platform: "silam_pollen",
+      translationKey: "birch",
+      deviceMeta: { name: "SILAM Stockholm", configEntries: ["cfg_silam"] },
+    },
+    {
+      entityId: "sensor.silam_pollen_stockholm_grass",
+      state: "12",
+      deviceId: "dev_silam",
+      platform: "silam_pollen",
+      translationKey: "grass",
+    },
+  ]);
+}
+
+/** Location count for both discovery shapes (SILAM converts the engine map). */
+function locationCount(discovery: unknown): number {
+  const locations = (discovery as { locations?: Map<string, unknown> })
+    ?.locations;
+  return locations ? locations.size : 0;
+}
+
+interface MemoCase {
+  /** Adapter id, used as the test name. */
+  id: string;
+  /** The memoized discovery entry point the card and editor call. */
+  discover: (hass: HomeAssistant, debug?: boolean) => unknown;
+  /** Registry-backed install for this adapter. */
+  makeHass: () => HomeAssistant;
+}
+
+const CASES: MemoCase[] = [
+  { id: "pp", discover: discoverPpSensors, makeHass: ppHass },
+  { id: "dwd", discover: discoverDwdSensors, makeHass: dwdHass },
+  { id: "peu", discover: discoverPeuSensors, makeHass: peuHass },
+  { id: "plu", discover: discoverPluSensors, makeHass: pluHass },
+  { id: "msw", discover: discoverMswSensors, makeHass: mswHass },
+  { id: "irmkmi", discover: discoverIrmkmiSensors, makeHass: irmkmiHass },
+  { id: "atmo", discover: discoverAtmoSensors, makeHass: atmoHass },
+  { id: "gp", discover: discoverGpSensors, makeHass: gpHass },
+  { id: "gpl", discover: discoverGplSensors, makeHass: gplHass },
+  { id: "kleenex", discover: discoverKleenex, makeHass: kleenexHass },
+  { id: "silam", discover: discoverSilamSensors, makeHass: silamHass },
+];
+
+describe("discovery memoization: per-adapter call counts (#321)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Guards the fixtures themselves: a hass that discovers nothing would still
+  // satisfy the call-count assertions (memoizeByHass caches empty results too),
+  // so the table would keep passing while proving nothing about real installs.
+  it.each(CASES)(
+    "$id: the fixture discovers a real location",
+    ({ discover, makeHass }) => {
+      expect(locationCount(discover(makeHass()))).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(CASES)(
+    "$id: sweeps the registry once per hass and returns the same reference",
+    ({ discover, makeHass }) => {
+      const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+      const hass = makeHass();
+
+      const first = discover(hass);
+      const second = discover(hass);
+      const third = discover(hass);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    },
+  );
+
+  it.each(CASES)(
+    "$id: sweeps again when Home Assistant swaps the hass object",
+    ({ discover, makeHass }) => {
+      const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+      const tick1 = makeHass();
+      // Same states/registries, new identity: what HA hands the card on every
+      // state update.
+      const tick2 = { ...tick1 } as HomeAssistant;
+
+      const first = discover(tick1);
+      const second = discover(tick2);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(second).not.toBe(first);
+      expect(locationCount(second)).toBe(locationCount(first));
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The two sweeps that never reach the engine
+// ---------------------------------------------------------------------------
+// kleenexDeviceIds (#322) and Atmo's detectLocation (#323) walk the registries
+// themselves and are module-private, so neither the engine spy nor a direct
+// import can see them. They carry their own recordDiscoveryScan tags precisely
+// so they can be counted; these tests read those counters.
+
+describe("discovery memoization: sweeps counted by tag (#322, #323)", () => {
+  let counters: Record<string, number>;
+
+  beforeEach(() => {
+    counters = {};
+    // recordDiscoveryScan is a no-op without a window; the suite runs under the
+    // node environment, so stand one up for the duration of the test.
+    vi.stubGlobal("window", { __ppDiscoveryScans: counters });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Manual mode is what reaches the device sweep: scopeManualEntities narrows a
+  // straddling prefix, and it asks kleenexDeviceIds who owns the prefix.
+  const kleenexManualConfig = {
+    integration: "kleenex",
+    location: "manual",
+    entity_prefix: "kleenex_pollen_",
+    allergens: ["grass"],
+    days_to_show: 2,
+    pollen_threshold: 0,
+  } as never;
+
+  it("Kleenex:deviceIds: the device sweep runs once per hass", async () => {
+    const { fetchForecast } =
+      await import("../../src/adapters/kleenex/index.js");
+    const hass = kleenexTwoLocationHass();
+
+    await fetchForecast(hass, kleenexManualConfig);
+    await fetchForecast(hass, kleenexManualConfig);
+    await fetchForecast(hass, kleenexManualConfig);
+
+    expect(counters["Kleenex:deviceIds"]).toBe(1);
+  });
+
+  it("Kleenex:deviceIds: the device sweep runs again on a new hass", async () => {
+    const { fetchForecast } =
+      await import("../../src/adapters/kleenex/index.js");
+    const tick1 = kleenexTwoLocationHass();
+    const tick2 = { ...tick1 } as HomeAssistant;
+
+    await fetchForecast(tick1, kleenexManualConfig);
+    await fetchForecast(tick2, kleenexManualConfig);
+
+    expect(counters["Kleenex:deviceIds"]).toBe(2);
+  });
+
+  const atmoLegacyConfig = {
+    integration: "atmo",
+    location: "",
+    allergens: ["birch", "grass"],
+  } as never;
+
+  it("ATMO:detectLocation: the state scan runs once per hass", async () => {
+    const { resolveEntityIds } = await import("../../src/adapters/atmo.js");
+    const hass = atmoForecastOnlyHass();
+
+    resolveEntityIds(atmoLegacyConfig, hass);
+    resolveEntityIds(atmoLegacyConfig, hass);
+    resolveEntityIds(atmoLegacyConfig, hass);
+
+    expect(counters["ATMO:detectLocation"]).toBe(1);
+  });
+
+  it("ATMO:detectLocation: the state scan runs again on a new hass", async () => {
+    const { resolveEntityIds } = await import("../../src/adapters/atmo.js");
+    const tick1 = atmoForecastOnlyHass();
+    const tick2 = { ...tick1 } as HomeAssistant;
+
+    resolveEntityIds(atmoLegacyConfig, tick1);
+    resolveEntityIds(atmoLegacyConfig, tick2);
+
+    expect(counters["ATMO:detectLocation"]).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cycle: detection and the fetch path share one sweep
+// ---------------------------------------------------------------------------
+// This is the payoff #321 is actually after. Within one HA tick the card and
+// the badge each run their own detection pass and the card then fetches; every
+// one of those swept the registries separately before memoization. Two
+// detections are what makes the test bite: detectIntegrationStates already
+// memoizes within a single DetectionResult, so a single pass would pass even
+// unmemoized. The contract is one sweep per platform per tick, no matter how
+// many consumers ask.
+
+/** Sweeps the engine performed under a given logTag. */
+function sweepsFor(
+  spy: { mock: { calls: unknown[][] } },
+  logTag: string,
+): number {
+  return spy.mock.calls.filter(
+    (call) => (call[1] as { logTag?: string })?.logTag === logTag,
+  ).length;
+}
+
+describe("discovery memoization: detection and fetch share one sweep (#321)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pp: two detections plus fetchForecast sweep once", async () => {
+    const { detectIntegrationStates } =
+      await import("../../src/utils/autodetect.js");
+    const { fetchForecast } = await import("../../src/adapters/pp.js");
+    const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+    const hass = ppHass();
+
+    // PP discovery sits behind a lazy getter in the detection result; the card
+    // and badge both reach it when resolving the location label.
+    detectIntegrationStates(hass).getPpDiscovery();
+    detectIntegrationStates(hass).getPpDiscovery();
+
+    await fetchForecast(hass, {
+      integration: "pp",
+      city: "Stockholm",
+      allergens: ["Björk", "Gräs"],
+      days_to_show: 3,
+      pollen_threshold: 0,
+    } as never);
+
+    expect(sweepsFor(spy, "PP")).toBe(1);
+  });
+
+  it("kleenex: two detections plus fetchForecast sweep once", async () => {
+    const { detectIntegrationStates } =
+      await import("../../src/utils/autodetect.js");
+    const { fetchForecast } =
+      await import("../../src/adapters/kleenex/index.js");
+    const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+    const hass = kleenexHass();
+
+    // Kleenex discovery runs eagerly during detection.
+    detectIntegrationStates(hass);
+    detectIntegrationStates(hass);
+
+    await fetchForecast(hass, {
+      integration: "kleenex",
+      location: "utrecht",
+      allergens: ["grass", "trees"],
+      days_to_show: 3,
+      pollen_threshold: 0,
+    } as never);
+
+    expect(sweepsFor(spy, "Kleenex")).toBe(1);
+  });
+
+  it("every eager detection platform sweeps once across two detections", async () => {
+    const { detectIntegrationStates } =
+      await import("../../src/utils/autodetect.js");
+    const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+    const hass = kleenexHass();
+
+    detectIntegrationStates(hass);
+    detectIntegrationStates(hass);
+
+    // SILAM, Kleenex, ATMO and GP run their discovery eagerly on every
+    // detection pass, so they are the ones a second consumer used to double.
+    for (const tag of ["SILAM", "Kleenex", "ATMO", "GP"]) {
+      expect(sweepsFor(spy, tag), `${tag} sweeps`).toBe(1);
+    }
+  });
+});

--- a/test/utils/adapter-helpers.test.ts
+++ b/test/utils/adapter-helpers.test.ts
@@ -1424,6 +1424,23 @@ describe("memoizeByHass", () => {
     }
   });
 
+  it("installs the counter itself when called with debug", () => {
+    // debug is forwarded to the counter, so a debug-enabled run bootstraps the
+    // tally exactly like the engine's own does. Without this, the sweeps that
+    // never reach the engine (kleenexDeviceIds, atmo detectLocation) could only
+    // ever be measured by someone who had created the global by hand first.
+    const fakeWindow: { __ppDiscoveryScans?: Record<string, number> } = {};
+    (globalThis as { window?: unknown }).window = fakeWindow;
+    try {
+      const memoized = memoizeByHass(() => ({}), "unit-tag");
+      memoized(makeHass("a"), true);
+      memoized(makeHass("b"), true);
+      expect(fakeWindow.__ppDiscoveryScans).toEqual({ "unit-tag": 2 });
+    } finally {
+      delete (globalThis as { window?: unknown }).window;
+    }
+  });
+
   it("rejects a function whose extra argument selects what to discover", () => {
     // Compile-time guard, not a runtime assertion: discoverGplAllergens-style
     // signatures (hass, configEntryId, debug) must stay unwrappable, since the


### PR DESCRIPTION
Part 2 of 2 for #321: every adapter's entity discovery now runs at most once per HA state update, shared across all code paths (detection, resolveEntityIds, fetchForecast, card, badge, editors). Mechanism landed in #340.

## What

- All 11 discovery wrappers adopt `memoizeByHass` with the module-level singleton pattern: the inner function becomes `discoverXxxSensorsUncached`, the export stays name- and signature-compatible (`export const discoverXxxSensors = memoizeByHass(discoverXxxSensorsUncached)`). Zero call-site changes.
- Extras that sweep outside the shared engine get their own counter tags: the Kleenex device-registry sweep (`Kleenex:deviceIds`, #322) and Atmo's legacy location scan (`ATMO:detectLocation`, #323).
- The editor now threads its real `debug` flag into its seven discovery calls instead of hardcoding `false`, so a debug-enabled editor session logs discovery again.
- New test suite `test/adapters/discovery-memoization.test.ts` (40 tests): per adapter, three calls on the same `hass` hit the engine exactly once and return the same reference, a cloned `hass` recomputes; cross-cycle tests prove two detection passes plus `fetchForecast` on one `hass` cost one sweep per platform (two passes, because `detectIntegrationStates`' existing lazy getters would mask the memoization with a single one).

## Deliberately NOT wrapped

- `discoverGpAllergens` / `discoverGplAllergens`: their second argument is a `configEntryId` with semantic meaning; memoizing on `hass` alone would return the first entry's allergen list for every entry. The narrowed `memoizeByHass` signature from #340 rejects them at compile time (it flagged Atmo's mandatory `debug` parameter for real during adoption).
- `precomputedDiscovery` threading and `makeLazyDiscovery` stay: both are now harmless double layers on top of a cache hit; retiring them is a separate decision.

## Verified invariants

- Goldens byte-identical (29/29, no snapshot touched).
- Mutation sweep clean: `.locations.set(` / `.entities.set(` / `.delete(` / `.clear(` on discovery results occur only inside the engine and `discoverSilamSensorsUncached` building their own fresh result. No consumer mutates a shared result; card/badge/editor all derive new arrays (verified file-by-file).
- The DWD duplicate-region label disambiguation happens inside the uncached function before the cache ever sees the result.

## Known limitations (accepted)

- `debug` is not part of the cache key (first call of a tick wins), so discovery debug logging is best-effort in both directions when the editor and card share a `hass` object. Data is unaffected; `debug` only gates logging.
- The memoization rests on HA replacing the `hass` object on every state/registry update; an in-place mutation of `hass.devices`/`hass.entities` would go stale for one tick. The HA frontend builds a new `hass` object on registry updates.

## Empirical before/after (hass-test)

Measured with the opt-in counter from #340 (`window.__ppDiscoveryScans`), Playwright-driven against the hass-test instance, REST-driven state updates as the clock. On the branch build every platform tag increments exactly once per update cycle across all runs, which doubles as the correctness check.

| View | dev `d47d26c` | branch | factor |
|---|---|---|---|
| 17 cards + 9 badges | 125 sweeps/cycle | 10 (1 per platform) | 12.5× |
| same view, card editor open | 23/cycle (Kleenex alone 7.4) | 10 | 2.3× |
| manual mode, 9 cards | 45/cycle (undercount: the Kleenex device sweep had no tag pre-PR) | 9 incl. `Kleenex:deviceIds` | 5× |

Worst single platform: SILAM/Kleenex/GP each went 21 → 1 sweep per cycle on the big view.

Smoke on the branch build, all pass: a device rename via the WS device registry rendered live and triggered fresh discovery (no stale lock-in); a location change persisted through `lovelace/config/save` re-rendered with the new location's data; hard refresh rendered 17 cards and 9 badges with zero errors. `ATMO:detectLocation` never fired because its code path (empty location AND empty discovery) is not reachable on these dashboards — expected.

## Issues

Part of #321.
Adoption tickets (closed manually after merge; PRs into dev do not auto-close):
#322 (kleenex), #323 (atmo), #324 (gp), #325 (silam), #328 (pp), #329 (gpl), #330 (dwd), #331 (peu), #332 (plu), #333 (msw), #334 (irmkmi).
