### PR TITLE
(kleenex) Thread debug through the device-sweep counter

### DIFF
--- a/src/adapters/kleenex/discovery.ts
+++ b/src/adapters/kleenex/discovery.ts
@@ -656,10 +656,11 @@ const kleenexDeviceIds = memoizeByHass(
 function findPrefixOwnerDevice(
   hass: HomeAssistant,
   needle: string,
+  debug = false,
 ): string | null {
   if (!needle) return null;
   let found: string | null = null;
-  for (const deviceId of kleenexDeviceIds(hass)) {
+  for (const deviceId of kleenexDeviceIds(hass, debug)) {
     const device = hass?.devices?.[deviceId];
     if (!device) continue;
     if (!deviceSlugCandidates(device).has(needle)) continue;
@@ -761,9 +762,9 @@ export function scopeManualEntities(
   // another Kleenex device is dropped; entities with no registry entry, and
   // entities on devices from other integrations, are none of our business and
   // stay.
-  const ownerDeviceId = findPrefixOwnerDevice(hass, needle);
+  const ownerDeviceId = findPrefixOwnerDevice(hass, needle, debug);
   if (ownerDeviceId) {
-    const kleenexDevices = kleenexDeviceIds(hass);
+    const kleenexDevices = kleenexDeviceIds(hass, debug);
     const kept = entityIds.filter((eid) => {
       const deviceId = hass?.entities?.[eid]?.device_id;
       if (!deviceId || deviceId === ownerDeviceId) return true;

--- a/test/adapters/discovery-memoization.test.ts
+++ b/test/adapters/discovery-memoization.test.ts
@@ -605,3 +605,54 @@ describe("discovery memoization: detection and fetch share one sweep (#321)", ()
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// The extra counters must not depend on someone else going first
+// ---------------------------------------------------------------------------
+
+describe("discovery memoization: Kleenex:deviceIds installs its own counter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // The tests above hand recordDiscoveryScan a counter object that already
+  // exists, which hides whether the tag can bootstrap one. In a real debug
+  // session nothing pre-creates it: the first sweep of the tick has to, from
+  // its own debug flag. The device sweep therefore has to receive that flag
+  // through findPrefixOwnerDevice, or it only ever counts when the engine's
+  // eager "Kleenex" sweep happens to run first and install the object for it.
+  it("counts under debug with no engine sweep beforehand", async () => {
+    const { scopeManualEntities } =
+      await import("../../src/adapters/kleenex/discovery.js");
+    const fakeWindow: { __ppDiscoveryScans?: Record<string, number> } = {};
+    vi.stubGlobal("window", fakeWindow);
+    const spy = vi.spyOn(helpers, "discoverEntitiesByDevice");
+    const hass = kleenexTwoLocationHass();
+
+    const scope = scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+      debug: true,
+    });
+
+    // Narrowing happened on the registry alone, so the engine never ran and
+    // could not have created the counter object.
+    expect(scope.label).toBe("Kleenex pollen");
+    expect(spy).not.toHaveBeenCalled();
+    expect(fakeWindow.__ppDiscoveryScans).toEqual({ "Kleenex:deviceIds": 1 });
+  });
+
+  it("stays silent without debug when nothing opted in", async () => {
+    const { scopeManualEntities } =
+      await import("../../src/adapters/kleenex/discovery.js");
+    const fakeWindow: { __ppDiscoveryScans?: Record<string, number> } = {};
+    vi.stubGlobal("window", fakeWindow);
+    const hass = kleenexTwoLocationHass();
+
+    scopeManualEntities(hass, Object.keys(hass.states), {
+      prefix: "kleenex_pollen_",
+    });
+
+    expect(fakeWindow.__ppDiscoveryScans).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #341. The `Kleenex:deviceIds` instrumentation tag only counted because the engine's own Kleenex tally happened to install the counter object first (autodetect runs eagerly before the manual fetch) — it worked by call order, not by design. `kleenexDeviceIds` was invoked without a `debug` argument at both call sites, so its counter could never self-install the way `ATMO:detectLocation` already does.

## What

- `findPrefixOwnerDevice` gains a `debug` parameter and both `kleenexDeviceIds` call sites forward the flag (three lines; no call sites outside the module affected).
- Two new tests in `test/adapters/discovery-memoization.test.ts` lock the order independence in the gate: the tag counts under `debug: true` with the engine spy asserted to zero calls (so no other path could have installed the counter), and the global stays untouched without debug (no always-on counter in production). The first test fails if the threading is removed.

Instrumentation only; entity selection and data are unaffected. Full gate green, goldens untouched.

Part of #322.
