### PR TITLE
fix(setup): port corrected prek bootstrap and per-path escape hatch docs (backfill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,13 @@ install --hook-type pre-push` so `.pre-commit-config.yaml` actually runs on
   On a machine that routes Git hooks through a global `core.hooksPath`
   dispatcher (`prek install` refuses there on purpose), it detects that and
   tells you to use `git config prek.enabled true` instead -- see
-  CONTRIBUTING.md for which path applies to you. `SKIP_PREK=1 git commit`
-  skips the lint stage for one commit without disabling the separate
-  AI-attribution guard.
+  CONTRIBUTING.md for which path applies to you. On an ordinary clone,
+  `git commit --no-verify` skips the installed hooks for one commit, or
+  `SKIP=<hook-id>`/`PREK_SKIP=<hook-id>` (comma-delimited, read by prek
+  itself) skips just specific hooks. `SKIP_PREK=1 git commit` only does
+  something on the global-dispatcher machine -- that dispatcher, not
+  `prek` or Git itself, is what reads it. Either way, the separate
+  AI-attribution guard is unaffected.
 
 ### Commit Messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,16 @@ setup` if they're missing.
        for any repo that opts in that way. `npm run setup` detects this
        case automatically and tells you which command to run.
 
+   Escape hatches, one per path above: on an ordinary clone,
+   `git commit --no-verify` skips every hook `npm run setup` installed for
+   one commit; to skip only specific hooks instead, prek itself reads
+   `SKIP=<hook-id>[,<hook-id>...]` or `PREK_SKIP=<hook-id>[,...]`
+   (comma-delimited — e.g. `SKIP=eslint git commit`). `SKIP_PREK=1 git
+commit` only does something on the global-dispatcher machine (the
+   `git config prek.enabled true` case above) — that dispatcher, not
+   `prek` or Git itself, is what reads `SKIP_PREK`. Either way, the
+   separate AI-attribution guard is unaffected by any of these.
+
 For detailed architecture documentation and development patterns, see the code comments and structure in `src/`.
 
 ---

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -7,18 +7,24 @@
 #
 # Runs prek AND a standalone eslint/prettier check-mode pass on purpose:
 # `prek run --all-files` resolves its file list from git (tracked files),
-# so a newly written, still-untracked module is invisible to it. Worse,
-# prek's eslint/prettier hooks autofix and report "Passed" once the fix is
-# applied — a bare `prek run` can silently launder a lint error into a
-# green run. The explicit `eslint .` (no --fix) and `prettier --check .`
-# below scan the whole working tree in report-only mode and catch both
-# gaps; `gitleaks dir .` closes the same hole for the gitleaks hook (its
-# `--staged` default sees zero files when nothing is staged).
+# so a newly written, still-untracked file is invisible to it -- a lint
+# or format issue in it goes entirely unseen by prek, not autofixed and
+# not reported either way. (For a file prek DOES see, its own
+# before/after diff check catches an autofix: changing a tracked file
+# marks that hook Failed, so a fix prek just applied is never silently
+# reported "Passed".) The explicit `eslint .` (no --fix) and
+# `prettier --check .` below scan the whole working tree in report-only
+# mode and close that untracked-file gap; `gitleaks dir .` closes the
+# same hole for the gitleaks hook (its `--staged` default sees zero files
+# when nothing is staged).
 #
-# prek runs through `pipx run --spec`/`uv tool run --from` (same as CI,
-# same as scripts/setup-dev.sh) rather than a `prek` on PATH -- see
-# setup-dev.sh for why: it removes the "wrong prek version" class of bug
-# regardless of what else happens to be installed or where.
+# prek runs through the persistent, version-pinned binary `npm run setup`
+# installs (see scripts/setup-dev.sh) when that exists -- no pipx/uv
+# overhead per invocation. Only when that hasn't been set up yet does
+# this fall back to `pipx run --spec`/`uv tool run --from` (same as CI),
+# rather than a `prek` on PATH -- see setup-dev.sh for why: it removes
+# the "wrong prek version" class of bug regardless of what else happens
+# to be installed or where.
 set -eu
 cd "$(dirname "$0")/.."
 
@@ -28,15 +34,24 @@ if [ -z "$prek_version" ]; then
 	exit 1
 fi
 
-if command -v pipx >/dev/null 2>&1; then
+persistent_prek="$HOME/.local/state/pollenprognos-card-prek/$prek_version/bin/prek"
+if [ -x "$persistent_prek" ]; then
+	prek() { "$persistent_prek" "$@"; }
+elif command -v pipx >/dev/null 2>&1; then
 	# --backend pip: pipx's own uv-detection can pick an incompatible
-	# uv already on PATH (from an unrelated toolchain) and refuse to run;
-	# pip's ephemeral-venv path has no such conflict.
-	prek() { pipx run --backend pip --spec "prek==$prek_version" prek "$@"; }
+	# uv already on PATH (from an unrelated toolchain) and refuse to run.
+	# Older pipx (reported: 1.4.3) predates the --backend flag entirely
+	# and errors out on it ("unrecognized arguments"), so only pass it
+	# when this pipx's own --help advertises it.
+	if pipx run --help 2>&1 | grep -q -- '--backend'; then
+		prek() { pipx run --backend pip --spec "prek==$prek_version" prek "$@"; }
+	else
+		prek() { pipx run --spec "prek==$prek_version" prek "$@"; }
+	fi
 elif command -v uv >/dev/null 2>&1; then
 	prek() { uv tool run --from "prek==$prek_version" prek "$@"; }
 else
-	echo "missing: pipx or uv -- run npm run setup"
+	echo "missing: prek -- run npm run setup"
 	exit 1
 fi
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,33 +1,37 @@
 #!/bin/sh
 # npm run setup — one-command contributor bootstrap for the local quality
-# gate. Wires .pre-commit-config.yaml into this clone's Git hooks by
-# running prek through `pipx run --spec prek==X.Y.Z` (or the uv
-# equivalent) instead of relying on a `prek` already on PATH.
+# gate. Wires .pre-commit-config.yaml into this clone's Git hooks.
 #
-# That removes the whole class of "wrong prek version" problems Codex
-# found across three rounds on PR #346 (no version check at all; treating
-# any core.hooksPath as the one known dispatcher and skipping bootstrap
-# entirely; a stale prek shadowing a freshly pipx-installed one on PATH):
-# `pipx run --spec`/`uv tool run --from` always resolve the exact pinned
-# spec from their own cache, regardless of what else is installed or
-# where it sits on PATH. `prek install` embeds the absolute path it was
-# invoked from into the generated hook script (verified against a real
-# pipx cache), so the Git hook itself execs that cached, version-pinned
-# binary directly on every commit -- no pipx/uv overhead per commit, only
-# during this setup step.
+# Resolving the pinned version (`prek --version` below) always goes
+# through `pipx run --spec prek==X.Y.Z` (or the uv equivalent), never a
+# `prek` already on PATH -- that removes the "wrong version" class of bug
+# regardless of what else is installed or where it sits on PATH.
+#
+# Actually WIRING the hooks is different: `prek install` embeds the
+# absolute path it was invoked from into the generated hook script, so
+# pointing it at an ephemeral `pipx run`/`uv tool run` cache entry bakes a
+# path into .git/hooks/pre-commit that can silently stop existing later
+# (pipx documents its run-cache as pruned after as little as 14 days;
+# reported against this script). Once pruned, every commit fails with a
+# missing-executable error until `npm run setup` is re-run. So once a
+# hooks_path clone is confirmed (below), the pinned version is installed
+# *persistently* (`pipx install --force` / `uv tool install --force`,
+# not `run`) before `prek install` runs, so the embedded path survives.
 #
 # gitleaks has no such wrapper (a Go binary, not a Python package) and is
 # still expected to be a real installed binary on PATH.
 #
 # core.hooksPath handling: ANY custom hooks path means this clone's own
 # .git/hooks won't run (a maintainer-machine convention routes ALL repos
-# through one global dispatcher instead) -- hook installation is skipped
-# in that case, without trying to identify which dispatcher it is. The
-# prek/gitleaks checks above still run either way, since `npm run check`
-# needs them regardless of how hooks are wired.
+# through one global dispatcher instead) -- hook installation (and the
+# persistent install above) is skipped in that case, without trying to
+# identify which dispatcher it is. The prek/gitleaks checks above still
+# run either way, since `npm run check` needs them regardless of how
+# hooks are wired.
 #
 # Idempotent: safe to re-run any time (e.g. after .github/workflows/test.yml
-# bumps the pinned prek version).
+# bumps the pinned prek version) -- `--force` re-pins the persistent
+# install to whatever version is current.
 set -eu
 cd "$(dirname "$0")/.."
 
@@ -43,11 +47,21 @@ fi
 
 if command -v pipx >/dev/null 2>&1; then
 	# --backend pip: pipx's own uv-detection can pick an incompatible
-	# uv already on PATH (from an unrelated toolchain) and refuse to run;
-	# pip's ephemeral-venv path has no such conflict.
-	prek() { pipx run --backend pip --spec "prek==$prek_version" prek "$@"; }
+	# uv already on PATH (from an unrelated toolchain) and refuse to run.
+	# Older pipx (reported: 1.4.3) predates the --backend flag entirely
+	# and errors out on it ("unrecognized arguments"), so only pass it
+	# when this pipx's own --help advertises it.
+	if pipx run --help 2>&1 | grep -q -- '--backend'; then
+		pipx_backend_flag="--backend pip"
+	else
+		pipx_backend_flag=""
+	fi
+	# shellcheck disable=SC2086 # intentional word-splitting: empty when unsupported
+	prek() { pipx run $pipx_backend_flag --spec "prek==$prek_version" prek "$@"; }
+	backend="pipx"
 elif command -v uv >/dev/null 2>&1; then
 	prek() { uv tool run --from "prek==$prek_version" prek "$@"; }
+	backend="uv"
 else
 	echo "missing: pipx or uv, needed to run the pinned prek==$prek_version"
 	echo "without depending on whatever else might be on PATH. Install one:"
@@ -59,14 +73,25 @@ fi
 echo "resolving prek==$prek_version ..."
 prek --version
 
-if command -v gitleaks >/dev/null 2>&1; then
-	echo "gitleaks already installed ($(gitleaks version 2>&1 | head -n1))"
-else
+if ! command -v gitleaks >/dev/null 2>&1; then
 	echo "missing: gitleaks. Install it, e.g.:"
 	echo "  brew install gitleaks"
 	echo "or download a release: https://github.com/gitleaks/gitleaks/releases"
 	exit 1
 fi
+# A legacy gitleaks (pre-v8 `detect`/`protect` CLI, no `dir` subcommand)
+# would report success here and then fail later, at `gitleaks dir .` in
+# scripts/check.sh, with an unknown-command error -- check for `dir`
+# explicitly rather than just presence on PATH.
+if ! gitleaks --help 2>&1 | grep -q '^ *dir '; then
+	echo "installed gitleaks is too old (no 'dir' subcommand -- needs v8+):"
+	echo "  $(gitleaks version 2>&1 | head -n1)"
+	echo "Upgrade it, e.g.:"
+	echo "  brew upgrade gitleaks"
+	echo "or download a current release: https://github.com/gitleaks/gitleaks/releases"
+	exit 1
+fi
+echo "gitleaks already installed ($(gitleaks version 2>&1 | head -n1))"
 
 hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
 if [ -n "$hooks_path" ]; then
@@ -81,7 +106,45 @@ if [ -n "$hooks_path" ]; then
 	exit 0
 fi
 
-prek install
-prek install --hook-type pre-push
+# Install the pinned version persistently before wiring hooks, so the
+# path `prek install` embeds in .git/hooks/{pre-commit,pre-push} outlives
+# pipx's/uv's ephemeral run-cache pruning (see the top-of-file comment).
+#
+# Installed into a VERSION-SCOPED location, not pipx's/uv's shared "prek"
+# app slot: that shared slot is a single global name, so a plain `pipx
+# install --force prek==X`/`uv tool install --force prek` for one repo
+# would silently overwrite the exact binary path already embedded in
+# every other repo's hooks the moment that other repo pins a different
+# prek version -- defeating the version pinning for whichever repo was
+# set up first. Scoping the install directory by $prek_version means two
+# repos pinning the same version safely share one binary, and two repos
+# pinning different versions each get their own, never overwriting the
+# other. `PIPX_HOME`/`PIPX_BIN_DIR` (pipx) and `UV_TOOL_DIR`/
+# `UV_TOOL_BIN_DIR` (uv) redirect the install without touching either
+# tool's shared/default namespace at all.
+persist_root="$HOME/.local/state/pollenprognos-card-prek/$prek_version"
+bin_dir="$persist_root/bin"
+echo "installing prek==$prek_version persistently for the Git hooks ..."
+if [ "$backend" = "pipx" ]; then
+	# shellcheck disable=SC2086 # intentional word-splitting: empty when unsupported
+	PIPX_HOME="$persist_root/pipx" PIPX_BIN_DIR="$bin_dir" \
+		pipx install --force $pipx_backend_flag "prek==$prek_version"
+else
+	UV_TOOL_DIR="$persist_root/uv-tools" UV_TOOL_BIN_DIR="$bin_dir" \
+		uv tool install --force --from "prek==$prek_version" prek
+fi
+prek_bin="$bin_dir/prek"
+
+if [ ! -x "$prek_bin" ]; then
+	echo "installed prek==$prek_version but $prek_bin is missing or not"
+	echo "executable -- add $bin_dir to PATH, then re-run 'npm run setup'."
+	exit 1
+fi
+
+# From here on, use the resolved persistent binary directly (not the
+# ephemeral `prek` shell function defined above, and not a PATH lookup)
+# so the embedded hook path is the persistent one.
+"$prek_bin" install
+"$prek_bin" install --hook-type pre-push
 echo "OK: pre-commit/pre-push hooks installed from .pre-commit-config.yaml"
 echo "Run 'npm run check' any time to run the same gate CI does."


### PR DESCRIPTION
## Summary

Backfill of the quality gate introduced earlier this week, bringing the repo in line with the later repos in the rollout. Each checklist item is its own commit; items already satisfied were verified and left untouched.

- `make setup`: one-command contributor bootstrap — pinned, version-scoped prek via `pipx run --spec`, gitleaks version check, and detection of a global `core.hooksPath` dispatcher (defers to `git config prek.enabled true` there).
- `make check`: prefers the version-scoped prek binary, reports `missing: <tool> — run make setup` instead of installing anything, runs the formatter in check mode and a full-tree `gitleaks dir .`.
- Docs: both activation paths and the escape hatch per path (`SKIP_PREK=1` only with the dispatcher; `PREK_SKIP` for an installed hook).
- Hook config and CI aligned with the portfolio recipe where they deviated (explicit stages, cache key, checksum-verified gitleaks, actionlint).
- `.git-blame-ignore-revs`: only revisions that are ancestors of the base branch are kept; see the commit message for the squash investigation where applicable.

Merge with a merge commit, per the portfolio convention for gate PRs.
