### PR TITLE
(kleenex) Keep the category sensor when a detail sensor is unavailable

### DIFF
--- a/src/adapters/kleenex/forecast.ts
+++ b/src/adapters/kleenex/forecast.ts
@@ -704,6 +704,17 @@ export async function fetchForecast(
     // Skip allergens not requested in config.
     if (!configuredAllergens.includes(canonicalName)) continue;
 
+    // A DetailSensor reporting a non-numeric state (`unknown`, `unavailable`,
+    // …) is not usable as data -- treating it as 0 ppm would mask real outages
+    // and falsely suppress the NA warning -- and it is not usable as a link
+    // target either: the row's numbers then come from the working category
+    // sensor, so opening the dead entity shows the user nothing (issue #326).
+    // A blank state is counted out explicitly: Number("") is 0, which would
+    // otherwise pass as a real reading of zero ppm.
+    const rawState = String(sensor.state ?? "").trim();
+    const parsedState = Number(rawState);
+    const hasUsableState = rawState !== "" && Number.isFinite(parsedState);
+
     // Only fill slots not already populated by category-sensor pass -- but
     // adopt the entity either way. The reading may well have come from the
     // category sensor's details (that pass runs first and wins on data), while
@@ -717,22 +728,22 @@ export async function fetchForecast(
       const derivedFromCategory =
         alreadyCollected.source === "individual_details" ||
         alreadyCollected.source === "individual_forecast";
-      if (derivedFromCategory) {
+      if (derivedFromCategory && hasUsableState) {
         alreadyCollected.entity_id = sensor.entity_id;
         if (debug) {
           console.debug(
             `[Kleenex] DetailSensor ${sensor.entity_id} adopted as the entity for ${canonicalName}`,
           );
         }
+      } else if (derivedFromCategory && debug) {
+        console.debug(
+          `[Kleenex] DetailSensor ${sensor.entity_id} has state '${sensor.state}'; ${canonicalName} keeps ${alreadyCollected.entity_id} as its more-info target`,
+        );
       }
       continue;
     }
 
-    // Skip when the sensor reports a non-numeric state (`unknown`,
-    // `unavailable`, etc.) — treating those as 0 ppm would mask real
-    // outages and falsely suppress the NA warning.
-    const parsedState = Number(sensor.state);
-    if (!Number.isFinite(parsedState)) continue;
+    if (!hasUsableState) continue;
 
     if (debug) {
       console.debug(

--- a/test/adapters/__goldens__/kleenex-detail-sensor-links.json
+++ b/test/adapters/__goldens__/kleenex-detail-sensor-links.json
@@ -1,0 +1,176 @@
+[
+  {
+    "allergenReplaced": "trees_cat",
+    "entity_id": "sensor.kleenex_pollen_radar_amsterdam_trees",
+    "days": [
+      {
+        "name": "Trees",
+        "day": "Today",
+        "state": 2,
+        "display_state": 2,
+        "state_text": "Moderate levels",
+        "value": 200,
+        "raw_value": 200,
+        "description": "Moderate levels"
+      },
+      {
+        "name": "Trees",
+        "day": "Tomorrow",
+        "state": 2,
+        "display_state": 2,
+        "state_text": "Moderate levels",
+        "value": 120,
+        "raw_value": 120,
+        "description": "Moderate levels"
+      },
+      {
+        "name": "Trees",
+        "day": "Day after tomorrow",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Trees",
+        "day": "Jun 18",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Trees",
+        "day": "Jun 19",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      }
+    ],
+    "allergenCapitalized": "Trees",
+    "allergenShort": "Trees"
+  },
+  {
+    "allergenReplaced": "birch",
+    "entity_id": "sensor.kleenex_pollen_radar_amsterdam_birch",
+    "days": [
+      {
+        "name": "Birch",
+        "day": "Today",
+        "state": 2,
+        "display_state": 2,
+        "state_text": "Moderate levels",
+        "value": 150,
+        "raw_value": 150,
+        "description": "Moderate levels"
+      },
+      {
+        "name": "Birch",
+        "day": "Tomorrow",
+        "state": 2,
+        "display_state": 2,
+        "state_text": "Moderate levels",
+        "value": 100,
+        "raw_value": 100,
+        "description": "Moderate levels"
+      },
+      {
+        "name": "Birch",
+        "day": "Day after tomorrow",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Birch",
+        "day": "Jun 18",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Birch",
+        "day": "Jun 19",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      }
+    ],
+    "allergenCapitalized": "Birch",
+    "allergenShort": "Birch"
+  },
+  {
+    "allergenReplaced": "oak",
+    "entity_id": "sensor.kleenex_pollen_radar_amsterdam_trees",
+    "days": [
+      {
+        "name": "Oak",
+        "day": "Today",
+        "state": 1,
+        "display_state": 1,
+        "state_text": "Low levels",
+        "value": 50,
+        "raw_value": 50,
+        "description": "Low levels"
+      },
+      {
+        "name": "Oak",
+        "day": "Tomorrow",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Oak",
+        "day": "Day after tomorrow",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Oak",
+        "day": "Jun 18",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      },
+      {
+        "name": "Oak",
+        "day": "Jun 19",
+        "state": -1,
+        "display_state": -1,
+        "state_text": "(No information)",
+        "value": -1,
+        "raw_value": -1,
+        "description": "(No information)"
+      }
+    ],
+    "allergenCapitalized": "Oak",
+    "allergenShort": "Oak"
+  }
+]

--- a/test/adapters/kleenex.test.ts
+++ b/test/adapters/kleenex.test.ts
@@ -3568,3 +3568,100 @@ describe("Kleenex adapter: more-info target (issue #317)", () => {
     ).toBe("sensor.kleenex_pollen_radar_paris_trees");
   });
 });
+
+// ---------------------------------------------------------------------------
+// 19. Unavailable detail sensors are not link targets (issue #326)
+// ---------------------------------------------------------------------------
+/**
+ * The adoption above answers "which entity is this row", and an entity that
+ * cannot answer for itself is not it. When a DetailSensor is `unavailable` or
+ * `unknown`, the row's numbers come from the category sensor's `details`
+ * instead, so adopting the dead entity would open a dialog with nothing in it
+ * for a row that is showing perfectly good data.
+ */
+describe("Kleenex adapter: unavailable detail sensors (issue #326)", () => {
+  const unusableStates = ["unavailable", "unknown", ""];
+
+  for (const state of unusableStates) {
+    it(`keeps the category sensor when the DetailSensor is '${state}'`, async () => {
+      const category = makeKleenexEntity(
+        "amsterdam",
+        "trees",
+        200,
+        [{ name: "Birch", value: 150 }],
+        [],
+      );
+      const detailSensor = {
+        entity_id: "sensor.kleenex_pollen_radar_amsterdam_birch",
+        state,
+        attributes: { forecast: [] },
+      };
+      const hass = makeHassFromEntities([category, detailSensor]);
+      const config = makeConfig({
+        location: "amsterdam",
+        allergens: ["birch"],
+        pollen_threshold: 0,
+      });
+
+      const result = await fetchForecast(hass, config);
+
+      const birch = result.find((s) => s.allergenReplaced === "birch")!;
+      expect(birch.entity_id).toBe(
+        "sensor.kleenex_pollen_radar_amsterdam_trees",
+      );
+      // The row itself is unaffected: the reading still comes from the
+      // category sensor's details, as it did before the DetailSensor existed.
+      expect(birch.days[0]!.value).toBe(150);
+    });
+  }
+
+  it("still adopts a DetailSensor reading zero", async () => {
+    // Zero ppm is a real measurement, so the test above must turn on whether
+    // the state parses as a number, not on whether it is truthy.
+    const category = makeKleenexEntity(
+      "amsterdam",
+      "trees",
+      200,
+      [{ name: "Birch", value: 150 }],
+      [],
+    );
+    const detailSensor = {
+      entity_id: "sensor.kleenex_pollen_radar_amsterdam_birch",
+      state: "0",
+      attributes: { forecast: [] },
+    };
+    const hass = makeHassFromEntities([category, detailSensor]);
+    const config = makeConfig({
+      location: "amsterdam",
+      allergens: ["birch"],
+      pollen_threshold: 0,
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    const birch = result.find((s) => s.allergenReplaced === "birch")!;
+    expect(birch.entity_id).toBe("sensor.kleenex_pollen_radar_amsterdam_birch");
+  });
+
+  it("drops an allergen the category cannot cover either", async () => {
+    // Nothing changes for the case the isFinite check was written for: with no
+    // category reading to fall back on, an unavailable DetailSensor yields no
+    // row rather than a zero one.
+    const category = makeKleenexEntity("amsterdam", "trees", 200, [], []);
+    const detailSensor = {
+      entity_id: "sensor.kleenex_pollen_radar_amsterdam_birch",
+      state: "unavailable",
+      attributes: { forecast: [] },
+    };
+    const hass = makeHassFromEntities([category, detailSensor]);
+    const config = makeConfig({
+      location: "amsterdam",
+      allergens: ["birch"],
+      pollen_threshold: 0,
+    });
+
+    const result = await fetchForecast(hass, config);
+
+    expect(result.find((s) => s.allergenReplaced === "birch")).toBeUndefined();
+  });
+});

--- a/test/golden-fixtures.ts
+++ b/test/golden-fixtures.ts
@@ -275,6 +275,28 @@ function kleenexUSEntity(location: string, category: string, ppmValue: number) {
   };
 }
 
+// A per-allergen DetailSensor, the optional entities the integration creates
+// alongside the category sensors. `state` is a raw PPM string, or one of HA's
+// unavailable markers when the entity is disabled or its update failed --
+// which is the case this fixture exists to freeze (issue #326).
+function kleenexDetailEntity(
+  location: string,
+  allergen: string,
+  state: string,
+  forecast: Array<{ value: number }> = [],
+) {
+  return {
+    entity_id: `sensor.kleenex_pollen_radar_${location}_${allergen}`,
+    state,
+    attributes: {
+      forecast: forecast.map((f, i) => ({
+        date: new Date(Date.now() + (i + 1) * 86400000).toISOString(),
+        value: f.value,
+      })),
+    },
+  };
+}
+
 function kleenexHass(
   entities: Array<{ entity_id: string; [key: string]: any }>,
 ) {
@@ -723,6 +745,36 @@ export function buildGoldenFixtures(): GoldenCase[] {
     ]),
     cfg(stubConfigKleenex, {
       location: "atlanta_georgia",
+      pollen_threshold: 0,
+    }),
+  );
+
+  // Category sensor plus the optional per-allergen DetailSensors, one healthy
+  // and one unavailable. Both rows read their numbers out of the category
+  // sensor's details either way; what this freezes is the more-info target
+  // each row ends up with (issue #326). Birch has a working entity of its own
+  // and must link to it; oak's is dead, so oak keeps the category sensor
+  // rather than pointing at something that would open empty.
+  add(
+    "kleenex",
+    "detail-sensor-links",
+    kleenexHass([
+      kleenexEntity(
+        "amsterdam",
+        "trees",
+        200,
+        [
+          { name: "Birch", value: 150 },
+          { name: "Oak", value: 50 },
+        ],
+        [{ level: 2, value: 120, details: [{ name: "Birch", value: 100 }] }],
+      ),
+      kleenexDetailEntity("amsterdam", "birch", "150", [{ value: 100 }]),
+      kleenexDetailEntity("amsterdam", "oak", "unavailable"),
+    ]),
+    cfg(stubConfigKleenex, {
+      location: "amsterdam",
+      allergens: ["birch", "oak", "trees_cat"],
       pollen_threshold: 0,
     }),
   );


### PR DESCRIPTION
Fixes the Kleenex row link target for rows whose numbers come from a working category sensor: pass 2 adopted a per-allergen detail sensor as the row's more-info target *before* the `Number.isFinite(state)` check, so an unavailable detail sensor became what a tap opens. Pre-existing since the #318 adoption; found in review of #319.

## What

- `hasUsableState` is computed once, before the branch on `alreadyCollected`, and both the adopt-into-existing-row branch and the create-new-row branch require it. Previously the two branches asked the same question ("is this state usable?") with different answers only because the check lived in one of them; a post-hoc fallback would have added a third place to keep in sync. Level computation is untouched.
- A blank state (`""`) now also counts as unusable: `Number("")` is `0`, so an empty state would have passed `isFinite` and rendered as a genuine 0-reading. Same failure class, one line, covered by a dedicated test.
- 5 new tests in the Kleenex suite: `unavailable`/`unknown`/`""` keep the category sensor as the link target while still showing the category `details` value; a detail sensor at `"0"` is still adopted (the condition is isFinite, not truthiness); with no category coverage an unavailable detail sensor yields no row at all (the original purpose of the check).
- New golden variant `kleenex / detail-sensor-links` (category sensor + one healthy + one unavailable detail sensor) freezes the link-target choice — the adoption path was previously invisible to goldens, which contain no detail sensors at all. Negative control: removing the guard flips exactly the dead sensor's `entity_id` in this golden and nothing else.

## Behavior note

When a detail sensor flaps between available and unavailable, the row's tap target follows it (detail sensor when alive, category sensor when dead). This is intended — a tap should always open something that shows data — but it does mean the more-info dialog can differ between updates on installs with unstable detail sensors.

Verified in hass-test (click target read from the actually opened more-info dialog's `entityId`): with the detail sensor forced `unavailable` or blank via REST, the row renders the category value and tap opens the category sensor's dialog; after restoring the sensor the next update links the detail sensor again; a healthy detail sensor from load links itself as before. The same fixture and clicks against a pre-fix build open the dead detail sensor, so the difference is attributable to the fix. (The 0-row half of the blank-state guard is covered by unit tests — in the click scenario the category pass fills the gap before the detail sensor is considered, so no 0-row can arise there regardless.)

Closes-manually-after-merge: #326 (PRs into dev do not auto-close).
